### PR TITLE
Empty fields are omitted when marshaling to JSON or YAML a DeviceProfile

### DIFF
--- a/models/action.go
+++ b/models/action.go
@@ -19,9 +19,9 @@ import (
 )
 
 type Action struct {
-	Path      string     `json:"path"`          // path used by service for action on a device or sensor
-	Responses []Response `json:"responses"`     // responses from get or put requests to service
-	URL       string     `json:"url,omitempty"` // url for requests from command service
+	Path      string     `json:"path" yaml:"path,omitempty"`           // path used by service for action on a device or sensor
+	Responses []Response `json:"responses" yaml:"responses,omitempty"` // responses from get or put requests to service
+	URL       string     `json:"url,omitempty" yaml:"url,omitempty"`   // url for requests from command service
 }
 
 /*

--- a/models/addressable_test.go
+++ b/models/addressable_test.go
@@ -82,7 +82,7 @@ func TestAddressable_String(t *testing.T) {
 			"\",\"topic\":\"" + TestAddressable.Topic +
 			"\",\"baseURL\":\"" + TestAddressable.Protocol + "://" + TestAddressable.Address + ":" + strconv.Itoa(TestAddressable.Port) +
 			"\",\"url\":\"" + TestAddressable.Protocol + "://" + TestAddressable.Address + ":" + strconv.Itoa(TestAddressable.Port) + TestAddressable.Path + "\"}"},
-		{"empty", EmptyAddressable, "{\"created\":0,\"modified\":0,\"origin\":0}"},
+		{"empty", EmptyAddressable, "{}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/baseobject.go
+++ b/models/baseobject.go
@@ -18,15 +18,10 @@ import (
 	"encoding/json"
 )
 
-/*
-TODO: Since this type is embedded throughout many contract models, we must leave the bson tags in place until
-the full decoupling from Mongo is complete. This shouldn't have any impact since there isn't a direct import
-to mgo/bson
-*/
 type BaseObject struct {
-	Created  int64 `bson:"created" json:"created"`
-	Modified int64 `bson:"modified" json:"modified"`
-	Origin   int64 `bson:"origin" json:"origin"`
+	Created  int64 `json:"created,omitempty" yaml:"created,omitempty"`
+	Modified int64 `json:"modified,omitempty" yaml:"modified,omitempty"`
+	Origin   int64 `json:"origin,omitempty" yaml:"origin,omitempty"`
 }
 
 /*

--- a/models/baseobject_test.go
+++ b/models/baseobject_test.go
@@ -25,7 +25,7 @@ func TestBaseObject_String(t *testing.T) {
 		baseObject *BaseObject
 		want       string
 	}{
-		{"empty base", &EmptyBaseObject, "{\"created\":0,\"modified\":0,\"origin\":0}"},
+		{"empty base", &EmptyBaseObject, "{}"},
 		{"populated base", &TestBaseObject, "{\"created\":123,\"modified\":123,\"origin\":123}"},
 	}
 	for _, tt := range tests {

--- a/models/command.go
+++ b/models/command.go
@@ -26,20 +26,20 @@ import (
  */
 type Command struct {
 	BaseObject `yaml:",inline"`
-	Id         string `json:"id"`
-	Name       string `json:"name" yaml:"name"` // Command name (unique on the profile)
-	Get        *Get   `json:"get" yaml:"get"`   // Get Command
-	Put        *Put   `json:"put" yaml:"put"`   // Put Command
+	Id         string `json:"id" yaml:"id,omitempty"`
+	Name       string `json:"name" yaml:"name,omitempty"` // Command name (unique on the profile)
+	Get        *Get   `json:"get" yaml:"get,omitempty"`   // Get Command
+	Put        *Put   `json:"put" yaml:"put,omitempty"`   // Put Command
 }
 
 // Custom marshaling for making empty strings null
 func (c Command) MarshalJSON() ([]byte, error) {
 	test := struct {
 		BaseObject
-		Id   *string `json:"id"`
-		Name *string `json:"name"` // Command name (unique on the profile)
-		Get  *Get    `json:"get"`  // Get Command
-		Put  *Put    `json:"put"`  // Put Command
+		Id   *string `json:"id,omitempty"`
+		Name *string `json:"name,omitempty"` // Command name (unique on the profile)
+		Get  *Get    `json:"get,omitempty"`  // Get Command
+		Put  *Put    `json:"put,omitempty"`  // Put Command
 	}{
 		BaseObject: c.BaseObject,
 		Get:        c.Get,

--- a/models/command_test.go
+++ b/models/command_test.go
@@ -57,7 +57,7 @@ func TestCommand_String(t *testing.T) {
 			"{\"created\":" + strconv.FormatInt(TestCommand.Created, 10) +
 				",\"modified\":" + strconv.FormatInt(TestCommand.Modified, 10) +
 				",\"origin\":" + strconv.FormatInt(TestCommand.Origin, 10) +
-				",\"id\":null,\"name\":\"" + TestCommand.Name + "\"" +
+				",\"name\":\"" + TestCommand.Name + "\"" +
 				",\"get\":" + TestGet.String() +
 				",\"put\":" + TestPut.String() + "}"},
 	}

--- a/models/describedobject.go
+++ b/models/describedobject.go
@@ -18,7 +18,7 @@ import "encoding/json"
 
 type DescribedObject struct {
 	BaseObject  `yaml:",inline"`
-	Description string `json:"description" yaml:"description"`
+	Description string `json:"description" yaml:"description,omitempty"`
 }
 
 /*

--- a/models/deviceprofile.go
+++ b/models/deviceprofile.go
@@ -26,35 +26,37 @@ import (
  */
 type DeviceProfile struct {
 	DescribedObject `yaml:",inline"`
-	Id              string            `json:"id"`
-	Name            string            `json:"name" yaml:"name"`                 // Non-database identifier (must be unique)
-	Manufacturer    string            `json:"manufacturer" yaml:"manufacturer"` // Manufacturer of the device
-	Model           string            `json:"model" yaml:"model"`               // Model of the device
-	Labels          []string          `json:"labels" yaml:"labels,flow"`        // Labels used to search for groups of profiles
-	DeviceResources []DeviceResource  `json:"deviceResources" yaml:"deviceResources"`
-	Resources       []ProfileResource `json:"resources" yaml:"resources"`
-	Commands        []Command         `json:"commands" yaml:"commands"` // List of commands to Get/Put information for devices associated with this profile
+	Id              string            `json:"id" yaml:"id,omitempty"`
+	Name            string            `json:"name" yaml:"name,omitempty"`                 // Non-database identifier (must be unique)
+	Manufacturer    string            `json:"manufacturer" yaml:"manufacturer,omitempty"` // Manufacturer of the device
+	Model           string            `json:"model" yaml:"model,omitempty"`               // Model of the device
+	Labels          []string          `json:"labels" yaml:"labels,flow,omitempty"`        // Labels used to search for groups of profiles
+	DeviceResources []DeviceResource  `json:"deviceResources" yaml:"deviceResources,omitempty"`
+	Resources       []ProfileResource `json:"resources" yaml:"resources,omitempty"`
+	Commands        []Command         `json:"commands" yaml:"commands,omitempty"` // List of commands to Get/Put information for devices associated with this profile
 }
 
 // Custom marshaling so that empty strings and arrays are null
 func (dp DeviceProfile) MarshalJSON() ([]byte, error) {
 	test := struct {
 		DescribedObject
-		Id              string            `json:"id"`
-		Name            *string           `json:"name"`         // Non-database identifier (must be unique)
-		Manufacturer    *string           `json:"manufacturer"` // Manufacturer of the device
-		Model           *string           `json:"model"`        // Model of the device
-		Labels          []string          `json:"labels"`       // Labels used to search for groups of profiles
-		DeviceResources []DeviceResource  `json:"deviceResources"`
-		Resources       []ProfileResource `json:"resources"`
-		Commands        []Command         `json:"commands"` // List of commands to Get/Put information for devices associated with this profile
+		Id              *string           `json:"id,omitempty"`
+		Name            *string           `json:"name,omitempty"`         // Non-database identifier (must be unique)
+		Manufacturer    *string           `json:"manufacturer,omitempty"` // Manufacturer of the device
+		Model           *string           `json:"model,omitempty"`        // Model of the device
+		Labels          []string          `json:"labels,omitempty"`       // Labels used to search for groups of profiles
+		DeviceResources []DeviceResource  `json:"deviceResources,omitempty"`
+		Resources       []ProfileResource `json:"resources,omitempty"`
+		Commands        []Command         `json:"commands,omitempty"` // List of commands to Get/Put information for devices associated with this profile
 	}{
-		Id:              dp.Id,
 		Labels:          dp.Labels,
 		DescribedObject: dp.DescribedObject,
 	}
 
 	// Empty strings are null
+	if dp.Id != "" {
+		test.Id = &dp.Id
+	}
 	if dp.Name != "" {
 		test.Name = &dp.Name
 	}

--- a/models/deviceprofile_test.go
+++ b/models/deviceprofile_test.go
@@ -68,7 +68,6 @@ func TestDeviceProfile_String(t *testing.T) {
 				",\"modified\":" + strconv.FormatInt(TestDescribedObject.Modified, 10) +
 				",\"origin\":" + strconv.FormatInt(TestDescribedObject.Origin, 10) +
 				",\"description\":\"" + TestDescribedObject.Description + "\"" +
-				",\"id\":\"\"" +
 				",\"name\":\"" + TestProfileName + "\"" +
 				",\"manufacturer\":\"" + TestManufacturer + "\"" +
 				",\"model\":\"" + TestModel + "\"" +

--- a/models/deviceresource.go
+++ b/models/deviceresource.go
@@ -19,21 +19,21 @@ import (
 )
 
 type DeviceResource struct {
-	Description string                 `json:"description"`
-	Name        string                 `json:"name"`
-	Tag         string                 `json:"tag"`
+	Description string                 `json:"description" yaml:"description,omitempty"`
+	Name        string                 `json:"name" yaml:"name,omitempty"`
+	Tag         string                 `json:"tag" yaml:"tag,omitempty"`
 	Properties  ProfileProperty        `json:"properties" yaml:"properties"`
-	Attributes  map[string]interface{} `json:"attributes" yaml:"attributes"`
+	Attributes  map[string]interface{} `json:"attributes" yaml:"attributes,omitempty"`
 }
 
 // Custom marshaling to make empty strings null
 func (do DeviceResource) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Description *string                `json:"description"`
-		Name        *string                `json:"name"`
-		Tag         *string                `json:"tag"`
+		Description *string                `json:"description,omitempty"`
+		Name        *string                `json:"name,omitempty"`
+		Tag         *string                `json:"tag,omitempty"`
 		Properties  ProfileProperty        `json:"properties"`
-		Attributes  map[string]interface{} `json:"attributes"`
+		Attributes  map[string]interface{} `json:"attributes,omitempty"`
 	}{
 		Properties: do.Properties,
 	}

--- a/models/deviceresource_test.go
+++ b/models/deviceresource_test.go
@@ -61,8 +61,7 @@ func TestDeviceResource_String(t *testing.T) {
 			"{\"description\":\"" + TestDeviceResourceDescription + "\"" +
 				",\"name\":\"" + TestDeviceResourceName + "\"" +
 				",\"tag\":\"" + TestDeviceResourceTag + "\"" +
-				",\"properties\":" + TestProfileProperty.String() +
-				",\"attributes\":null}"},
+				",\"properties\":" + TestProfileProperty.String() + "}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/get.go
+++ b/models/get.go
@@ -23,8 +23,8 @@ type Get struct {
 // Custom marshaling to make empty strings and arrays null
 func (g Get) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Path      *string    `json:"path"`
-		Responses []Response `json:"responses"`
+		Path      *string    `json:"path,omitempty"`
+		Responses []Response `json:"responses,omitempty"`
 		URL       string     `json:"url,omitempty"`
 	}{URL: g.Action.URL}
 

--- a/models/notifications_test.go
+++ b/models/notifications_test.go
@@ -70,8 +70,8 @@ func TestNotification_String(t *testing.T) {
 		notification *Notification
 		want         string
 	}{
-		{"test empty notification to string", &TestEmptyNotification, "{\"created\":0,\"modified\":0,\"origin\":0,\"id\":null}"},
-		{"test notification to string", &TestNotification, "{\"created\":123,\"modified\":123,\"origin\":0,\"id\":null,\"slug\":\"test slug\",\"sender\":\"test sender\",\"category\":\"SECURITY\",\"severity\":\"CRITICAL\",\"content\":\"test content\",\"description\":\"test description\",\"status\":\"NEW\",\"labels\":[\"label1\",\"labe2\"]}"},
+		{"test empty notification to string", &TestEmptyNotification, "{\"id\":null}"},
+		{"test notification to string", &TestNotification, "{\"created\":123,\"modified\":123,\"id\":null,\"slug\":\"test slug\",\"sender\":\"test sender\",\"category\":\"SECURITY\",\"severity\":\"CRITICAL\",\"content\":\"test content\",\"description\":\"test description\",\"status\":\"NEW\",\"labels\":[\"label1\",\"labe2\"]}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/profileresource.go
+++ b/models/profileresource.go
@@ -17,17 +17,17 @@ package models
 import "encoding/json"
 
 type ProfileResource struct {
-	Name string              `json:"name"`
-	Get  []ResourceOperation `json:"get"`
-	Set  []ResourceOperation `json:"set"`
+	Name string              `json:"name" yaml:"name,omitempty"`
+	Get  []ResourceOperation `json:"get" yaml:"get,omitempty"`
+	Set  []ResourceOperation `json:"set" yaml:"set,omitempty"`
 }
 
 // Custom marshaling to make empty strings null
 func (pr ProfileResource) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Name *string             `json:"name"`
-		Get  []ResourceOperation `json:"get"`
-		Set  []ResourceOperation `json:"set"`
+		Name *string             `json:"name,omitempty"`
+		Get  []ResourceOperation `json:"get,omitempty"`
+		Set  []ResourceOperation `json:"set,omitempty"`
 	}{}
 
 	// Empty strings are null

--- a/models/propertyvalue.go
+++ b/models/propertyvalue.go
@@ -19,19 +19,19 @@ import (
 )
 
 type PropertyValue struct {
-	Type         string `json:"type"`                             // ValueDescriptor Type of property after transformations
-	ReadWrite    string `json:"readWrite" yaml:"readWrite"`       // Read/Write Permissions set for this property
-	Minimum      string `json:"minimum"`                          // Minimum value that can be get/set from this property
-	Maximum      string `json:"maximum"`                          // Maximum value that can be get/set from this property
-	DefaultValue string `json:"defaultValue" yaml:"defaultValue"` // Default value set to this property if no argument is passed
-	Size         string `json:"size"`                             // Size of this property in its type  (i.e. bytes for numeric types, characters for string types)
-	Mask         string `json:"mask"`                             // Mask to be applied prior to get/set of property
-	Shift        string `json:"shift"`                            // Shift to be applied after masking, prior to get/set of property
-	Scale        string `json:"scale"`                            // Multiplicative factor to be applied after shifting, prior to get/set of property
-	Offset       string `json:"offset"`                           // Additive factor to be applied after multiplying, prior to get/set of property
-	Base         string `json:"base"`                             // Base for property to be applied to, leave 0 for no power operation (i.e. base ^ property: 2 ^ 10)
-	Assertion    string `json:"assertion"`                        // Required value of the property, set for checking error state.  Failing an assertion condition will mark the device with an error state
-	Precision    string `json:"precision"`
+	Type         string `json:"type" yaml:"type,omitempty"`                 // ValueDescriptor Type of property after transformations
+	ReadWrite    string `json:"readWrite" yaml:"readWrite,omitempty"`       // Read/Write Permissions set for this property
+	Minimum      string `json:"minimum" yaml:"minimum,omitempty"`           // Minimum value that can be get/set from this property
+	Maximum      string `json:"maximum" yaml:"maximum,omitempty"`           // Maximum value that can be get/set from this property
+	DefaultValue string `json:"defaultValue" yaml:"defaultValue,omitempty"` // Default value set to this property if no argument is passed
+	Size         string `json:"size" yaml:"size,omitempty"`                 // Size of this property in its type  (i.e. bytes for numeric types, characters for string types)
+	Mask         string `json:"mask" yaml:"mask,omitempty"`                 // Mask to be applied prior to get/set of property
+	Shift        string `json:"shift" yaml:"shift,omitempty"`               // Shift to be applied after masking, prior to get/set of property
+	Scale        string `json:"scale" yaml:"scale,omitempty"`               // Multiplicative factor to be applied after shifting, prior to get/set of property
+	Offset       string `json:"offset" yaml:"offset,omitempty"`             // Additive factor to be applied after multiplying, prior to get/set of property
+	Base         string `json:"base" yaml:"base,omitempty"`                 // Base for property to be applied to, leave 0 for no power operation (i.e. base ^ property: 2 ^ 10)
+	Assertion    string `json:"assertion" yaml:"assertion,omitempty"`       // Required value of the property, set for checking error state.  Failing an assertion condition will mark the device with an error state
+	Precision    string `json:"precision" yaml:"precision,omitempty"`
 }
 
 // Custom marshaling to make empty strings null

--- a/models/put.go
+++ b/models/put.go
@@ -23,15 +23,15 @@ import "encoding/json"
  */
 type Put struct {
 	Action         `yaml:",inline"`
-	ParameterNames []string `json:"parameterNames" yaml:"parameterNames"`
+	ParameterNames []string `json:"parameterNames" yaml:"parameterNames,omitempty"`
 }
 
 // Custom marshaling to make empty strings null
 func (p Put) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Path           *string    `json:"path"`
-		Responses      []Response `json:"responses"`
-		ParameterNames []string   `json:"parameterNames"`
+		Path           *string    `json:"path,omitempty"`
+		Responses      []Response `json:"responses,omitempty"`
+		ParameterNames []string   `json:"parameterNames,omitempty"`
 		URL            string     `json:"url,omitempty"`
 	}{URL: p.Action.URL}
 

--- a/models/resourceoperation.go
+++ b/models/resourceoperation.go
@@ -17,25 +17,25 @@ package models
 import "encoding/json"
 
 type ResourceOperation struct {
-	Index     string            `json:"index"`
-	Operation string            `json:"operation"`
-	Object    string            `json:"object"`
-	Parameter string            `json:"parameter"`
-	Resource  string            `json:"resource"`
-	Secondary []string          `json:"secondary"`
-	Mappings  map[string]string `json:"mappings"`
+	Index     string            `json:"index" yaml:"index,omitempty"`
+	Operation string            `json:"operation" yaml:"operation,omitempty"`
+	Object    string            `json:"object" yaml:"object,omitempty"`
+	Parameter string            `json:"parameter" yaml:"parameter,omitempty"`
+	Resource  string            `json:"resource" yaml:"resource,omitempty"`
+	Secondary []string          `json:"secondary" yaml:"secondary,omitempty"`
+	Mappings  map[string]string `json:"mappings" yaml:"mappings,omitempty"`
 }
 
 // Custom marshaling to make empty strings null
 func (ro ResourceOperation) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Index     *string           `json:"index"`
-		Operation *string           `json:"operation"`
-		Object    *string           `json:"object"`
-		Parameter *string           `json:"parameter"`
-		Resource  *string           `json:"resource"`
-		Secondary []string          `json:"secondary"`
-		Mappings  map[string]string `json:"mappings"`
+		Index     *string           `json:"index,omitempty"`
+		Operation *string           `json:"operation,omitempty"`
+		Object    *string           `json:"object,omitempty"`
+		Parameter *string           `json:"parameter,omitempty"`
+		Resource  *string           `json:"resource,omitempty"`
+		Secondary []string          `json:"secondary,omitempty"`
+		Mappings  map[string]string `json:"mappings,omitempty"`
 	}{
 		Secondary: ro.Secondary,
 		Mappings:  ro.Mappings,

--- a/models/resourceoperation_test.go
+++ b/models/resourceoperation_test.go
@@ -67,8 +67,7 @@ func TestResourceOperation_String(t *testing.T) {
 				",\"object\":\"" + TestResourceObject + "\"" +
 				",\"parameter\":\"" + TestParameter + "\"" +
 				",\"resource\":\"" + TestResource + "\"" +
-				",\"secondary\":" + fmt.Sprint(string(secondarySlice)) +
-				",\"mappings\":{}}"},
+				",\"secondary\":" + fmt.Sprint(string(secondarySlice)) + "}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/response.go
+++ b/models/response.go
@@ -27,17 +27,17 @@ import (
  * Response Struct
  */
 type Response struct {
-	Code           string   `json:"code" yaml:"code"`
-	Description    string   `json:"description" yaml:"description"`
-	ExpectedValues []string `json:"expectedValues" yaml:"expectedValues"`
+	Code           string   `json:"code" yaml:"code,omitempty"`
+	Description    string   `json:"description" yaml:"description,omitempty"`
+	ExpectedValues []string `json:"expectedValues" yaml:"expectedValues,omitempty"`
 }
 
 // Custom marshalling to make empty strings null
 func (r Response) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Code           *string  `json:"code"`
-		Description    *string  `json:"description"`
-		ExpectedValues []string `json:"expectedValues"`
+		Code           *string  `json:"code,omitempty"`
+		Description    *string  `json:"description,omitempty"`
+		ExpectedValues []string `json:"expectedValues,omitempty"`
 	}{
 		ExpectedValues: r.ExpectedValues,
 	}

--- a/models/subscription_test.go
+++ b/models/subscription_test.go
@@ -58,7 +58,7 @@ func TestSubscription_String(t *testing.T) {
 		sub  *Subscription
 		want string
 	}{
-		{"test string empty subscription", &TestEmptySubscription, "{\"created\":0,\"modified\":0,\"origin\":0,\"id\":null}"},
+		{"test string empty subscription", &TestEmptySubscription, "{\"id\":null}"},
 		{"test subscription", &TestSubscription, "{\"created\":123,\"modified\":123,\"origin\":123,\"id\":null,\"slug\":\"test slug\",\"receiver\":\"test receiver\",\"description\":\"test description\",\"subscribedCategories\":[\"SW_HEALTH\"],\"subscribedLabels\":[\"test label\"],\"channels\":[{\"type\":\"EMAIL\",\"mailAddresses\":[\"jpwhite_mn@yahoo.com\",\"james_white2@dell.com\"]},{\"type\":\"REST\",\"url\":\"http://www.someendpoint.com/notifications\"}]}"},
 	}
 	for _, tt := range tests {

--- a/models/transmission_test.go
+++ b/models/transmission_test.go
@@ -56,8 +56,8 @@ func TestTransmission_String(t *testing.T) {
 		trans *Transmission
 		want  string
 	}{
-		{"test string of empty transmission", &TestEmptyTransmission, "{\"created\":0,\"modified\":0,\"origin\":0,\"id\":null,\"notification\":{\"created\":0,\"modified\":0,\"origin\":0,\"id\":null},\"channel\":{},\"resendcount\":0}"},
-		{"test string of transmission", &TestTransmission, "{\"created\":123,\"modified\":123,\"origin\":123,\"id\":null,\"notification\":{\"created\":123,\"modified\":123,\"origin\":0,\"id\":null,\"slug\":\"test slug\",\"sender\":\"test sender\",\"category\":\"SECURITY\",\"severity\":\"CRITICAL\",\"content\":\"test content\",\"description\":\"test description\",\"status\":\"NEW\",\"labels\":[\"label1\",\"labe2\"]},\"receiver\":\"test receiver\",\"channel\":{\"type\":\"EMAIL\",\"mailAddresses\":[\"jpwhite_mn@yahoo.com\",\"james_white2@dell.com\"]},\"status\":\"SENT\",\"resendcount\":0,\"records\":[{\"status\":\"SENT\",\"response\":\"ok\",\"sent\":123}]}"},
+		{"test string of empty transmission", &TestEmptyTransmission, "{\"id\":null,\"notification\":{\"id\":null},\"channel\":{},\"resendcount\":0}"},
+		{"test string of transmission", &TestTransmission, "{\"created\":123,\"modified\":123,\"origin\":123,\"id\":null,\"notification\":{\"created\":123,\"modified\":123,\"id\":null,\"slug\":\"test slug\",\"sender\":\"test sender\",\"category\":\"SECURITY\",\"severity\":\"CRITICAL\",\"content\":\"test content\",\"description\":\"test description\",\"status\":\"NEW\",\"labels\":[\"label1\",\"labe2\"]},\"receiver\":\"test receiver\",\"channel\":{\"type\":\"EMAIL\",\"mailAddresses\":[\"jpwhite_mn@yahoo.com\",\"james_white2@dell.com\"]},\"status\":\"SENT\",\"resendcount\":0,\"records\":[{\"status\":\"SENT\",\"response\":\"ok\",\"sent\":123}]}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/units.go
+++ b/models/units.go
@@ -17,17 +17,17 @@ package models
 import "encoding/json"
 
 type Units struct {
-	Type         string `json:"type"`
-	ReadWrite    string `json:"readWrite" yaml:"readWrite"`
-	DefaultValue string `json:"defaultValue" yaml:"defaultValue"`
+	Type         string `json:"type" yaml:"type,omitempty"`
+	ReadWrite    string `json:"readWrite" yaml:"readWrite,omitempty"`
+	DefaultValue string `json:"defaultValue" yaml:"defaultValue,omitempty"`
 }
 
 // Custom marshaling to make empty strings null
 func (u Units) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Type         *string `json:"type"`
-		ReadWrite    *string `json:"readWrite"`
-		DefaultValue *string `json:"defaultValue"`
+		Type         *string `json:"type,omitempty"`
+		ReadWrite    *string `json:"readWrite,omitempty"`
+		DefaultValue *string `json:"defaultValue,omitempty"`
 	}{}
 
 	// Empty strings are null


### PR DESCRIPTION
Implements #16.

This is a YAML file before:
```
created: 1551108837189
modified: 1551108837189
origin: 0
description: Example of Simple Device
id: 20128964-ecfd-4c63-a6af-70bcd27f062b
name: Simple-Device
manufacturer: Simple Corp.
model: SP-01
labels: [modbus]
deviceResources:
- description: Switch On/Off.
  name: SwitchButton
  tag: ""
  properties:
    value:
      type: Bool
      readWrite: RW
      minimum: ""
      maximum: ""
      defaultValue: ""
      size: ""
      mask: ""
      shift: ""
      scale: ""
      offset: ""
      base: ""
      assertion: ""
      precision: ""
    units:
      type: String
      readWrite: R
      defaultValue: On/Off
  attributes: {}
resources:
- name: Switch
  get:
  - index: ""
    operation: get
    object: SwitchButton
    parameter: Switch
    resource: ""
    secondary: []
    mappings: {}
  set:
  - index: ""
    operation: set
    object: SwitchButton
    parameter: Switch
    resource: ""
    secondary: []
    mappings: {}
commands:
- created: 1551108837187
  modified: 1551108837187
  origin: 0
  id: 5f91c18c-65cf-4015-956a-30171d41b7e6
  name: Switch
  get:
    path: /api/v1/device/{deviceId}/Switch
    responses:
    - code: "200"
      description: ""
      expectedValues:
      - Switch
    - code: "503"
      description: service unavailable
      expectedValues: []
    url: ""
  put:
    path: /api/v1/device/{deviceId}/Switch
    responses:
    - code: "200"
      description: ""
      expectedValues: []
    - code: "503"
      description: service unavailable
      expectedValues: []
    url: ""
    parameterNames:
    - Switch
```
And after:
```
created: 1551108837189
modified: 1551108837189
description: Example of Simple Device
id: 20128964-ecfd-4c63-a6af-70bcd27f062b
name: Simple-Device
manufacturer: Simple Corp.
model: SP-01
labels: [modbus]
deviceResources:
- description: Switch On/Off.
  name: SwitchButton
  properties:
    value:
      type: Bool
      readWrite: RW
    units:
      type: String
      readWrite: R
      defaultValue: On/Off
resources:
- name: Switch
  get:
  - operation: get
    object: SwitchButton
    parameter: Switch
  set:
  - operation: set
    object: SwitchButton
    parameter: Switch
commands:
- created: 1551108837187
  modified: 1551108837187
  id: 5f91c18c-65cf-4015-956a-30171d41b7e6
  name: Switch
  get:
    path: /api/v1/device/{deviceId}/Switch
    responses:
    - code: "200"
      expectedValues:
      - Switch
    - code: "503"
      description: service unavailable
  put:
    path: /api/v1/device/{deviceId}/Switch
    responses:
    - code: "200"
    - code: "503"
      description: service unavailable
    parameterNames:
    - Switch
```
With JSON there is a similar result.

Signed-off-by: Joan Duran <jduran@circutor.com>