### PR TITLE
 Expand CommandClient interface for Put/Get by Names 

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -26,10 +26,14 @@ import (
 
 // The CommandClient interface defines interactions with the EdgeX Core Command microservice.
 type CommandClient interface {
-	// Get issues a GET command targeting the specified device, using the specified command
+	// Get issues a GET command targeting the specified device, using the specified command id
 	Get(deviceId string, commandId string, ctx context.Context) (string, error)
-	// Put issues a PUT command targeting the specified device, using the specified command
+	// Put issues a PUT command targeting the specified device, using the specified command id
 	Put(deviceId string, commandId string, body string, ctx context.Context) (string, error)
+	// GetDeviceCommandByNames issues a GET command targeting the specified device, using the specified device and command name
+	GetDeviceCommandByNames(deviceName string, commandName string, ctx context.Context) (string, error)
+	// PutDeviceCommandByNames issues a PUT command targeting the specified device, using the specified device and command names
+	PutDeviceCommandByNames(deviceName string, commandName string, body string, ctx context.Context) (string, error)
 }
 
 type commandRestClient struct {
@@ -68,4 +72,13 @@ func (cc *commandRestClient) Get(deviceId string, commandId string, ctx context.
 
 func (cc *commandRestClient) Put(deviceId string, commandId string, body string, ctx context.Context) (string, error) {
 	return clients.PutRequest(cc.url+"/"+deviceId+"/command/"+commandId, []byte(body), ctx)
+}
+
+func (cc *commandRestClient) GetDeviceCommandByNames(deviceName string, commandName string, ctx context.Context) (string, error) {
+	body, err := clients.GetRequest(cc.url+"/name/"+deviceName+"/command/"+commandName, ctx)
+	return string(body), err
+}
+
+func (cc *commandRestClient) PutDeviceCommandByNames(deviceName string, commandName string, body string, ctx context.Context) (string, error) {
+	return clients.PutRequest(cc.url+"/name/"+deviceName+"/command/"+commandName, []byte(body), ctx)
 }

--- a/clients/command/client_test.go
+++ b/clients/command/client_test.go
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+)
+
+func TestGetDeviceCommandById(t *testing.T) {
+	ts := testHttpServer(t, http.MethodGet, clients.ApiDeviceRoute+"/device1/command/command1")
+
+	defer ts.Close()
+
+	url := ts.URL + clients.ApiDeviceRoute
+
+	params := types.EndpointParams{
+		ServiceKey:  clients.CoreCommandServiceKey,
+		Path:        clients.ApiDeviceRoute,
+		UseRegistry: false,
+		Url:         url,
+		Interval:    clients.ClientMonitorDefault,
+	}
+
+	cc := NewCommandClient(params, MockEndpoint{})
+
+	res, _ := cc.Get("device1", "command1", context.Background())
+
+	if res != "Ok" {
+		t.Errorf("expected response body \"Ok\", but received %s", res)
+	}
+}
+
+func TestPutDeviceCommandById(t *testing.T) {
+	ts := testHttpServer(t, http.MethodPut, clients.ApiDeviceRoute+"/device1/command/command1")
+
+	defer ts.Close()
+
+	url := ts.URL + clients.ApiDeviceRoute
+
+	params := types.EndpointParams{
+		ServiceKey:  clients.CoreCommandServiceKey,
+		Path:        clients.ApiDeviceRoute,
+		UseRegistry: false,
+		Url:         url,
+		Interval:    clients.ClientMonitorDefault,
+	}
+
+	cc := NewCommandClient(params, MockEndpoint{})
+
+	res, _ := cc.Put("device1", "command1", "body", context.Background())
+
+	if res != "Ok" {
+		t.Errorf("expected response body \"Ok\", but received %s", res)
+	}
+}
+
+func TestGetDeviceByName(t *testing.T) {
+	ts := testHttpServer(t, http.MethodGet, clients.ApiDeviceRoute+"/name/device1/command/command1")
+
+	defer ts.Close()
+
+	url := ts.URL + clients.ApiDeviceRoute
+
+	params := types.EndpointParams{
+		ServiceKey:  clients.CoreCommandServiceKey,
+		Path:        clients.ApiDeviceRoute,
+		UseRegistry: false,
+		Url:         url,
+		Interval:    clients.ClientMonitorDefault,
+	}
+
+	cc := NewCommandClient(params, MockEndpoint{})
+
+	res, _ := cc.GetDeviceCommandByNames("device1", "command1", context.Background())
+
+	if res != "Ok" {
+		t.Errorf("expected response body \"Ok\", but received %s", res)
+	}
+}
+
+func TestPutDeviceCommandByNames(t *testing.T) {
+	ts := testHttpServer(t, http.MethodPut, clients.ApiDeviceRoute+"/name/device1/command/command1")
+
+	defer ts.Close()
+
+	url := ts.URL + clients.ApiDeviceRoute
+
+	params := types.EndpointParams{
+		ServiceKey:  clients.CoreCommandServiceKey,
+		Path:        clients.ApiDeviceRoute,
+		UseRegistry: false,
+		Url:         url,
+		Interval:    clients.ClientMonitorDefault,
+	}
+
+	cc := NewCommandClient(params, MockEndpoint{})
+
+	res, _ := cc.PutDeviceCommandByNames("device1", "command1", "body", context.Background())
+
+	if res != "Ok" {
+		t.Errorf("expected response body \"Ok\", but received %s", res)
+	}
+}
+
+type MockEndpoint struct {
+}
+
+func (e MockEndpoint) Monitor(params types.EndpointParams, ch chan string) {
+	switch params.ServiceKey {
+	case clients.CoreCommandServiceKey:
+		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48082, params.Path)
+		ch <- url
+		break
+	default:
+		ch <- ""
+	}
+}
+
+// testHttpServer instantiates a test HTTP Server to be used for conveniently verifying a client's invocation
+func testHttpServer(t *testing.T, matchingRequestMethod string, matchingRequestUri string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method == matchingRequestMethod && r.RequestURI == matchingRequestUri {
+			w.Write([]byte("Ok"))
+		} else {
+			t.Errorf("expected endpoint %s to be invoked by client, %s invoked", matchingRequestUri, r.RequestURI)
+		}
+	}))
+}


### PR DESCRIPTION
Fix #141 

Expand CommandClient interface for Put/Get by Names

- Add GetDeviceCommandByNames method to Command client

- Add PutDeviceCommandByNames method to Command client

- Add unit tests for the client

Signed-off-by: Jason Bonafide <jbonafide623@gmail.com>