### PR TITLE
Updated GoDoc on Command/Client

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -23,8 +23,10 @@ import (
 
 // The CommandClient interface defines interactions with the EdgeX Core Command microservice.
 type CommandClient interface {
-	Get(id string, cID string, ctx context.Context) (string, error)
-	Put(id string, cID string, body string, ctx context.Context) (string, error)
+	// Get issues a GET command targeting the specified device, using the specified command
+	Get(deviceId string, commandId string, ctx context.Context) (string, error)
+	// Put issues a PUT command targeting the specified device, using the specified command
+	Put(deviceId string, commandId string, body string, ctx context.Context) (string, error)
 }
 
 type commandRestClient struct {
@@ -56,13 +58,11 @@ func (c *commandRestClient) init(params types.EndpointParams) {
 	}
 }
 
-// Get issues a GET command targeting the specified device, using the specified command
 func (cc *commandRestClient) Get(deviceId string, commandId string, ctx context.Context) (string, error) {
 	body, err := clients.GetRequest(cc.url+"/"+deviceId+"/command/"+commandId, ctx)
 	return string(body), err
 }
 
-// Put issues a PUT command targeting the specified device, using the specified command
 func (cc *commandRestClient) Put(deviceId string, commandId string, body string, ctx context.Context) (string, error) {
 	return clients.PutRequest(cc.url+"/"+deviceId+"/command/"+commandId, []byte(body), ctx)
 }


### PR DESCRIPTION
#31 

Follow up to #43 

- I did not modify the parameter names in the actual interface definition per @jduranf 's comment on the previous PR.
- See #core channel in Slack related to local GoDoc review. I have moved the comments for the methods off the implementing type (because they don't show up) to the interface itself.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>