### PR TITLE
Added AddBytes & MarshalEvent methods to EventClient

### DIFF
--- a/clients/coredata/reading_test.go
+++ b/clients/coredata/reading_test.go
@@ -36,7 +36,10 @@ const (
 )
 
 var testReading = models.Reading{Pushed: 123, Created: 123, Origin: 123, Modified: 123, Device: "test device name",
-	Name: "Temperature", Value: "45", BinaryValue: []byte{0xbf}}
+	Name: "Temperature", Value: "45"}
+
+var testBinaryReading = models.Reading{Pushed: 123, Created: 123, Origin: 123, Modified: 123, Device: "test device name",
+	Name: "Temperature", BinaryValue: []byte{0xbf}}
 
 func TestGetReadings(t *testing.T) {
 	reading1 := testReading


### PR DESCRIPTION
#62 

The Device Services group asked that the EventClient take on the centralized responsibility for handling encoding of events. To that end, marshaling has been exposed to callers via the MarshalEvent method. After the caller uses this method to encode the event, they can add the event directly as a byte array via the new EventClient.AddBytes method.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>