### PR TITLE
Create new fields in ResourceOperation

### DIFF
--- a/models/resourceoperation.go
+++ b/models/resourceoperation.go
@@ -17,25 +17,30 @@ package models
 import "encoding/json"
 
 type ResourceOperation struct {
-	Index     string            `json:"index" yaml:"index,omitempty"`
-	Operation string            `json:"operation" yaml:"operation,omitempty"`
-	Object    string            `json:"object" yaml:"object,omitempty"`
-	Parameter string            `json:"parameter" yaml:"parameter,omitempty"`
-	Resource  string            `json:"resource" yaml:"resource,omitempty"`
-	Secondary []string          `json:"secondary" yaml:"secondary,omitempty"`
-	Mappings  map[string]string `json:"mappings" yaml:"mappings,omitempty"`
+	Index          string            `json:"index" yaml:"index,omitempty"`
+	Operation      string            `json:"operation" yaml:"operation,omitempty"`
+	Object         string            `json:"object" yaml:"object,omitempty"`                 // Deprecated
+	DeviceResource string            `json:"deviceResource" yaml:"deviceResource,omitempty"` // The replacement of Object field
+	Parameter      string            `json:"parameter" yaml:"parameter,omitempty"`
+	Resource       string            `json:"resource" yaml:"resource,omitempty"`           // Deprecated
+	DeviceCommand  string            `json:"deviceCommand" yaml:"deviceCommand,omitempty"` // The replacement of Resource field
+	Secondary      []string          `json:"secondary" yaml:"secondary,omitempty"`
+	Mappings       map[string]string `json:"mappings" yaml:"mappings,omitempty"`
+	isValidated    bool              // internal member used for validation check
 }
 
 // Custom marshaling to make empty strings null
 func (ro ResourceOperation) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Index     *string           `json:"index,omitempty"`
