### PR TITLE
Changing interval model to support subsecond frequency time duration

### DIFF
--- a/models/interval.go
+++ b/models/interval.go
@@ -143,6 +143,7 @@ func (i Interval) Validate() (bool, error) {
 			}
 		}
 		if i.Frequency != "" {
+			/* legacy frequencyPattern */
 			matched, _ := regexp.MatchString(frequencyPattern, i.Frequency)
 			if matched {
 				if i.Frequency == "P" || i.Frequency == "PT" {
@@ -150,7 +151,11 @@ func (i Interval) Validate() (bool, error) {
 				}
 			}
 			if !matched {
-				return false, NewErrContractInvalid(fmt.Sprintf("invalid Interval Frequency %s", i.Frequency))
+				// parse frequency example "1h15m30s10us9ns"
+				_, err := time.ParseDuration(i.Frequency)
+				if err != nil {
+					return false, NewErrContractInvalid(fmt.Sprintf("invalid Interval frequency %s format", i.Frequency))
+				}
 			}
 		}
 		err := validate(i)

--- a/models/interval_test.go
+++ b/models/interval_test.go
@@ -35,16 +35,24 @@ func TestIntervalValidation(t *testing.T) {
 	invalidFrequency := testInterval
 	invalidFrequency.Frequency = "blah"
 
+	invalidNewFrequency := testInterval
+	invalidNewFrequency.Frequency = "10mzz"
+
+	validNewFrequency := testInterval
+	validNewFrequency.Frequency = "10h20m15s11us"
+
 	tests := []struct {
 		name        string
 		i           Interval
 		expectError bool
 	}{
-		{"valid interval", valid, false},
+		{"valid interval legacy frequency", valid, false},
+		{"valid interval", validNewFrequency, false},
 		{"invalid interval identifiers", invalidIdentifiers, true},
 		{"invalid interval start", invalidStart, true},
 		{"invalid interval end", invalidEnd, true},
 		{"invalid interval frequency", invalidFrequency, true},
+		{"invalid interval new frequency", invalidNewFrequency, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix #138

- Added support for Golang's subsecond patterns "30m10s1000ns"
- Includeds backward compatablity with legacy frequency pattern
- Marshalling/Unmarshalling code updated to reflect the bifurated pattern legacy or golang

Signed-off-by: xmlviking <ecotter@gmail.com>