### PR TITLE
Renamed the BaseObject type to Timestamps to better reflect its intent

### DIFF
--- a/clients/logger/logger.go
+++ b/clients/logger/logger.go
@@ -44,12 +44,7 @@ const (
 	ErrorLog = "ERROR"
 )
 
-var logLevels = []string{
-	TraceLog,
-	DebugLog,
-	InfoLog,
-	WarnLog,
-	ErrorLog}
+var logLevels = LogLevels()
 
 // LoggingClient defines the interface for logging operations.
 type LoggingClient interface {
@@ -122,6 +117,16 @@ func NewClient(owningServiceName string, isRemote bool, logTarget string, logLev
 	}
 
 	return lc
+}
+
+// LogLevels returns an array of the possible log levels in order from most to least verbose.
+func LogLevels()[]string{
+	return []string{
+		TraceLog,
+		DebugLog,
+		InfoLog,
+		WarnLog,
+		ErrorLog}
 }
 
 func (f *fileWriter) Write(p []byte) (n int, err error) {

--- a/models/addressable.go
+++ b/models/addressable.go
@@ -28,7 +28,7 @@ import (
  * Addressable struct
  */
 type Addressable struct {
-	BaseObject
+	Timestamps
 	Id         string `json:"id"`
 	Name       string `json:"name"`
 	Protocol   string `json:"protocol"`    // Protocol for the address (HTTP/TCP)
@@ -47,7 +47,7 @@ type Addressable struct {
 // Treat the strings as pointers so they can be null in JSON
 func (a Addressable) MarshalJSON() ([]byte, error) {
 	aux := struct {
-		BaseObject
+		Timestamps
 		Id         *string `json:"id,omitempty"`
 		Name       *string `json:"name,omitempty"`
 		Protocol   *string `json:"protocol,omitempty"`    // Protocol for the address (HTTP/TCP)
@@ -62,7 +62,7 @@ func (a Addressable) MarshalJSON() ([]byte, error) {
 		BaseURL    *string `json:"baseURL,omitempty"`
 		URL        *string `json:"url,omitempty"`
 	}{
-		BaseObject: a.BaseObject,
+		Timestamps: a.Timestamps,
 		Port:       a.Port,
 	}
 

--- a/models/addressable_test.go
+++ b/models/addressable_test.go
@@ -32,7 +32,7 @@ const testUser = "edgexer"
 const testPassword = "password"
 const testTopic = "device_topic"
 
-var TestAddressable = Addressable{BaseObject: TestBaseObject, Name: testAddrName, Protocol: testProtocol, HTTPMethod: testMethod, Address: testAddress, Port: testPort, Path: clients.ApiDeviceRoute, Publisher: testPublisher, User: testUser, Password: testPassword, Topic: testTopic}
+var TestAddressable = Addressable{Timestamps: TestTimestamps, Name: testAddrName, Protocol: testProtocol, HTTPMethod: testMethod, Address: testAddress, Port: testPort, Path: clients.ApiDeviceRoute, Publisher: testPublisher, User: testUser, Password: testPassword, Topic: testTopic}
 var EmptyAddressable = Addressable{}
 
 func TestAddressable_MarshalJSON(t *testing.T) {

--- a/models/command.go
+++ b/models/command.go
@@ -25,7 +25,7 @@ import (
  * Command struct
  */
 type Command struct {
-	BaseObject `yaml:",inline"`
+	Timestamps `yaml:",inline"`
 	Id         string `json:"id" yaml:"id,omitempty"`
 	Name       string `json:"name" yaml:"name,omitempty"` // Command name (unique on the profile)
 	Get        *Get   `json:"get" yaml:"get,omitempty"`   // Get Command
@@ -35,13 +35,13 @@ type Command struct {
 // Custom marshaling for making empty strings null
 func (c Command) MarshalJSON() ([]byte, error) {
 	test := struct {
-		BaseObject
+		Timestamps
 		Id   *string `json:"id,omitempty"`
 		Name *string `json:"name,omitempty"` // Command name (unique on the profile)
 		Get  *Get    `json:"get,omitempty"`  // Get Command
 		Put  *Put    `json:"put,omitempty"`  // Put Command
 	}{
-		BaseObject: c.BaseObject,
+		Timestamps: c.Timestamps,
 		Get:        c.Get,
 		Put:        c.Put,
 	}

--- a/models/command_test.go
+++ b/models/command_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var TestCommandName = "test command name"
-var TestCommand = Command{BaseObject: TestBaseObject, Name: TestCommandName, Get: &TestGet, Put: &TestPut}
+var TestCommand = Command{Timestamps: TestTimestamps, Name: TestCommandName, Get: &TestGet, Put: &TestPut}
 
 func TestCommand_MarshalJSON(t *testing.T) {
 	var testCommandBytes = []byte(TestCommand.String())

--- a/models/describedobject.go
+++ b/models/describedobject.go
@@ -17,7 +17,7 @@ package models
 import "encoding/json"
 
 type DescribedObject struct {
-	BaseObject  `yaml:",inline"`
+	Timestamps  `yaml:",inline"`
 	Description string `json:"description" yaml:"description,omitempty"`
 }
 

--- a/models/describedobject_test.go
+++ b/models/describedobject_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var TestDscription = "test description"
-var TestDescribedObject = DescribedObject{BaseObject: TestBaseObject, Description: TestDescription}
+var TestDescribedObject = DescribedObject{Timestamps: TestTimestamps, Description: TestDescription}
 
 func TestDescribedObject_String(t *testing.T) {
 	tests := []struct {

--- a/models/devicereport.go
+++ b/models/devicereport.go
@@ -19,7 +19,7 @@ import (
 )
 
 type DeviceReport struct {
-	BaseObject
+	Timestamps
 	Id       string   `json:"id"`
 	Name     string   `json:"name"`     // non-database identifier for a device report - must be unique
 	Device   string   `json:"device"`   // associated device name - should be a valid and unique device name
@@ -30,14 +30,14 @@ type DeviceReport struct {
 // Custom marshaling to make empty strings null
 func (dr DeviceReport) MarshalJSON() ([]byte, error) {
 	test := struct {
-		BaseObject
+		Timestamps
 		Id       string   `json:"id"`
 		Name     *string  `json:"name"`     // non-database identifier for a device report - must be unique
 		Device   *string  `json:"device"`   // associated device name - should be a valid and unique device name
 		Action   *string  `json:"action"`   // associated interval action name - should be a valid and unique interval action name
 		Expected []string `json:"expected"` // array of value descriptor names describing the types of data captured in the report
 	}{
-		BaseObject: dr.BaseObject,
+		Timestamps: dr.Timestamps,
 		Id:         dr.Id,
 		Expected:   dr.Expected,
 	}

--- a/models/devicereport_test.go
+++ b/models/devicereport_test.go
@@ -25,7 +25,7 @@ import (
 var TestIntervalaction = "Test Interval Action"
 var TestReportName = "Test Report.NAME"
 var TestReportExpected = []string{"vD1", "vD2"}
-var TestDeviceReport = DeviceReport{BaseObject: TestBaseObject, Name: TestReportName, Device: TestDeviceName, Action: TestIntervalaction, Expected: TestReportExpected}
+var TestDeviceReport = DeviceReport{Timestamps: TestTimestamps, Name: TestReportName, Device: TestDeviceName, Action: TestIntervalaction, Expected: TestReportExpected}
 
 func TestDeviceReport_MarshalJSON(t *testing.T) {
 	var emptyDeviceReport = DeviceReport{}
@@ -63,9 +63,9 @@ func TestDeviceReport_String(t *testing.T) {
 		want string
 	}{
 		{"device report to string", TestDeviceReport,
-			"{\"created\":" + strconv.FormatInt(TestBaseObject.Created, 10) +
-				",\"modified\":" + strconv.FormatInt(TestBaseObject.Modified, 10) +
-				",\"origin\":" + strconv.FormatInt(TestBaseObject.Origin, 10) +
+			"{\"created\":" + strconv.FormatInt(TestTimestamps.Created, 10) +
+				",\"modified\":" + strconv.FormatInt(TestTimestamps.Modified, 10) +
+				",\"origin\":" + strconv.FormatInt(TestTimestamps.Origin, 10) +
 				",\"id\":\"\"" +
 				",\"name\":\"" + TestReportName + "\"" +
 				",\"device\":\"" + TestDeviceName + "\"" +

--- a/models/interval.go
+++ b/models/interval.go
@@ -35,7 +35,7 @@ type Interval struct {
 // Custom marshaling to make empty strings null
 func (i Interval) MarshalJSON() ([]byte, error) {
 	test := struct {
-		BaseObject
+		Timestamps
 		ID        *string `json:"id,omitempty"`
 		Created   int64   `json:"created,omitempty"`
 		Modified  int64   `json:"modified,omitempty"`

--- a/models/notifications.go
+++ b/models/notifications.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Notification struct {
-	BaseObject
+	Timestamps
 	ID          string                `json:"id,omitempty"`
 	Slug        string                `json:"slug,omitempty"`
 	Sender      string                `json:"sender,omitempty"`
@@ -35,7 +35,7 @@ type Notification struct {
 
 func (n Notification) MarshalJSON() ([]byte, error) {
 	test := struct {
-		BaseObject
+		Timestamps
 		ID          *string               `json:"id"`
 		Slug        *string               `json:"slug,omitempty,omitempty"`
 		Sender      *string               `json:"sender,omitempty"`
@@ -47,7 +47,7 @@ func (n Notification) MarshalJSON() ([]byte, error) {
 		Labels      []string              `json:"labels,omitempty"`
 		ContentType *string               `json:"contenttype,omitempty"`
 	}{
-		BaseObject: n.BaseObject,
+		Timestamps: n.Timestamps,
 		Category:   n.Category,
 		Severity:   n.Severity,
 		Status:     n.Status,

--- a/models/notifications_test.go
+++ b/models/notifications_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var TestEmptyNotification = Notification{}
-var TestNotification = Notification{BaseObject: BaseObject{Created: 123, Modified: 123}, Category: NotificationsCategory("SECURITY"),
+var TestNotification = Notification{Timestamps: Timestamps{Created: 123, Modified: 123}, Category: NotificationsCategory("SECURITY"),
 	Content: "test content", Description: "test description", Labels: []string{"label1", "labe2"}, Sender: "test sender",
 	Severity: NotificationsSeverity("CRITICAL"), Slug: "test slug", Status: NotificationsStatus("NEW")}
 
@@ -40,7 +40,7 @@ func TestNotification_MarshalJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n := Notification{
-				BaseObject:  tt.notification.BaseObject,
+				Timestamps:  tt.notification.Timestamps,
 				ID:          tt.notification.ID,
 				Slug:        tt.notification.Slug,
 				Sender:      tt.notification.Sender,

--- a/models/provisionwatcher.go
+++ b/models/provisionwatcher.go
@@ -19,7 +19,7 @@ import (
 )
 
 type ProvisionWatcher struct {
-	BaseObject
+	Timestamps
 	Id             string            `json:"id"`
 	Name           string            `json:"name"`           // unique name and identifier of the addressable
 	Identifiers    map[string]string `json:"identifiers"`    // set of key value pairs that identify type of of address (MAC, HTTP,...) and address to watch for (00-05-1B-A1-99-99, 10.0.0.1,...)
@@ -31,7 +31,7 @@ type ProvisionWatcher struct {
 // Custom marshaling to make empty strings null
 func (pw ProvisionWatcher) MarshalJSON() ([]byte, error) {
 	test := struct {
-		BaseObject
+		Timestamps
 		Id             string            `json:"id"`
 		Name           *string           `json:"name"`           // unique name and identifier of the addressable
 		Identifiers    map[string]string `json:"identifiers"`    // set of key value pairs that identify type of of address (MAC, HTTP,...) and address to watch for (00-05-1B-A1-99-99, 10.0.0.1,...)
@@ -40,7 +40,7 @@ func (pw ProvisionWatcher) MarshalJSON() ([]byte, error) {
 		OperatingState OperatingState    `json:"operatingState"` // operational state - either enabled or disabled
 	}{
 		Id:             pw.Id,
-		BaseObject:     pw.BaseObject,
+		Timestamps:     pw.Timestamps,
 		Profile:        pw.Profile,
 		Service:        pw.Service,
 		OperatingState: pw.OperatingState,

--- a/models/provisionwatcher_test.go
+++ b/models/provisionwatcher_test.go
@@ -31,7 +31,7 @@ var TestIdentifiers = map[string]string{
 	TestPWNameKey1: TestPWVal1,
 	TestPWNameKey2: TestPWVal2,
 }
-var TestProvisionWatcher = ProvisionWatcher{BaseObject: TestBaseObject, Name: TestPWName, Identifiers: TestIdentifiers, Profile: TestProfile, Service: TestDeviceService}
+var TestProvisionWatcher = ProvisionWatcher{Timestamps: TestTimestamps, Name: TestPWName, Identifiers: TestIdentifiers, Profile: TestProfile, Service: TestDeviceService}
 
 func TestProvisionWatcher_MarshalJSON(t *testing.T) {
 	var testPWBytes = []byte(TestProvisionWatcher.String())

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -26,7 +26,7 @@ import (
  * Subscription struct
  */
 type Subscription struct {
-	BaseObject
+	Timestamps
 	ID                   string                  `json:"id"`
 	Slug                 string                  `json:"slug,omitempty"`
 	Receiver             string                  `json:"receiver,omitempty"`
@@ -39,7 +39,7 @@ type Subscription struct {
 // Custom marshaling to make empty strings null
 func (s Subscription) MarshalJSON() ([]byte, error) {
 	test := struct {
-		BaseObject
+		Timestamps
 		ID                   *string                 `json:"id"`
 		Slug                 *string                 `json:"slug,omitempty"`
 		Receiver             *string                 `json:"receiver,omitempty"`
@@ -48,7 +48,7 @@ func (s Subscription) MarshalJSON() ([]byte, error) {
 		SubscribedLabels     []string                `json:"subscribedLabels,omitempty"`
 		Channels             []Channel               `json:"channels,omitempty"`
 	}{
-		BaseObject:           s.BaseObject,
+		Timestamps:           s.Timestamps,
 		SubscribedCategories: s.SubscribedCategories,
 		SubscribedLabels:     s.SubscribedLabels,
 		Channels:             s.Channels,

--- a/models/subscription_test.go
+++ b/models/subscription_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var TestEmptySubscription = Subscription{}
-var TestSubscription = Subscription{BaseObject: TestBaseObject, Slug: "test slug", Receiver: "test receiver", Description: "test description",
+var TestSubscription = Subscription{Timestamps: TestTimestamps, Slug: "test slug", Receiver: "test receiver", Description: "test description",
 	SubscribedCategories: []NotificationsCategory{NotificationsCategory(Swhealth)}, SubscribedLabels: []string{"test label"},
 	Channels: []Channel{TestEChannel, TestRChannel}}
 

--- a/models/timestamps.go
+++ b/models/timestamps.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 )
 
-type BaseObject struct {
+type Timestamps struct {
 	Created  int64 `json:"created,omitempty" yaml:"created,omitempty"`
 	Modified int64 `json:"modified,omitempty" yaml:"modified,omitempty"`
 	Origin   int64 `json:"origin,omitempty" yaml:"origin,omitempty"`
@@ -27,7 +27,7 @@ type BaseObject struct {
 /*
  * String function for representing a device
  */
-func (o *BaseObject) String() string {
+func (o *Timestamps) String() string {
 	out, err := json.Marshal(o)
 	if err != nil {
 		return err.Error()
@@ -38,7 +38,7 @@ func (o *BaseObject) String() string {
 /*
  * Compare the Created of two objects to determine given is newer
  */
-func (ba *BaseObject) compareTo(i BaseObject) int {
+func (ba *Timestamps) compareTo(i Timestamps) int {
 	if i.Created > ba.Created {
 		return 1
 	}

--- a/models/timestamps_test.go
+++ b/models/timestamps_test.go
@@ -16,48 +16,48 @@ package models
 
 import "testing"
 
-var TestBaseObject = BaseObject{Created: 123, Modified: 123, Origin: 123}
-var EmptyBaseObject = BaseObject{}
+var TestTimestamps = Timestamps{Created: 123, Modified: 123, Origin: 123}
+var EmptyTimestamps = Timestamps{}
 
-func TestBaseObject_String(t *testing.T) {
+func TestTimestamps_String(t *testing.T) {
 	tests := []struct {
 		name       string
-		baseObject *BaseObject
+		timestamps *Timestamps
 		want       string
 	}{
-		{"empty base", &EmptyBaseObject, "{}"},
-		{"populated base", &TestBaseObject, "{\"created\":123,\"modified\":123,\"origin\":123}"},
+		{"empty timestamps", &EmptyTimestamps, "{}"},
+		{"populated timestamps", &TestTimestamps, "{\"created\":123,\"modified\":123,\"origin\":123}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.baseObject.String(); got != tt.want {
-				t.Errorf("BaseObject.String() = %v, want %v", got, tt.want)
+			if got := tt.timestamps.String(); got != tt.want {
+				t.Errorf("Timestamps.String() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestBaseObject_compareTo(t *testing.T) {
+func TestTimestamps_compareTo(t *testing.T) {
 	type args struct {
-		i BaseObject
+		i Timestamps
 	}
-	var sameBaseObject = args{TestBaseObject}
-	var newerBaseObject = args{BaseObject{234, 234, 234}}
-	var olderBaseObject = args{BaseObject{1, 1, 1}}
+	var sameTimestamps = args{TestTimestamps}
+	var newerTimestamps = args{Timestamps{234, 234, 234}}
+	var olderTimestamps = args{Timestamps{1, 1, 1}}
 	tests := []struct {
 		name string
-		ba   *BaseObject
+		ba   *Timestamps
 		args args
 		want int
 	}{
-		{"same object", &TestBaseObject, sameBaseObject, -1},
-		{"newer", &TestBaseObject, newerBaseObject, 1},
-		{"older", &TestBaseObject, olderBaseObject, -1},
+		{"same timestamps", &TestTimestamps, sameTimestamps, -1},
+		{"newer", &TestTimestamps, newerTimestamps, 1},
+		{"older", &TestTimestamps, olderTimestamps, -1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.ba.compareTo(tt.args.i); got != tt.want {
-				t.Errorf("BaseObject.compareTo() = %v, want %v", got, tt.want)
+				t.Errorf("Timestamps.compareTo() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/models/transmission.go
+++ b/models/transmission.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Transmission struct {
-	BaseObject
+	Timestamps
 	ID           string               `json:"id"`
 	Notification Notification         `json:"notification"`
 	Receiver     string               `json:"receiver,omitempty"`
@@ -33,7 +33,7 @@ type Transmission struct {
 // Custom marshaling to make empty strings null
 func (t Transmission) MarshalJSON() ([]byte, error) {
 	test := struct {
-		BaseObject
+		Timestamps
 		ID           *string              `json:"id"`
 		Notification Notification         `json:"notification,omitempty"`
 		Receiver     *string              `json:"receiver,omitempty"`
@@ -42,7 +42,7 @@ func (t Transmission) MarshalJSON() ([]byte, error) {
 		ResendCount  int                  `json:"resendcount"`
 		Records      []TransmissionRecord `json:"records,omitempty"`
 	}{
-		BaseObject:   t.BaseObject,
+		Timestamps:   t.Timestamps,
 		Notification: t.Notification,
 		Channel:      t.Channel,
 		Status:       t.Status,

--- a/models/transmission_test.go
+++ b/models/transmission_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var TestEmptyTransmission = Transmission{}
-var TestTransmission = Transmission{BaseObject: TestBaseObject, Notification: TestNotification, Receiver: "test receiver",
+var TestTransmission = Transmission{Timestamps: TestTimestamps, Notification: TestNotification, Receiver: "test receiver",
 	Channel: Channel{Type: ChannelType(Email), MailAddresses: []string{"jpwhite_mn@yahoo.com", "james_white2@dell.com"}}, Status: TransmissionStatus(Sent), ResendCount: 0, Records: []TransmissionRecord{TestSentTransRecord}}
 
 func TestTransmission_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
Updated all references to BaseObject to now use Timestamps.

I also made a change regarding the `logLevels` array and its accessibility. When I updated `edgex-go` to leverage these changes there was a compilation issue due to the `logLevels` having been updated to not be exported as a global variable. I created an exported function in the `LogLevels`  in the `logger` package so that the log level information can be safely be shared across repos. I will have changes in the `edgex-go` repo which will update the to using a version of `go-mod-core-contracts` which contains these changes, once they are merged.