### PR TITLE
Added text/plain content type.

### DIFF
--- a/clients/constants.go
+++ b/clients/constants.go
@@ -73,4 +73,5 @@ const (
 	ContentTypeCBOR = "application/cbor"
 	ContentTypeJSON = "application/json"
 	ContentTypeYAML = "application/x-yaml"
+	ContentTypeText = "text/plain"
 )


### PR DESCRIPTION
This content type is used by the `ping` endpoints.

https://github.com/edgexfoundry/edgex-go/issues/1712

Signed-off-by: Brandon Forster <brandonforster@gmail.com>