### PR TITLE
Added ErrContractInvalid Type. Return from Validate()

### DIFF
--- a/models/addressable.go
+++ b/models/addressable.go
@@ -17,7 +17,6 @@ package models
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"strconv"
 	"strings"
 )
@@ -186,7 +185,7 @@ func (a *Addressable) UnmarshalJSON(data []byte) error {
 func (a Addressable) Validate() (bool, error) {
 	if !a.isValidated {
 		if a.Id == "" && a.Name == "" {
-			return false, errors.New("Addressable ID and Name are both blank")
+			return false, NewErrContractInvalid("Addressable ID and Name are both blank")
 		}
 		return true, nil
 	}

--- a/models/addressable_test.go
+++ b/models/addressable_test.go
@@ -108,6 +108,7 @@ func TestAddressableNoCallback(t *testing.T) {
 }
 
 func TestAddressableValidation(t *testing.T) {
+	valid := TestAddressable
 	invalid := TestAddressable
 	invalid.Name = ""
 	invalid.Id = ""
@@ -117,18 +118,13 @@ func TestAddressableValidation(t *testing.T) {
 		a           Addressable
 		expectError bool
 	}{
-		{"valid addressable", TestAddressable, false},
+		{"valid addressable", valid, false},
 		{"invalid addressable", invalid, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.a.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/adminstate.go
+++ b/models/adminstate.go
@@ -48,7 +48,7 @@ func (as *AdminState) UnmarshalJSON(data []byte) error {
 func (as AdminState) Validate() (bool, error) {
 	_, found := map[string]AdminState{"LOCKED": Locked, "UNLOCKED": Unlocked}[string(as)]
 	if !found {
-		return false, fmt.Errorf("invalid AdminState %q", as)
+		return false, NewErrContractInvalid(fmt.Sprintf("invalid AdminState %q", as))
 	}
 	return true, nil
 }

--- a/models/adminstate_test.go
+++ b/models/adminstate_test.go
@@ -42,10 +42,17 @@ func TestAdminState_UnmarshalJSON(t *testing.T) {
 			if err := tt.as.UnmarshalJSON(tt.args.data); err != nil {
 				t.Errorf("AdminState.UnmarshalJSON() error = %v", err)
 			} else {
-				if _, err = tt.as.Validate(); (err != nil) != tt.wantErr {
-					// if the bytes did unmarshal, make sure they unmarshaled to correct enum by comparing it to expected results
-					var unmarshaledResult = string(*tt.as)
-					t.Errorf("Unmarshal did not result in expected admin state string.  Expected:  %s, got: %s", expected, unmarshaledResult)
+				_, err = tt.as.Validate()
+				if err != nil {
+					if !tt.wantErr {
+						// if the bytes did unmarshal, make sure they unmarshaled to correct enum by comparing it to expected results
+						var unmarshaledResult = string(*tt.as)
+						t.Errorf("Unmarshal did not result in expected admin state string.  Expected:  %s, got: %s", expected, unmarshaledResult)
+					}
+					_, ok := err.(ErrContractInvalid)
+					if !ok {
+						t.Errorf("incorrect error type returned")
+					}
 				}
 			}
 		})

--- a/models/command.go
+++ b/models/command.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // Command defines a specific read/write operation targeting a device
@@ -91,7 +90,7 @@ func (c *Command) UnmarshalJSON(data []byte) error {
 func (c Command) Validate() (bool, error) {
 	if !c.isValidated {
 		if c.Name == "" {
-			return false, errors.New("Name cannot be blank")
+			return false, NewErrContractInvalid("Name cannot be blank")
 		}
 		err := validate(c)
 		if err != nil {

--- a/models/command_test.go
+++ b/models/command_test.go
@@ -93,6 +93,7 @@ func TestCommand_AllAssociatedValueDescriptors(t *testing.T) {
 }
 
 func TestCommandValidation(t *testing.T) {
+	valid := TestCommand
 	invalid := TestCommand
 	invalid.Name = ""
 	tests := []struct {
@@ -100,18 +101,13 @@ func TestCommandValidation(t *testing.T) {
 		cmd         Command
 		expectError bool
 	}{
-		{"valid command", TestCommand, false},
+		{"valid command", valid, false},
 		{"invalid command", invalid, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.cmd.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/device.go
+++ b/models/device.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // Device represents a registered device participating within the EdgeX Foundry ecosystem
@@ -134,10 +133,10 @@ func (d *Device) UnmarshalJSON(data []byte) error {
 func (d Device) Validate() (bool, error) {
 	if !d.isValidated {
 		if d.Id == "" && d.Name == "" {
-			return false, errors.New("Device ID and Name are both blank")
+			return false, NewErrContractInvalid("Device ID and Name are both blank")
 		}
 		if len(d.Protocols) == 0 {
-			return false, errors.New("no supporting protocol specified for device")
+			return false, NewErrContractInvalid("no supporting protocol specified for device")
 		}
 		err := validate(d)
 		if err != nil {

--- a/models/device_test.go
+++ b/models/device_test.go
@@ -115,6 +115,7 @@ func TestDevice_AllAssociatedValueDescriptors(t *testing.T) {
 }
 
 func TestDeviceValidation(t *testing.T) {
+	valid := TestDevice
 	invalidIdentifiers := TestDevice
 	invalidIdentifiers.Name = ""
 	invalidIdentifiers.Id = ""
@@ -127,19 +128,14 @@ func TestDeviceValidation(t *testing.T) {
 		d           Device
 		expectError bool
 	}{
-		{"valid device", TestDevice, false},
+		{"valid device", valid, false},
 		{"invalid device identifiers", invalidIdentifiers, true},
 		{"invalid protocols", invalidProtocols, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.d.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/deviceprofile.go
+++ b/models/deviceprofile.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // DeviceProfile represents the attributes and operational capabilities of a device. It is a template for which
@@ -127,7 +126,7 @@ func (dp *DeviceProfile) UnmarshalJSON(data []byte) error {
 func (dp DeviceProfile) Validate() (bool, error) {
 	if !dp.isValidated {
 		if dp.Id == "" && dp.Name == "" {
-			return false, errors.New("Device ID and Name are both blank")
+			return false, NewErrContractInvalid("Device ID and Name are both blank")
 		}
 		// Check if there are duplicate names in the device profile command list
 		cmds := map[string]int{}
@@ -135,7 +134,7 @@ func (dp DeviceProfile) Validate() (bool, error) {
 			if _, ok := cmds[c.Name]; !ok {
 				cmds[c.Name] = 1
 			} else {
-				return false, errors.New("duplicate names in device profile commands")
+				return false, NewErrContractInvalid("duplicate names in device profile commands")
 			}
 		}
 		err := validate(dp)

--- a/models/deviceprofile_test.go
+++ b/models/deviceprofile_test.go
@@ -87,6 +87,7 @@ func TestDeviceProfile_String(t *testing.T) {
 }
 
 func TestDeviceProfileValidation(t *testing.T) {
+	valid := TestProfile
 	invalidIdentifiers := TestProfile
 	invalidIdentifiers.Name = ""
 	invalidIdentifiers.Id = ""
@@ -99,19 +100,14 @@ func TestDeviceProfileValidation(t *testing.T) {
 		dp          DeviceProfile
 		expectError bool
 	}{
-		{"valid device profile", TestProfile, false},
+		{"valid device profile", valid, false},
 		{"invalid profile identifiers", invalidIdentifiers, true},
 		{"invalid profile commands", invalidCommands, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.dp.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/deviceservice_test.go
+++ b/models/deviceservice_test.go
@@ -54,6 +54,7 @@ func TestDeviceService_MarshalJSON(t *testing.T) {
 }
 
 func TestDeviceService_UnmarshalJSON(t *testing.T) {
+	valid := TestDeviceService
 	fmt.Println(TestDeviceService.String())
 	var resultTestBytes = []byte(TestDeviceService.String())
 	type args struct {
@@ -65,8 +66,8 @@ func TestDeviceService_UnmarshalJSON(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"unmarshal normal device service with success", &TestDeviceService, args{resultTestBytes}, false},
-		{"unmarshal normal device service failed", &TestDeviceService, args{[]byte("{nonsense}")}, true},
+		{"unmarshal normal device service with success", &valid, args{resultTestBytes}, false},
+		{"unmarshal normal device service failed", &valid, args{[]byte("{nonsense}")}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -116,8 +117,22 @@ func TestDeviceService_String(t *testing.T) {
 }
 
 func TestDeviceServiceValidation(t *testing.T) {
-	isValid, err := TestDeviceService.Validate()
-	if !isValid {
-		t.Errorf(err.Error())
+	valid := TestDeviceService
+	invalid := TestDeviceService
+	invalid.Addressable.Name = ""
+
+	tests := []struct {
+		name        string
+		ds          DeviceService
+		expectError bool
+	}{
+		{"valid", valid, false},
+		{"invalid", invalid, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.ds.Validate()
+			checkValidationError(err, tt.expectError, tt.name, t)
+		})
 	}
 }

--- a/models/errors.go
+++ b/models/errors.go
@@ -14,34 +14,19 @@
 
 package models
 
-import (
-	"testing"
-)
+// ErrContractInvalid is a specific error type for handling model validation failures. Type checking within
+// the calling application will facilitate more explicit error handling whereby it's clear that validation
+// has failed as opposed to something unexpected happening.
+type ErrContractInvalid struct {
+	errMsg string
+}
 
-var testLogEntry = LogEntry{Level: InfoLog, Created: 123, Message: "We logged some stuff"}
+// NewErrContractInvalid returns an instance of the error interface with ErrContractInvalid as its implementation.
+func NewErrContractInvalid(message string) error {
+	return ErrContractInvalid{errMsg: message}
+}
 
-func TestLogEntryValidation(t *testing.T) {
-	valid := testLogEntry
-
-	invalid := testLogEntry
-	invalid.Level = "blah"
-
-	blank := testLogEntry
-	blank.Level = ""
-
-	tests := []struct {
-		name        string
-		le          LogEntry
-		expectError bool
-	}{
-		{"valid log entry", valid, false},
-		{"invalid log level", invalid, true},
-		{"blank log level", blank, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.le.Validate()
-			checkValidationError(err, tt.expectError, tt.name, t)
-		})
-	}
+// Error fulfills the error interface and returns an error message assembled from the state of ErrContractInvalid.
+func (e ErrContractInvalid) Error() string {
+	return e.errMsg
 }

--- a/models/errors_test.go
+++ b/models/errors_test.go
@@ -14,34 +14,20 @@
 
 package models
 
-import (
-	"testing"
-)
+import "testing"
 
-var testLogEntry = LogEntry{Level: InfoLog, Created: 123, Message: "We logged some stuff"}
-
-func TestLogEntryValidation(t *testing.T) {
-	valid := testLogEntry
-
-	invalid := testLogEntry
-	invalid.Level = "blah"
-
-	blank := testLogEntry
-	blank.Level = ""
-
-	tests := []struct {
-		name        string
-		le          LogEntry
-		expectError bool
-	}{
-		{"valid log entry", valid, false},
-		{"invalid log level", invalid, true},
-		{"blank log level", blank, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.le.Validate()
-			checkValidationError(err, tt.expectError, tt.name, t)
-		})
+func checkValidationError(err error, expectError bool, testName string, t *testing.T) {
+	if err != nil {
+		if !expectError {
+			t.Errorf("unexpected error: %v", err)
+		}
+		_, ok := err.(ErrContractInvalid)
+		if !ok {
+			t.Errorf("incorrect error type returned")
+		}
+	} else {
+		if expectError {
+			t.Errorf("did not receive expected error: %s", testName)
+		}
 	}
 }

--- a/models/event.go
+++ b/models/event.go
@@ -16,8 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
-
 	"github.com/ugorji/go/codec"
 )
 
@@ -119,7 +117,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 func (e Event) Validate() (bool, error) {
 	if !e.isValidated {
 		if e.Device == "" {
-			return false, errors.New("source device for event not specified")
+			return false, NewErrContractInvalid("source device for event not specified")
 		}
 	}
 	return true, nil

--- a/models/event_test.go
+++ b/models/event_test.go
@@ -77,6 +77,7 @@ func TestEvent_String(t *testing.T) {
 }
 
 func TestEventValidation(t *testing.T) {
+	valid := TestEvent
 	invalid := TestEvent
 	invalid.Device = ""
 
@@ -85,18 +86,13 @@ func TestEventValidation(t *testing.T) {
 		e           Event
 		expectError bool
 	}{
-		{"valid event", TestEvent, false},
+		{"valid event", valid, false},
 		{"invalid event", invalid, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.e.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/interval.go
+++ b/models/interval.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -128,18 +127,18 @@ func (i *Interval) UnmarshalJSON(data []byte) error {
 func (i Interval) Validate() (bool, error) {
 	if !i.isValidated {
 		if i.ID == "" && i.Name == "" {
-			return false, errors.New("Interval ID and Name are both blank")
+			return false, NewErrContractInvalid("Interval ID and Name are both blank")
 		}
 		if i.Start != "" {
 			_, err := strconv.ParseInt(i.Start, 10, 64)
 			if err != nil {
-				return false, fmt.Errorf("error parsing Start %v", err)
+				return false, NewErrContractInvalid(fmt.Sprintf("error parsing Start %v", err))
 			}
 		}
 		if i.End != "" {
 			_, err := strconv.ParseInt(i.End, 10, 64)
 			if err != nil {
-				return false, fmt.Errorf("error parsing End %v", err)
+				return false, NewErrContractInvalid(fmt.Sprintf("error parsing End %v", err))
 			}
 		}
 		if i.Frequency != "" {
@@ -150,7 +149,7 @@ func (i Interval) Validate() (bool, error) {
 				}
 			}
 			if !matched {
-				return false, fmt.Errorf("invalid Interval Frequency %s", i.Frequency)
+				return false, NewErrContractInvalid(fmt.Sprintf("invalid Interval Frequency %s", i.Frequency))
 			}
 		}
 		err := validate(i)

--- a/models/interval_action.go
+++ b/models/interval_action.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"strconv"
 	"strings"
 )
@@ -194,13 +193,13 @@ func (ia *IntervalAction) UnmarshalJSON(data []byte) error {
 func (ia IntervalAction) Validate() (bool, error) {
 	if !ia.isValidated {
 		if ia.ID == "" && ia.Name == "" {
-			return false, errors.New("IntervalAction ID and Name are both blank")
+			return false, NewErrContractInvalid("IntervalAction ID and Name are both blank")
 		}
 		if ia.Target == "" {
-			return false, errors.New("intervalAction target is blank")
+			return false, NewErrContractInvalid("intervalAction target is blank")
 		}
 		if ia.Interval == "" {
-			return false, errors.New("intervalAction interval is blank")
+			return false, NewErrContractInvalid("intervalAction interval is blank")
 		}
 		return true, nil
 	}

--- a/models/interval_action_test.go
+++ b/models/interval_action_test.go
@@ -20,6 +20,8 @@ var testIntervalAction = IntervalAction{Name: "Test Interval Action", Interval: 
 	Address: "localhost", Port: 48080, Protocol: "http", HTTPMethod: "DELETE", Path: "/api/v1/event/removeold/age/604800000"}
 
 func TestIntervalActionValidation(t *testing.T) {
+	valid := testIntervalAction
+
 	invalidIdentifiers := testIntervalAction
 	invalidIdentifiers.Name = ""
 	invalidIdentifiers.ID = ""
@@ -35,7 +37,7 @@ func TestIntervalActionValidation(t *testing.T) {
 		ia          IntervalAction
 		expectError bool
 	}{
-		{"valid interval action", testIntervalAction, false},
+		{"valid interval action", valid, false},
 		{"invalid identifiers", invalidIdentifiers, true},
 		{"invalid target", invalidTarget, true},
 		{"invalid interval", invalidInterval, true},
@@ -43,12 +45,7 @@ func TestIntervalActionValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.ia.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/interval_test.go
+++ b/models/interval_test.go
@@ -20,6 +20,8 @@ var testInterval = Interval{Name: "Test Interval", Timestamps: testTimestamps, S
 	End: "1464039919109", Frequency: "P1D"}
 
 func TestIntervalValidation(t *testing.T) {
+	valid := testInterval
+
 	invalidIdentifiers := testInterval
 	invalidIdentifiers.Name = ""
 	invalidIdentifiers.ID = ""
@@ -38,7 +40,7 @@ func TestIntervalValidation(t *testing.T) {
 		i           Interval
 		expectError bool
 	}{
-		{"valid interval", testInterval, false},
+		{"valid interval", valid, false},
 		{"invalid interval identifiers", invalidIdentifiers, true},
 		{"invalid interval start", invalidStart, true},
 		{"invalid interval end", invalidEnd, true},
@@ -47,12 +49,7 @@ func TestIntervalValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.i.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/log_entry.go
+++ b/models/log_entry.go
@@ -111,7 +111,7 @@ func (le LogEntry) Validate() (bool, error) {
 				return true, nil
 			}
 		}
-		return false, fmt.Errorf("Invalid level in LogEntry: %s", le.Level)
+		return false, NewErrContractInvalid(fmt.Sprintf("Invalid level in LogEntry: %s", le.Level))
 	}
 	return le.isValidated, nil
 }

--- a/models/notify_update.go
+++ b/models/notify_update.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -57,12 +56,12 @@ func (n *NotifyUpdate) UnmarshalJSON(data []byte) error {
 func (n NotifyUpdate) Validate() (bool, error) {
 	if !n.isValidated {
 		if n.Name == "" || n.Operation == "" {
-			return false, errors.New("Name and Operation must both have a value")
+			return false, NewErrContractInvalid("Name and Operation must both have a value")
 		}
 		if n.Operation != NotifyUpdateAdd &&
 			n.Operation != NotifyUpdateUpdate &&
 			n.Operation != NotifyUpdateDelete {
-			return false, fmt.Errorf("Invalid value for operation %s", n.Operation)
+			return false, NewErrContractInvalid(fmt.Sprintf("Invalid value for operation %s", n.Operation))
 		}
 	}
 	return true, nil

--- a/models/notify_update_test.go
+++ b/models/notify_update_test.go
@@ -19,6 +19,8 @@ import "testing"
 var testNotifyUpdate = NotifyUpdate{Name: "For Testing", Operation: NotifyUpdateAdd}
 
 func TestNotifyUpdateValidation(t *testing.T) {
+	valid := testNotifyUpdate
+
 	invalidName := testNotifyUpdate
 	invalidName.Name = ""
 
@@ -33,7 +35,7 @@ func TestNotifyUpdateValidation(t *testing.T) {
 		nu          NotifyUpdate
 		expectError bool
 	}{
-		{"valid notify update", testNotifyUpdate, false},
+		{"valid notify update", valid, false},
 		{"invalid name", invalidName, true},
 		{"invalid operation", invalidOp, true},
 		{"invalid operation value", invalidOpNotBlank, true},
@@ -41,12 +43,7 @@ func TestNotifyUpdateValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.nu.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/operatingstate.go
+++ b/models/operatingstate.go
@@ -50,7 +50,7 @@ func (os *OperatingState) UnmarshalJSON(data []byte) error {
 func (os OperatingState) Validate() (bool, error) {
 	_, found := map[string]OperatingState{"ENABLED": Enabled, "DISABLED": Disabled}[string(os)]
 	if !found {
-		return false, fmt.Errorf("invalid OperatingState %q", os)
+		return false, NewErrContractInvalid(fmt.Sprintf("invalid OperatingState %q", os))
 	}
 	return true, nil
 }

--- a/models/operatingstate_test.go
+++ b/models/operatingstate_test.go
@@ -43,10 +43,17 @@ func TestOperatingState_UnmarshalJSON(t *testing.T) {
 			if err := tt.os.UnmarshalJSON(tt.args.data); err != nil {
 				t.Errorf("OperatingState.UnmarshalJSON() error = %v", err)
 			} else {
-				if _, err = tt.os.Validate(); (err != nil) != tt.wantErr {
-					// if the bytes did unmarshal, make sure they unmarshaled to correct enum by comparing it to expected results
-					var unmarshaledResult = string(*tt.os)
-					t.Errorf("Unmarshal did not result in expected admin operating string.  Expected:  %s, got: %s", expected, unmarshaledResult)
+				_, err = tt.os.Validate()
+				if err != nil {
+					if !tt.wantErr {
+						// if the bytes did unmarshal, make sure they unmarshaled to correct enum by comparing it to expected results
+						var unmarshaledResult = string(*tt.os)
+						t.Errorf("Unmarshal did not result in expected admin operating string.  Expected:  %s, got: %s", expected, unmarshaledResult)
+					}
+					_, ok := err.(ErrContractInvalid)
+					if !ok {
+						t.Errorf("incorrect error type returned")
+					}
 				}
 			}
 		})

--- a/models/provisionwatcher.go
+++ b/models/provisionwatcher.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 type ProvisionWatcher struct {
@@ -100,7 +99,7 @@ func (pw *ProvisionWatcher) UnmarshalJSON(data []byte) error {
 func (pw ProvisionWatcher) Validate() (bool, error) {
 	if !pw.isValidated {
 		if pw.Name == "" {
-			return false, errors.New("provision watcher name is blank")
+			return false, NewErrContractInvalid("provision watcher name is blank")
 		}
 		err := validate(pw)
 		if err != nil {

--- a/models/provisionwatcher_test.go
+++ b/models/provisionwatcher_test.go
@@ -87,6 +87,8 @@ func TestProvisionWatcher_String(t *testing.T) {
 }
 
 func TestProvisionWatcherValidation(t *testing.T) {
+	valid := TestProvisionWatcher
+
 	invalid := TestProvisionWatcher
 	invalid.Name = ""
 
@@ -95,18 +97,13 @@ func TestProvisionWatcherValidation(t *testing.T) {
 		pw          ProvisionWatcher
 		expectError bool
 	}{
-		{"valid provision watcher", TestProvisionWatcher, false},
+		{"valid provision watcher", valid, false},
 		{"invalid provision watcher", invalid, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.pw.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/reading.go
+++ b/models/reading.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 /*
@@ -125,13 +124,13 @@ func (r *Reading) UnmarshalJSON(data []byte) error {
 func (r Reading) Validate() (bool, error) {
 	if !r.isValidated {
 		if r.Device == "" {
-			return false, errors.New("source device for reading not specified")
+			return false, NewErrContractInvalid("source device for reading not specified")
 		}
 		if r.Name == "" {
-			return false, errors.New("name for reading's value descriptor not specified")
+			return false, NewErrContractInvalid("name for reading's value descriptor not specified")
 		}
 		if r.Value == "" && len(r.BinaryValue) == 0 {
-			return false, errors.New("reading has no value")
+			return false, NewErrContractInvalid("reading has no value")
 		}
 	}
 	return true, nil

--- a/models/reading_test.go
+++ b/models/reading_test.go
@@ -87,12 +87,14 @@ func TestReading_String(t *testing.T) {
 }
 
 func TestReadingValidation(t *testing.T) {
+	valid := TestReading
+
 	tests := []struct {
 		name        string
 		r           Reading
 		expectError bool
 	}{
-		{"valid reading", TestReading, false},
+		{"valid reading", valid, false},
 		{"invalid device", Reading{Name: "test", Value: "0"}, true},
 		{"invalid name", Reading{Device: "test", Value: "0"}, true},
 		{"invalid value", Reading{Device: "test", Name: "test"}, true},
@@ -100,12 +102,7 @@ func TestReadingValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.r.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/registration.go
+++ b/models/registration.go
@@ -132,7 +132,7 @@ func (r *Registration) UnmarshalJSON(data []byte) error {
 func (reg Registration) Validate() (bool, error) {
 	if !reg.isValidated {
 		if reg.Name == "" {
-			return false, fmt.Errorf("Name is required")
+			return false, NewErrContractInvalid("Name is required")
 		}
 
 		if reg.Compression == "" {
@@ -142,7 +142,7 @@ func (reg Registration) Validate() (bool, error) {
 		if reg.Compression != CompNone &&
 			reg.Compression != CompGzip &&
 			reg.Compression != CompZip {
-			return false, fmt.Errorf("Compression invalid: %s", reg.Compression)
+			return false, NewErrContractInvalid(fmt.Sprintf("Compression invalid: %s", reg.Compression))
 		}
 
 		if reg.Format != FormatJSON &&
@@ -154,7 +154,7 @@ func (reg Registration) Validate() (bool, error) {
 			reg.Format != FormatCSV &&
 			reg.Format != FormatThingsBoardJSON &&
 			reg.Format != FormatNOOP {
-			return false, fmt.Errorf("Format invalid: %s", reg.Format)
+			return false, NewErrContractInvalid(fmt.Sprintf("Format invalid: %s", reg.Format))
 		}
 
 		if reg.Destination != DestMQTT &&
@@ -164,7 +164,7 @@ func (reg Registration) Validate() (bool, error) {
 			reg.Destination != DestAWSMQTT &&
 			reg.Destination != DestRest &&
 			reg.Destination != DestInfluxDB {
-			return false, fmt.Errorf("Destination invalid: %s", reg.Destination)
+			return false, NewErrContractInvalid(fmt.Sprintf("Destination invalid: %s", reg.Destination))
 		}
 
 		if reg.Encryption.Algo == "" {
@@ -173,7 +173,7 @@ func (reg Registration) Validate() (bool, error) {
 
 		if reg.Encryption.Algo != EncNone &&
 			reg.Encryption.Algo != EncAes {
-			return false, fmt.Errorf("Encryption invalid: %s", reg.Encryption.Algo)
+			return false, NewErrContractInvalid(fmt.Sprintf("Encryption invalid: %s", reg.Encryption.Algo))
 		}
 		err := validate(reg)
 		if err != nil {

--- a/models/registration_test.go
+++ b/models/registration_test.go
@@ -23,6 +23,8 @@ var testRegistration = Registration{ID: uuid.New().String(), Name: "Test Registr
 	Format: FormatJSON, Destination: DestZMQ, Addressable: TestAddressable}
 
 func TestRegistrationValidation(t *testing.T) {
+	valid := testRegistration
+
 	invalidName := testRegistration
 	invalidName.Name = ""
 
@@ -43,7 +45,7 @@ func TestRegistrationValidation(t *testing.T) {
 		r           Registration
 		expectError bool
 	}{
-		{"valid registration", testRegistration, false},
+		{"valid registration", valid, false},
 		{"invalid registration name", invalidName, true},
 		{"invalid registration compression", invalidCompression, true},
 		{"invalid registration format", invalidFormat, true},
@@ -53,12 +55,7 @@ func TestRegistrationValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.r.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/models/validator.go
+++ b/models/validator.go
@@ -38,7 +38,7 @@ func validate(t interface{}) error {
 				cast := v.(Validator)
 				_, err := cast.Validate()
 				if err != nil {
-					return err
+					return NewErrContractInvalid(err.Error())
 				}
 			}
 		}

--- a/models/value-descriptor.go
+++ b/models/value-descriptor.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 )
@@ -182,14 +181,14 @@ func (v ValueDescriptor) Validate() (bool, error) {
 			formatSpecifier := "%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])"
 			match, err := regexp.MatchString(formatSpecifier, v.Formatting)
 			if err != nil {
-				return false, fmt.Errorf("error validating format string: %s", v.Formatting)
+				return false, NewErrContractInvalid(fmt.Sprintf("error validating format string: %s", v.Formatting))
 			}
 			if !match {
-				return false, fmt.Errorf("format is not a valid printf format: %s", v.Formatting)
+				return false, NewErrContractInvalid(fmt.Sprintf("format is not a valid printf format: %s", v.Formatting))
 			}
 		}
 		if v.Name == "" {
-			return false, errors.New("name for value descriptor not specified")
+			return false, NewErrContractInvalid("name for value descriptor not specified")
 		}
 	}
 	return true, nil

--- a/models/value-descriptor_test.go
+++ b/models/value-descriptor_test.go
@@ -91,6 +91,8 @@ func TestValueDescriptor_String(t *testing.T) {
 }
 
 func TestValueDescriptorValidation(t *testing.T) {
+	valid := TestValueDescriptor
+
 	invalidName := TestValueDescriptor
 	invalidName.Name = ""
 
@@ -102,19 +104,14 @@ func TestValueDescriptorValidation(t *testing.T) {
 		vd          ValueDescriptor
 		expectError bool
 	}{
-		{"valid value descriptor", TestValueDescriptor, false},
+		{"valid value descriptor", valid, false},
 		{"invalid format string", invalidFormat, true},
 		{"invalid name", invalidName, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.vd.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.expectError && err == nil {
-				t.Errorf("did not receive expected error: %s", tt.name)
-			}
+			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}
 }

--- a/requests/states/admin/update_test.go
+++ b/requests/states/admin/update_test.go
@@ -15,8 +15,9 @@
 package admin
 
 import (
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 func TestUpdateValidation(t *testing.T) {
@@ -33,8 +34,14 @@ func TestUpdateValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.up.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
+			if err != nil {
+				if !tt.expectError {
+					t.Errorf("unexpected error: %v", err)
+				}
+				_, ok := err.(models.ErrContractInvalid)
+				if !ok {
+					t.Errorf("incorrect error type returned")
+				}
 			}
 			if tt.expectError && err == nil {
 				t.Errorf("did not receive expected error: %s", tt.name)

--- a/requests/states/operating/update_test.go
+++ b/requests/states/operating/update_test.go
@@ -33,8 +33,14 @@ func TestUpdateValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.up.Validate()
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
+			if err != nil {
+				if !tt.expectError {
+					t.Errorf("unexpected error: %v", err)
+				}
+				_, ok := err.(models.ErrContractInvalid)
+				if !ok {
+					t.Errorf("incorrect error type returned")
+				}
 			}
 			if tt.expectError && err == nil {
 				t.Errorf("did not receive expected error: %s", tt.name)


### PR DESCRIPTION
#85

- Created ErrContractInvalid type, implementing Go stdlib `error`
  interface.
- The purpose of this type is to allow a caller to differentiate
  explicitly between a problem with validation versus an unexpected error
- For example, an API router could type check a returned error and if
  it's of type ErrContractInvalid, return a 400. Otherwise return 500.
- For tests oriented around validation testing, created a new
  checkValidationError() function for standard handling. Integrated
  into existing tests.
- Corrected test issue whereby a type instance such as TestAddressable
  that is used in multiple tests could cause tests to fail if used
  directly. This is because the private isValidated member would be set
  to true by the first test, causing validation to not be run by
  subsequent tests which would produce erroneous results. The solution
  is simply to copy the TestAddressable into a local variable (called
  "valid" where the change was made) and then use that within the test.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>