-		Operation *string           `json:"operation,omitempty"`
-		Object    *string           `json:"object,omitempty"`
-		Parameter *string           `json:"parameter,omitempty"`
-		Resource  *string           `json:"resource,omitempty"`
-		Secondary []string          `json:"secondary,omitempty"`
-		Mappings  map[string]string `json:"mappings,omitempty"`
+		Index          *string           `json:"index,omitempty"`
+		Operation      *string           `json:"operation,omitempty"`
+		Object         *string           `json:"object,omitempty"`
+		DeviceResource *string           `json:"deviceResource,omitempty"`
+		Parameter      *string           `json:"parameter,omitempty"`
+		Resource       *string           `json:"resource,omitempty"`
+		DeviceCommand  *string           `json:"deviceCommand,omitempty"`
+		Secondary      []string          `json:"secondary,omitempty"`
+		Mappings       map[string]string `json:"mappings,omitempty"`
 	}{
 		Secondary: ro.Secondary,
 		Mappings:  ro.Mappings,
@@ -48,17 +53,92 @@ func (ro ResourceOperation) MarshalJSON() ([]byte, error) {
 	if ro.Operation != "" {
 		test.Operation = &ro.Operation
 	}
-	if ro.Object != "" {
+	if ro.DeviceResource != "" {
+		test.DeviceResource = &ro.DeviceResource
+		test.Object = &ro.DeviceResource
+	} else if ro.Object != "" {
 		test.Object = &ro.Object
+		test.DeviceResource = &ro.Object
 	}
 	if ro.Parameter != "" {
 		test.Parameter = &ro.Parameter
 	}
-	if ro.Resource != "" {
+	if ro.DeviceCommand != "" {
+		test.DeviceCommand = &ro.DeviceCommand
+		test.Resource = &ro.DeviceCommand
+	} else if ro.Resource != "" {
 		test.Resource = &ro.Resource
+		test.DeviceCommand = &ro.Resource
 	}
 
 	return json.Marshal(test)
+}
+
+// UnmarshalJSON implements the Unmarshaler interface for the ResourceOperation type
+func (ro *ResourceOperation) UnmarshalJSON(data []byte) error {
+	var err error
+	type Alias struct {
+		Index          *string           `json:"index"`
+		Operation      *string           `json:"operation"`
+		Object         *string           `json:"object"`
+		DeviceResource *string           `json:"deviceResource"`
+		Parameter      *string           `json:"parameter"`
+		Resource       *string           `json:"resource"`
+		DeviceCommand  *string           `json:"deviceCommand"`
+		Secondary      []string          `json:"secondary"`
+		Mappings       map[string]string `json:"mappings"`
+	}
+	a := Alias{}
+	// Error with unmarshaling
+	if err = json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	// Check nil fields
+	if a.Index != nil {
+		ro.Index = *a.Index
+	}
+	if a.Operation != nil {
+		ro.Operation = *a.Operation
+	}
+	if a.DeviceResource != nil {
+		ro.DeviceResource = *a.DeviceResource
+		ro.Object = *a.DeviceResource
+	} else if a.Object != nil {
+		ro.Object = *a.Object
+		ro.DeviceResource = *a.Object
+	}
+	if a.Parameter != nil {
+		ro.Parameter = *a.Parameter
+	}
+	if a.DeviceCommand != nil {
+		ro.DeviceCommand = *a.DeviceCommand
+		ro.Resource = *a.DeviceCommand
+	} else if a.Resource != nil {
+		ro.Resource = *a.Resource
+		ro.DeviceCommand = *a.Resource
+	}
+	ro.Secondary = a.Secondary
+	ro.Mappings = a.Mappings
+
+	ro.isValidated, err = ro.Validate()
+
+	return err
+}
+
+// Validate satisfies the Validator interface
+func (ro ResourceOperation) Validate() (bool, error) {
+	if !ro.isValidated {
+		if ro.Object == "" && ro.DeviceResource == "" {
+			return false, NewErrContractInvalid("Object and DeviceResource are both blank")
+		}
+		err := validate(ro)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return ro.isValidated, nil
 }
 
 /*

--- a/models/resourceoperation_test.go
+++ b/models/resourceoperation_test.go
@@ -23,12 +23,12 @@ import (
 
 var TestResourceIndex = "test index"
 var TestOperation = "test operation"
-var TestResourceObject = "test resource object"
+var TestRODeviceResource = "test device resource"
 var TestParameter = "test parameter"
-var TestResource = "test resource"
+var TestDeviceCommand = "test device command"
 var TestSecondary = []string{"test secondary"}
 var TestMappings = make(map[string]string)
-var TestResourceOperation = ResourceOperation{Index: TestResourceIndex, Operation: TestOperation, Object: TestResourceObject, Parameter: TestParameter, Resource: TestResource, Secondary: TestSecondary, Mappings: TestMappings}
+var TestResourceOperation = ResourceOperation{Index: TestResourceIndex, Operation: TestOperation, DeviceResource: TestRODeviceResource, Parameter: TestParameter, DeviceCommand: TestDeviceCommand, Secondary: TestSecondary, Mappings: TestMappings}
 
 func TestResourceOperation_MarshalJSON(t *testing.T) {
 	var testResourceOperationBytes = []byte(TestResourceOperation.String())
@@ -64,15 +64,101 @@ func TestResourceOperation_String(t *testing.T) {
 		{"resource operation to string", TestResourceOperation,
 			"{\"index\":\"" + TestResourceIndex + "\"" +
 				",\"operation\":\"" + TestOperation + "\"" +
-				",\"object\":\"" + TestResourceObject + "\"" +
+				",\"object\":\"" + TestRODeviceResource + "\"" +
+				",\"deviceResource\":\"" + TestRODeviceResource + "\"" +
 				",\"parameter\":\"" + TestParameter + "\"" +
-				",\"resource\":\"" + TestResource + "\"" +
+				",\"resource\":\"" + TestDeviceCommand + "\"" +
+				",\"deviceCommand\":\"" + TestDeviceCommand + "\"" +
 				",\"secondary\":" + fmt.Sprint(string(secondarySlice)) + "}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.ro.String(); got != tt.want {
 				t.Errorf("ResourceOperation.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceOperationValidation(t *testing.T) {
+	valid := TestResourceOperation
+	noDeviceResource := TestResourceOperation
+	noDeviceResource.Object = ""
+	noDeviceResource.DeviceResource = ""
+	tests := []struct {
+		name        string
+		ro          ResourceOperation
+		expectError bool
+	}{
+		{"valid ResourceOperation", valid, false},
+		{"without Object and DeviceResource", noDeviceResource, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.ro.Validate()
+			checkValidationError(err, tt.expectError, tt.name, t)
+		})
+	}
+}
+
+func TestResourceOperation_FieldsAutoPopulation_MarshalJSON(t *testing.T) {
+	oldResourceOperation := ResourceOperation{Object: TestRODeviceResource, Resource: TestDeviceCommand}
+	newResourceOperation := ResourceOperation{DeviceResource: TestRODeviceResource, DeviceCommand: TestDeviceCommand}
+	oldNewResourceOperation := ResourceOperation{Object: "XX", DeviceResource: TestRODeviceResource, Resource: "XX", DeviceCommand: TestDeviceCommand}
+	expectedJsonString := "{\"object\":\"" + TestRODeviceResource + "\"" +
+		",\"deviceResource\":\"" + TestRODeviceResource + "\"" +
+		",\"resource\":\"" + TestDeviceCommand + "\"" +
+		",\"deviceCommand\":\"" + TestDeviceCommand + "\"}"
+	tests := []struct {
+		name string
+		ro   ResourceOperation
+	}{
+		{"old fields only", oldResourceOperation},
+		{"new fields only", newResourceOperation},
+		{"new fields and old fields are different", oldNewResourceOperation},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonBytes, err := tt.ro.MarshalJSON()
+			if err != nil {
+				t.Errorf("ResourceOperation.MarshalJSON() error = %v", err)
+			}
+			if string(jsonBytes) != expectedJsonString {
+				t.Errorf("Fields auto population is unexpected: %s, ", string(jsonBytes))
+			}
+		})
+	}
+}
+
+func TestResourceOperation_FieldsAutoPopulation_UnmarshalJSON(t *testing.T) {
+	oldJson := "{\"object\":\"" + TestRODeviceResource + "\"" +
+		",\"resource\":\"" + TestDeviceCommand + "\"}"
+	newJson := "{\"deviceResource\":\"" + TestRODeviceResource + "\"" +
+		",\"deviceCommand\":\"" + TestDeviceCommand + "\"}"
+	oldNewJson := "{\"object\":\"XX\"" +
+		",\"deviceResource\":\"" + TestRODeviceResource + "\"" +
+		",\"resource\":\"XX\"" +
+		",\"deviceCommand\":\"" + TestDeviceCommand + "\"}"
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"old fields only", oldJson},
+		{"new fields only", newJson},
+		{"new fields and old fields are different", oldNewJson},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ro := &ResourceOperation{}
+			err := ro.UnmarshalJSON([]byte(tt.json))
+			if err != nil {
+				t.Errorf("ResourceOperation.UnmarshalJSON() error = %v", err)
+			}
+			if ro.Object != TestRODeviceResource || ro.DeviceResource != TestRODeviceResource {
+				t.Errorf("Object and DeviceResource fields auto population is unexpected: %s, ", ro.String())
+			}
+			if ro.Resource != TestDeviceCommand || ro.DeviceCommand != TestDeviceCommand {
+				t.Errorf("Resource and DeviceCommand fields auto population is unexpected: %s, ", ro.String())
 			}
 		})
 	}


### PR DESCRIPTION
New fields:
DeviceCommand (json:"deviceCommand")
DeviceResource (json:"deviceResource")
"Object" to be marked as deprecated (replaced by DeviceResource)
"Resource" to be marked as deprecated (replaced by DeviceCommand)
Arrangements to be made in marshaling to duplicate values for compatibility purposes.
fix https://github.com/edgexfoundry/go-mod-core-contracts/issues/114

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>