### PR TITLE
Device support for multiple protocols, auto events

### DIFF
--- a/clients/metadata/device_test.go
+++ b/clients/metadata/device_test.go
@@ -31,9 +31,9 @@ import (
 
 // Test adding a device using the device client
 func TestAddDevice(t *testing.T) {
+
 	d := models.Device{
 		Id:             "1234",
-		Addressable:    models.Addressable{},
 		AdminState:     "UNLOCKED",
 		Name:           "Test name for device",
 		OperatingState: "ENABLED",

--- a/models/autoevent.go
+++ b/models/autoevent.go
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import "encoding/json"
+
+type AutoEvent struct {
+	Frequency int32  `json:"frequency,omitempty"`
+	OnChange  bool   `json:"onChange,omitempty"`
+	Resource  string `json:"resource,omitempty"`
+}
+
+/*
+ * String function for representing an auto-generated event from a device.
+ */
+func (a AutoEvent) String() string {
+	out, err := json.Marshal(a)
+	if err != nil {
+		return err.Error()
+	}
+	return string(out)
+}

--- a/models/autoevent_test.go
+++ b/models/autoevent_test.go
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+var TestAutoEvent = AutoEvent{Resource: "TestDevice", Frequency: 123, OnChange: true}
+
+func TestAutoEvent_MarshalJSON(t *testing.T) {
+	empty := AutoEvent{}
+	resultTestBytes := []byte(TestAutoEvent.String())
+	resultEmptyTestBytes := []byte(empty.String())
+
+	tests := []struct {
+		name    string
+		ae      AutoEvent
+		want    []byte
+		wantErr bool
+	}{
+		{"successful marshal", TestAutoEvent, resultTestBytes, false},
+		{"successful empty marshal", empty, resultEmptyTestBytes, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.ae)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeviceService.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeviceService.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAutoEvent_UnmarshalJSON(t *testing.T) {
+	resultTestBytes := []byte(TestAutoEvent.String())
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		ae      *AutoEvent
+		args    args
+		wantErr bool
+	}{
+		{"unmarshal normal auto event with success", &TestAutoEvent, args{resultTestBytes}, false},
+		{"unmarshal normal auto event failed", &TestAutoEvent, args{[]byte("{nonsense}")}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var expected = *tt.ae
+			if err := json.Unmarshal(tt.args.data, tt.ae); (err != nil) != tt.wantErr {
+				t.Errorf("AutoEvent.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			} else {
+				// if the bytes did unmarshal, make sure they unmarshaled to correct DS by comparing it to expected results
+				var unmarshaledResult = *tt.ae
+				if err == nil && !reflect.DeepEqual(expected, unmarshaledResult) {
+					t.Errorf("Unmarshal did not result in expected AutoEvent.")
+				}
+			}
+		})
+	}
+}
+
+func TestAutoEvent_String(t *testing.T) {
+	tests := []struct {
+		name string
+		ae   AutoEvent
+		want string
+	}{
+		{"auto event to string", TestAutoEvent,
+			"{\"frequency\":123,\"onChange\":true,\"resource\":\"TestDevice\"}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ae.String(); got != tt.want {
+				t.Errorf("AutoEvent.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/models/device.go
+++ b/models/device.go
@@ -26,45 +26,48 @@ import (
  */
 type Device struct {
 	DescribedObject
-	Id             string         `json:"id"`
-	Name           string         `json:"name"`           // Unique name for identifying a device
-	AdminState     AdminState     `json:"adminState"`     // Admin state (locked/unlocked)
-	OperatingState OperatingState `json:"operatingState"` // Operating state (enabled/disabled)
-	Addressable    Addressable    `json:"addressable"`    // Addressable for the device - stores information about it's address
-	LastConnected  int64          `json:"lastConnected"`  // Time (milliseconds) that the device last provided any feedback or responded to any request
-	LastReported   int64          `json:"lastReported"`   // Time (milliseconds) that the device reported data to the core microservice
-	Labels         []string       `json:"labels"`         // Other labels applied to the device to help with searching
-	Location       interface{}    `json:"location"`       // Device service specific location (interface{} is an empty interface so it can be anything)
-	Service        DeviceService  `json:"service"`        // Associated Device Service - One per device
-	Profile        DeviceProfile  `json:"profile"`        // Associated Device Profile - Describes the device
+	Id             string                       `json:"id"`
+	Name           string                       `json:"name"`           // Unique name for identifying a device
+	AdminState     AdminState                   `json:"adminState"`     // Admin state (locked/unlocked)
+	OperatingState OperatingState               `json:"operatingState"` // Operating state (enabled/disabled)
+	Protocols      map[string]map[string]string `json:"protocols"`      // A map of supported protocols for the given device
+	LastConnected  int64                        `json:"lastConnected"`  // Time (milliseconds) that the device last provided any feedback or responded to any request
+	LastReported   int64                        `json:"lastReported"`   // Time (milliseconds) that the device reported data to the core microservice
+	Labels         []string                     `json:"labels"`         // Other labels applied to the device to help with searching
+	Location       interface{}                  `json:"location"`       // Device service specific location (interface{} is an empty interface so it can be anything)
+	Service        DeviceService                `json:"service"`        // Associated Device Service - One per device
+	Profile        DeviceProfile                `json:"profile"`        // Associated Device Profile - Describes the device
+	AutoEvents     []AutoEvent                  `json:"autoEvents"`     // A list of auto-generated events coming from the device
 }
 
 // Custom marshaling to make empty strings null
 func (d Device) MarshalJSON() ([]byte, error) {
 	test := struct {
 		DescribedObject
-		Id             *string        `json:"id"`
-		Name           *string        `json:"name"`           // Unique name for identifying a device
-		AdminState     AdminState     `json:"adminState"`     // Admin state (locked/unlocked)
-		OperatingState OperatingState `json:"operatingState"` // Operating state (enabled/disabled)
-		Addressable    Addressable    `json:"addressable"`    // Addressable for the device - stores information about it's address
-		LastConnected  int64          `json:"lastConnected"`  // Time (milliseconds) that the device last provided any feedback or responded to any request
-		LastReported   int64          `json:"lastReported"`   // Time (milliseconds) that the device reported data to the core microservice
-		Labels         []string       `json:"labels"`         // Other labels applied to the device to help with searching
-		Location       interface{}    `json:"location"`       // Device service specific location (interface{} is an empty interface so it can be anything)
-		Service        DeviceService  `json:"service"`        // Associated Device Service - One per device
-		Profile        DeviceProfile  `json:"profile"`        // Associated Device Profile - Describes the device
+		Id             *string                      `json:"id,omitempty"`
+		Name           *string                      `json:"name,omitempty"`
+		AdminState     AdminState                   `json:"adminState,omitempty"`
+		OperatingState OperatingState               `json:"operatingState,omitempty"`
+		Protocols      map[string]map[string]string `json:"protocols,omitempty"`
+		LastConnected  int64                        `json:"lastConnected,omitempty"`
+		LastReported   int64                        `json:"lastReported,omitempty"`
+		Labels         []string                     `json:"labels,omitempty"`
+		Location       interface{}                  `json:"location,omitempty"`
+		Service        DeviceService                `json:"service,omitempty"`
+		Profile        DeviceProfile                `json:"profile,omitempty"`
+		AutoEvents     []AutoEvent                  `json:"autoEvents,omitempty"`
 	}{
 		DescribedObject: d.DescribedObject,
 		AdminState:      d.AdminState,
 		OperatingState:  d.OperatingState,
-		Addressable:     d.Addressable,
+		Protocols:       d.Protocols,
 		LastConnected:   d.LastConnected,
 		LastReported:    d.LastReported,
 		Labels:          d.Labels,
 		Location:        d.Location,
 		Service:         d.Service,
 		Profile:         d.Profile,
+		AutoEvents:      d.AutoEvents,
 	}
 
 	if d.Id != "" {

--- a/models/device_test.go
+++ b/models/device_test.go
@@ -27,10 +27,14 @@ var TestLabels = []string{"MODBUS", "TEMP"}
 var TestLastConnected = int64(1000000)
 var TestLastReported = int64(1000000)
 var TestLocation = "{40lat;45long}"
-var TestDevice = Device{DescribedObject: TestDescribedObject, Name: TestDeviceName, AdminState: "UNLOCKED", OperatingState: "ENABLED", Addressable: TestAddressable, LastReported: TestLastReported, LastConnected: TestLastConnected, Labels: TestLabels, Location: TestLocation, Service: TestDeviceService, Profile: TestProfile}
+var TestProtocols = newTestProtocols()
+var TestDevice = Device{DescribedObject: TestDescribedObject, Name: TestDeviceName, AdminState: "UNLOCKED", OperatingState: "ENABLED",
+	Protocols: TestProtocols, LastReported: TestLastReported, LastConnected: TestLastConnected,
+	Labels: TestLabels, Location: TestLocation, Service: TestDeviceService, Profile: TestProfile, AutoEvents: newAutoEvent()}
 
 func TestDevice_MarshalJSON(t *testing.T) {
-	var testDeviceBytes = []byte(TestDevice.String())
+	marshaled := TestDevice.String()
+	testDeviceBytes := []byte(marshaled)
 
 	tests := []struct {
 		name    string
@@ -66,14 +70,17 @@ func TestDevice_String(t *testing.T) {
 				",\"modified\":" + strconv.FormatInt(TestDevice.Modified, 10) +
 				",\"origin\":" + strconv.FormatInt(TestDevice.Origin, 10) +
 				",\"description\":\"" + TestDescription + "\"" +
-				",\"id\":null,\"name\":\"" + TestDevice.Name + "\"" +
-				",\"adminState\":\"UNLOCKED\",\"operatingState\":\"ENABLED\",\"addressable\":" + TestAddressable.String() +
+				",\"name\":\"" + TestDevice.Name + "\"" +
+				",\"adminState\":\"UNLOCKED\",\"operatingState\":\"ENABLED\"" +
+				",\"protocols\":{\"modbus-ip\":{\"host\":\"localhost\",\"port\":\"1234\",\"unitID\":\"1\"}," +
+				"\"modbus-rtu\":{\"baudRate\":\"19200\",\"dataBits\":\"8\",\"parity\":\"0\",\"serialPort\":\"/dev/USB0\",\"stopBits\":\"1\",\"unitID\":\"2\"}}" +
 				",\"lastConnected\":" + strconv.FormatInt(TestLastConnected, 10) +
 				",\"lastReported\":" + strconv.FormatInt(TestLastReported, 10) +
 				",\"labels\":" + fmt.Sprint(string(labelSlice)) +
 				",\"location\":\"" + TestLocation + "\"" +
 				",\"service\":" + TestDevice.Service.String() +
 				",\"profile\":" + TestDevice.Profile.String() +
+				",\"autoEvents\":[" + TestAutoEvent.String() + "]" +
 				"}"},
 	}
 	for _, tt := range tests {
@@ -105,4 +112,31 @@ func TestDevice_AllAssociatedValueDescriptors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestProtocols() map[string]map[string]string {
+	p1 := make(map[string]string)
+	p1["host"] = "localhost"
+	p1["port"] = "1234"
+	p1["unitID"] = "1"
+
+	p2 := make(map[string]string)
+	p2["serialPort"] = "/dev/USB0"
+	p2["baudRate"] = "19200"
+	p2["dataBits"] = "8"
+	p2["stopBits"] = "1"
+	p2["parity"] = "0"
+	p2["unitID"] = "2"
+
+	wrap := make(map[string]map[string]string)
+	wrap["modbus-ip"] = p1
+	wrap["modbus-rtu"] = p2
+
+	return wrap
+}
+
+func newAutoEvent() []AutoEvent {
+	a := []AutoEvent{}
+	a = append(a, TestAutoEvent)
+	return a
 }


### PR DESCRIPTION
Issues #7 and #14 

NOTE: I went with the property name AutoEvent.Frequency as opposed to AutoEvent.Interval because the new Scheduler contract has an `Interval` type. I thought that using the name Interval here would imply that it was of type `Interval` which is not the case.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>