### PR TITLE
Fix issue-#91 bug, baseURL is empty when command objecct returns

### DIFF
--- a/models/commandresponse.go
+++ b/models/commandresponse.go
@@ -96,12 +96,11 @@ func CommandResponseFromDevice(d Device, commands []Command, cmdURL string) Comm
 	}
 
 	basePath := fmt.Sprintf("%s%s/%s/command/", cmdURL, clients.ApiDeviceRoute, d.Id)
-
 	// TODO: Find a way to encapsulate this within the "Action" struct if possible
-	for _, c := range cmdResp.Commands {
-		url := basePath + c.Id
-		c.Get.URL = url
-		c.Put.URL = url
+	for i := 0; i < len(cmdResp.Commands); i++ {
+		url := basePath + cmdResp.Commands[i].Id
+		cmdResp.Commands[i].Get.URL = url
+		cmdResp.Commands[i].Put.URL = url
 	}
 
 	return cmdResp


### PR DESCRIPTION
Fix [issue-#91 bug](https://github.com/edgexfoundry/go-mod-core-contracts/issues/91)
the range statement just copy a duplicate value of origin object, so it will not change the origin object