### PR TITLE
Add constants for Base64Encoding and eNotation

### DIFF
--- a/models/propertyvalue.go
+++ b/models/propertyvalue.go
@@ -18,6 +18,13 @@ import (
 	"encoding/json"
 )
 
+const (
+	// Base64Encoding : the float value is represented in Base64 encoding
+	Base64Encoding = "Base64"
+	// ENotation : the float value is represented in eNotation
+	ENotation = "eNotation"
+)
+
 type PropertyValue struct {
 	Type          string `json:"type" yaml:"type,omitempty"`                 // ValueDescriptor Type of property after transformations
 	ReadWrite     string `json:"readWrite" yaml:"readWrite,omitempty"`       // Read/Write Permissions set for this property

--- a/models/propertyvalue_test.go
+++ b/models/propertyvalue_test.go
@@ -32,7 +32,7 @@ var TestPVOffset = "0.0"
 var TestPVBase = "0"
 var TestPVAssertion = "0"
 var TestPVPrecision = "1"
-var TestPVFloatEncoding = "Base64"
+var TestPVFloatEncoding = Base64Encoding
 var TestPropertyValue = PropertyValue{Type: TestPVType, ReadWrite: TestPVReadWrite, Minimum: TestPVMinimum, Maximum: TestPVMaximum, DefaultValue: TestPVDefaultValue, Size: TestPVSize, Mask: TestPVMask, Shift: TestPVShift, Scale: TestPVScale, Offset: TestPVOffset, Base: TestPVBase, Assertion: TestPVAssertion, Precision: TestPVPrecision, FloatEncoding: TestPVFloatEncoding, MediaType: TestMediaType}
 
 func TestPropertyValue_MarshalJSON(t *testing.T) {

--- a/models/value-descriptor_test.go
+++ b/models/value-descriptor_test.go
@@ -31,7 +31,7 @@ var TestUoMLabel = "C"
 var TestDefaultValue = 32
 var TestFormatting = "%d"
 var TestVDLabels = []string{"temp", "room temp"}
-var TestVDFloatEncoding = "eNotation"
+var TestVDFloatEncoding = ENotation
 var TestValueDescriptor = ValueDescriptor{Created: 123, Modified: 123, Origin: 123, Name: TestVDName, Description: TestVDDescription, Min: TestMin, Max: TestMax, DefaultValue: TestDefaultValue, Formatting: TestFormatting, Labels: TestVDLabels, UomLabel: TestUoMLabel, MediaType: TestMediaType, FloatEncoding: TestVDFloatEncoding}
 
 func TestValueDescriptor_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
The value of FloatEncoding field in PropertyValue and
ValueDescriptor is limited to "Base64" and "eNotation"
fix #74

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>