### PR TITLE
Fix Interval's Validate() method to check timestamp

### DIFF
--- a/models/interval.go
+++ b/models/interval.go
@@ -18,11 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strconv"
+	"time"
 )
 
 const (
 	frequencyPattern = `^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+S)?)?$`
+	timestampLayout  = "20060102T150405"
 )
 
 // Interval a period of time
@@ -130,13 +131,13 @@ func (i Interval) Validate() (bool, error) {
 			return false, NewErrContractInvalid("Interval ID and Name are both blank")
 		}
 		if i.Start != "" {
-			_, err := strconv.ParseInt(i.Start, 10, 64)
+			_, err := time.Parse(timestampLayout, i.Start)
 			if err != nil {
 				return false, NewErrContractInvalid(fmt.Sprintf("error parsing Start %v", err))
 			}
 		}
 		if i.End != "" {
-			_, err := strconv.ParseInt(i.End, 10, 64)
+			_, err := time.Parse(timestampLayout, i.End)
 			if err != nil {
 				return false, NewErrContractInvalid(fmt.Sprintf("error parsing End %v", err))
 			}

--- a/models/interval_test.go
+++ b/models/interval_test.go
@@ -16,8 +16,8 @@ package models
 
 import "testing"
 
-var testInterval = Interval{Name: "Test Interval", Timestamps: testTimestamps, Start: "1464039919104",
-	End: "1464039919109", Frequency: "P1D"}
+var testInterval = Interval{Name: "Test Interval", Timestamps: testTimestamps, Start: "20180101T000000",
+	End: "20200101T000000", Frequency: "P1D"}
 
 func TestIntervalValidation(t *testing.T) {
 	valid := testInterval


### PR DESCRIPTION
Fix #1308

Interval's Validate() method was attempting to parse an
integer out of a timestamp.  This change has it parsing
a time using the time package's Parse() function.

Signed-off-by: Daniel Harms <jdharms@gmail.com>