### PR TITLE
Fixed Event Struct Tags

### DIFF
--- a/models/event.go
+++ b/models/event.go
@@ -23,13 +23,13 @@ import (
 
 // Event represents a single measurable event read from a device
 type Event struct {
-	ID          string    `json:"id" codec:"omitempty"`       // ID uniquely identifies an event, for example a UUID
-	Pushed      int64     `json:"pushed" codec:"omitempty"`   // Pushed is a timestamp indicating when the event was exported. If unexported, the value is zero.
-	Device      string    `json:"device" codec:"omitempty"`   // Device identifies the source of the event, can be a device name or id. Usually the device name.
-	Created     int64     `json:"created" codec:"omitempty"`  // Created is a timestamp indicating when the event was created.
-	Modified    int64     `json:"modified" codec:"omitempty"` // Modified is a timestamp indicating when the event was last modified.
-	Origin      int64     `json:"origin" codec:"omitempty"`   // Origin is a timestamp that can communicate the time of the original reading, prior to event creation
-	Readings    []Reading `json:"readings" codec:"omitempty"` // Readings will contain zero to many entries for the associated readings of a given event.
+	ID          string    `json:"id" codec:"id,omitempty"`             // ID uniquely identifies an event, for example a UUID
+	Pushed      int64     `json:"pushed" codec:"pushed,omitempty"`     // Pushed is a timestamp indicating when the event was exported. If unexported, the value is zero.
+	Device      string    `json:"device" codec:"device,omitempty"`     // Device identifies the source of the event, can be a device name or id. Usually the device name.
+	Created     int64     `json:"created" codec:"created,omitempty"`   // Created is a timestamp indicating when the event was created.
+	Modified    int64     `json:"modified" codec:"modified,omitempty"` // Modified is a timestamp indicating when the event was last modified.
+	Origin      int64     `json:"origin" codec:"origin,omitempty"`     // Origin is a timestamp that can communicate the time of the original reading, prior to event creation
+	Readings    []Reading `json:"readings" codec:"readings,omitempty"` // Readings will contain zero to many entries for the associated readings of a given event.
 	isValidated bool      // internal member used for validation check
 }
 

--- a/models/event_test.go
+++ b/models/event_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/ugorji/go/codec"
 )
 
 var TestEvent = Event{Pushed: 123, Created: 123, Device: TestDeviceName, Origin: 123, Modified: 123, Readings: []Reading{TestReading}}
@@ -96,5 +98,20 @@ func TestEventValidation(t *testing.T) {
 				t.Errorf("did not receive expected error: %s", tt.name)
 			}
 		})
+	}
+}
+
+func Test_encodeAsCBOR(t *testing.T) {
+	bytes := TestEvent.CBOR()
+	var evt Event
+	var handle codec.CborHandle
+	dec := codec.NewDecoderBytes(bytes, &handle)
+	err := dec.Decode(&evt)
+	if err != nil {
+		t.Error("Error decoding Event: " + err.Error())
+	}
+
+	if !reflect.DeepEqual(TestEvent, evt) {
+		t.Error("Failed to properly decode event")
 	}
 }

--- a/models/reading.go
+++ b/models/reading.go
@@ -26,16 +26,17 @@ import (
  *
  * Struct for the Reading object in EdgeX
  */
+
 type Reading struct {
-	Id          string `json:"id"`
-	Pushed      int64  `json:"pushed"`  // When the data was pushed out of EdgeX (0 - not pushed yet)
-	Created     int64  `json:"created"` // When the reading was created
-	Origin      int64  `json:"origin"`
-	Modified    int64  `json:"modified"`
-	Device      string `json:"device"`
-	Name        string `json:"name"`
-	Value       string `json:"value"`       // Device sensor data value
-	BinaryValue []byte `json:"binaryValue"` // Binary data payload
+	Id          string `json:"id" codec:"id,omitempty"`
+	Pushed      int64  `json:"pushed" codec:"pushed,omitempty"`   // When the data was pushed out of EdgeX (0 - not pushed yet)
+	Created     int64  `json:"created" codec:"created,omitempty"` // When the reading was created
+	Origin      int64  `json:"origin" codec:"origin,omitempty"`
+	Modified    int64  `json:"modified" codec:"modified,omitempty"`
+	Device      string `json:"device" codec:"device,omitempty"`
+	Name        string `json:"name" codec:"name,omitempty"`
+	Value       string `json:"value"  codec:"value,omitempty"`            // Device sensor data value
+	BinaryValue []byte `json:"binaryValue" codec:"binaryValue,omitempty"` // Binary data payload
 	isValidated bool   // internal member used for validation check
 }
 


### PR DESCRIPTION
This commit fixes issue 76

Updated the struct tags on the Event type. Previously, the id portion of
the struct tag was not specified for the "codec" type, which was causing
issues when encoding and decoding into CBOR using the codec library.

Added "codec" struct tags to the Reading type

Added tests for both types which validates CBOR encoding and decoding
Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>