### PR TITLE
Replace value receiver with pointer receiver when validate adminstate and operatingstate

### DIFF
--- a/models/adminstate.go
+++ b/models/adminstate.go
@@ -45,10 +45,10 @@ func (as *AdminState) UnmarshalJSON(data []byte) error {
 }
 
 // Validate satisfies the Validator interface
-func (as AdminState) Validate() (bool, error) {
-	_, found := map[string]AdminState{"LOCKED": Locked, "UNLOCKED": Unlocked}[string(as)]
+func (as *AdminState) Validate() (bool, error) {
+	_, found := map[string]AdminState{"LOCKED": Locked, "UNLOCKED": Unlocked}[string(*as)]
 	if !found {
-		return false, NewErrContractInvalid(fmt.Sprintf("invalid AdminState %q", as))
+		return false, NewErrContractInvalid(fmt.Sprintf("invalid AdminState %q", *as))
 	}
 	return true, nil
 }

--- a/models/operatingstate.go
+++ b/models/operatingstate.go
@@ -47,10 +47,10 @@ func (os *OperatingState) UnmarshalJSON(data []byte) error {
 }
 
 // Validate satisfies the Validator interface
-func (os OperatingState) Validate() (bool, error) {
-	_, found := map[string]OperatingState{"ENABLED": Enabled, "DISABLED": Disabled}[string(os)]
+func (os *OperatingState) Validate() (bool, error) {
+	_, found := map[string]OperatingState{"ENABLED": Enabled, "DISABLED": Disabled}[string(*os)]
 	if !found {
-		return false, NewErrContractInvalid(fmt.Sprintf("invalid OperatingState %q", os))
+		return false, NewErrContractInvalid(fmt.Sprintf("invalid OperatingState %q", *os))
 	}
 	return true, nil
 }


### PR DESCRIPTION
Fix the [issue-#87](https://github.com/edgexfoundry/go-mod-core-contracts/issues/87)