### PR TITLE
Add ValueDescriptor mapping from DeviceResource

### DIFF
--- a/models/value-descriptor.go
+++ b/models/value-descriptor.go
@@ -20,6 +20,9 @@ import (
 	"regexp"
 )
 
+// defaultValueDescriptorFormat defines the default formatting value used with creating a ValueDescriptor from a DeviceResource.
+const defaultValueDescriptorFormat = "%s"
+
 /*
  * Value Descriptor Struct
  */
@@ -203,4 +206,24 @@ func (a ValueDescriptor) String() string {
 		return err.Error()
 	}
 	return string(out)
+}
+
+// From creates a ValueDescriptor based on the information provided in the DeviceResource.
+func From(dr DeviceResource) ValueDescriptor {
+	value := dr.Properties.Value
+	units := dr.Properties.Units
+	desc := ValueDescriptor{
+		Name:          dr.Name,
+		Min:           value.Minimum,
+		Max:           value.Maximum,
+		Type:          value.Type,
+		UomLabel:      units.DefaultValue,
+		DefaultValue:  value.DefaultValue,
+		Formatting:    defaultValueDescriptorFormat,
+		Description:   dr.Description,
+		FloatEncoding: value.FloatEncoding,
+		MediaType:     value.MediaType,
+	}
+
+	return desc
 }

--- a/models/value-descriptor_test.go
+++ b/models/value-descriptor_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -113,5 +114,46 @@ func TestValueDescriptorValidation(t *testing.T) {
 			_, err := tt.vd.Validate()
 			checkValidationError(err, tt.expectError, tt.name, t)
 		})
+	}
+}
+
+func TestFrom(t *testing.T) {
+	observed := From(TestDeviceResource)
+
+	errs := make([]string, 0)
+
+	if observed.Name != TestDeviceResource.Name {
+		errs = append(errs, "Name")
+	}
+	if observed.Description != TestDeviceResource.Description {
+		errs = append(errs, "Description")
+	}
+	if observed.Max != TestDeviceResource.Properties.Value.Maximum {
+		errs = append(errs, "Max")
+	}
+	if observed.Min != TestDeviceResource.Properties.Value.Minimum {
+		errs = append(errs, "Min")
+	}
+	if observed.Type != TestDeviceResource.Properties.Value.Type {
+		errs = append(errs, "Type")
+	}
+	if observed.FloatEncoding != TestDeviceResource.Properties.Value.FloatEncoding {
+		errs = append(errs, "FloatEncoding")
+	}
+	if observed.MediaType != TestDeviceResource.Properties.Value.MediaType {
+		errs = append(errs, "MediaType")
+	}
+	if observed.DefaultValue != TestDeviceResource.Properties.Value.DefaultValue {
+		errs = append(errs, "DefaultValue")
+	}
+	if observed.UomLabel != TestDeviceResource.Properties.Units.DefaultValue {
+		errs = append(errs, "UomLabel")
+	}
+	if observed.Formatting != defaultValueDescriptorFormat {
+		errs = append(errs, "UomLabel")
+	}
+
+	if len(errs) > 0 {
+		t.Errorf("The ValueDescriptor field(s) did not match the data provided in the DeviceResource: %s", strings.Join(errs, ", "))
 	}
 }


### PR DESCRIPTION
Fix #119

Add function in value-descriptor.go which handles the creation of a
value descriptor from a device resource.

Add new test to cover newly added functionality.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>