### PR TITLE
Parameter Path in IntervalAction is marshaled to JSON

### DIFF
--- a/models/interval_action.go
+++ b/models/interval_action.go
@@ -91,6 +91,9 @@ func (ia IntervalAction) MarshalJSON() ([]byte, error) {
 	if ia.Address != "" {
 		test.Address = &ia.Address
 	}
+	if ia.Path != "" {
+		test.Path = &ia.Path
+	}
 	if ia.Publisher != "" {
 		test.Publisher = &ia.Publisher
 	}


### PR DESCRIPTION
Fix issue #41 

Signed-off-by: Joan Duran <jduran@circutor.com>