### PR TITLE
Changing the interface of CommandResponseFromDevice function.

### DIFF
--- a/models/commandresponse.go
+++ b/models/commandresponse.go
@@ -86,7 +86,7 @@ func createUrl(basePath string, cmdId string) string {
 /*
  * CommandResponseFromDevice will create a CommandResponse struct from the supplied Device struct
  */
-func CommandResponseFromDevice(d Device, cmdURL string) CommandResponse {
+func CommandResponseFromDevice(d Device, commands []Command, cmdURL string) CommandResponse {
 	cmdResp := CommandResponse{
 		Id:             d.Id,
 		Name:           d.Name,
@@ -96,7 +96,7 @@ func CommandResponseFromDevice(d Device, cmdURL string) CommandResponse {
 		LastReported:   d.LastReported,
 		Labels:         d.Labels,
 		Location:       d.Location,
-		Commands:       d.Profile.CoreCommands,
+		Commands:       commands,
 	}
 
 	basePath := fmt.Sprintf("%s%s/%s/command/", cmdURL, clients.ApiDeviceRoute, d.Id)


### PR DESCRIPTION
This is first step toward facilitating the decoupling of the DeviceProfile
and its associated Commands from the Device.

Resolves/Fixes: https://github.com/edgexfoundry/go-mod-core-contracts/issues/68

Related with Issue in edgex-go/core-commands: https://github.com/edgexfoundry/edgex-go/issues/1254
It is preferable both PRs to be mearged at once.

Signed-off-by: difince <dianaa@vmware.com>