### PR TITLE
Add Endpointer.Fetch() method, integrate with Service Clients

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -50,6 +50,9 @@ func NewCommandClient(params types.EndpointParams, m clients.Endpointer) Command
 
 func (c *commandRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		c.url = c.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go c.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/command/client_test.go
+++ b/clients/command/client_test.go
@@ -135,6 +135,10 @@ func (e MockEndpoint) Monitor(params types.EndpointParams, ch chan string) {
 	}
 }
 
+func (e MockEndpoint) Fetch(params types.EndpointParams) string {
+	return fmt.Sprintf("http://%s:%v%s", "localhost", 48082, params.Path)
+}
+
 // testHttpServer instantiates a test HTTP Server to be used for conveniently verifying a client's invocation
 func testHttpServer(t *testing.T, matchingRequestMethod string, matchingRequestUri string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/clients/coredata/event.go
+++ b/clients/coredata/event.go
@@ -80,6 +80,9 @@ func NewEventClient(params types.EndpointParams, m clients.Endpointer) EventClie
 
 func (e *eventRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		e.url = e.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go e.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/coredata/event_test.go
+++ b/clients/coredata/event_test.go
@@ -66,7 +66,7 @@ func TestMarkPushed(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockEventEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{})
 
 	err := ec.MarkPushed(TestId, context.Background())
 
@@ -101,7 +101,7 @@ func TestMarkPushedByChecksum(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockEventEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{})
 
 	err := ec.MarkPushedByChecksum(TestChecksum, context.Background())
 
@@ -144,7 +144,7 @@ func TestGetEvents(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockEventEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{})
 
 	eArr, err := ec.Events(context.Background())
 	if err != nil {
@@ -175,7 +175,7 @@ func TestNewEventClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockEventEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{})
 
 	r, ok := ec.(*eventRestClient)
 	if !ok {
@@ -198,7 +198,7 @@ func TestMarshalEvent(t *testing.T) {
 	regularEvent := testEvent
 	regularEvent.Readings = append(regularEvent.Readings, testReading)
 
-	client := NewEventClient(types.EndpointParams{Url: "test"}, mockEventEndpoint{})
+	client := NewEventClient(types.EndpointParams{Url: "test"}, mockCoreDataEndpoint{})
 
 	tests := []struct {
 		name        string
@@ -236,10 +236,9 @@ func TestMarshalEvent(t *testing.T) {
 	}
 }
 
-type mockEventEndpoint struct {
-}
+type mockCoreDataEndpoint struct{}
 
-func (e mockEventEndpoint) Monitor(params types.EndpointParams, ch chan string) {
+func (e mockCoreDataEndpoint) Monitor(params types.EndpointParams, ch chan string) {
 	switch params.ServiceKey {
 	case clients.CoreDataServiceKey:
 		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
@@ -248,4 +247,8 @@ func (e mockEventEndpoint) Monitor(params types.EndpointParams, ch chan string) 
 	default:
 		ch <- ""
 	}
+}
+
+func (e mockCoreDataEndpoint) Fetch(params types.EndpointParams) string {
+	return fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
 }

--- a/clients/coredata/reading.go
+++ b/clients/coredata/reading.go
@@ -70,6 +70,9 @@ func NewReadingClient(params types.EndpointParams, m clients.Endpointer) Reading
 
 func (r *readingRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		r.url = r.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go r.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/coredata/reading_test.go
+++ b/clients/coredata/reading_test.go
@@ -19,7 +19,6 @@ package coredata
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,7 +77,7 @@ func TestGetReadings(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	rc := NewReadingClient(params, mockReadingEndpoint{})
+	rc := NewReadingClient(params, mockCoreDataEndpoint{})
 
 	rArr, err := rc.Readings(context.Background())
 	if err != nil {
@@ -110,7 +109,7 @@ func TestNewReadingClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	rc := NewReadingClient(params, mockReadingEndpoint{})
+	rc := NewReadingClient(params, mockCoreDataEndpoint{})
 
 	r, ok := rc.(*readingRestClient)
 	if !ok {
@@ -122,19 +121,5 @@ func TestNewReadingClientWithConsul(t *testing.T) {
 		t.Error("url was not initialized")
 	} else if r.url != deviceUrl {
 		t.Errorf("unexpected url value %s", r.url)
-	}
-}
-
-type mockReadingEndpoint struct {
-}
-
-func (r mockReadingEndpoint) Monitor(params types.EndpointParams, ch chan string) {
-	switch params.ServiceKey {
-	case clients.CoreDataServiceKey:
-		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
-		ch <- url
-		break
-	default:
-		ch <- ""
 	}
 }

--- a/clients/coredata/value_descriptor.go
+++ b/clients/coredata/value_descriptor.go
@@ -67,6 +67,9 @@ func NewValueDescriptorClient(params types.EndpointParams, m clients.Endpointer)
 
 func (d *valueDescriptorRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		d.url = d.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/coredata/value_descriptor_test.go
+++ b/clients/coredata/value_descriptor_test.go
@@ -17,7 +17,6 @@ package coredata
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -82,7 +81,7 @@ func TestGetvaluedescriptors(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
 
 	vdArr, err := vdc.ValueDescriptors(context.Background())
 	if err != nil {
@@ -135,7 +134,7 @@ func TestValueDescriptorUsage(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
 	usage, err := vdc.ValueDescriptorsUsage([]string{testValueDesciptorDescription1, testValueDesciptorDescription2}, context.Background())
 	if err != nil {
 		t.Errorf(err.Error())
@@ -162,7 +161,7 @@ func TestValueDescriptorUsageSerializationError(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
 	_, err := vdc.ValueDescriptorsUsage([]string{testValueDesciptorDescription1, testValueDesciptorDescription2}, context.Background())
 	if err == nil {
 		t.Error("Expected an error")
@@ -178,7 +177,7 @@ func TestValueDescriptorUsageGetRequestError(t *testing.T) {
 		Url:         "!@#",
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
 	_, err := vdc.ValueDescriptorsUsage([]string{testValueDesciptorDescription1, testValueDesciptorDescription2}, context.Background())
 	if err == nil {
 		t.Error("Expected an error")
@@ -195,7 +194,7 @@ func TestNewValueDescriptorClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
 
 	r, ok := vdc.(*valueDescriptorRestClient)
 	if !ok {
@@ -207,19 +206,5 @@ func TestNewValueDescriptorClientWithConsul(t *testing.T) {
 		t.Error("url was not initialized")
 	} else if r.url != deviceUrl {
 		t.Errorf("unexpected url value %s", r.url)
-	}
-}
-
-type mockEndpoint struct {
-}
-
-func (e mockEndpoint) Monitor(params types.EndpointParams, ch chan string) {
-	switch params.ServiceKey {
-	case clients.CoreDataServiceKey:
-		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
-		ch <- url
-		break
-	default:
-		ch <- ""
 	}
 }

--- a/clients/endpointer.go
+++ b/clients/endpointer.go
@@ -19,9 +19,10 @@ import "github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 //Endpointer is the interface for types that need to implement or simulate integration
 //with a service discovery provider.
 type Endpointer interface {
-	//Monitor is responsible for looking up information about the service endpoint corresponding
-	//to the params.ServiceKey property. The name "Monitor" implies that this lookup will be done
-	//at a regular interval. Information about the service from the discovery provider should be
-	//used to construct a URL which will then be pushed to the supplied channel.
+	//Fetch will return a string containing the URL for a service endpoint corresponding to the params.ServiceKey property.
+	Fetch(params types.EndpointParams) string
+	//Monitor is responsible for refreshing information about the service endpoint corresponding
+	//to the params.ServiceKey property on a set interval. Information about the service from the
+	//discovery provider should be used to construct a URL which will then be pushed to the supplied channel.
 	Monitor(params types.EndpointParams, ch chan string)
 }

--- a/clients/export/distro/client.go
+++ b/clients/export/distro/client.go
@@ -45,6 +45,9 @@ func NewDistroClient(params types.EndpointParams, m clients.Endpointer) DistroCl
 
 func (d *distroRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		d.url = d.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/general/client.go
+++ b/clients/general/client.go
@@ -46,6 +46,9 @@ func NewGeneralClient(params types.EndpointParams, m clients.Endpointer) General
 
 func (gc *generalRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		gc.url = gc.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go gc.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/general/client_test.go
+++ b/clients/general/client_test.go
@@ -17,6 +17,7 @@ package general
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,6 +34,10 @@ type mockGeneralEndpoint struct {
 }
 
 func (e mockGeneralEndpoint) Monitor(params types.EndpointParams, ch chan string) {
+}
+
+func (e mockGeneralEndpoint) Fetch(params types.EndpointParams) string {
+	return fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
 }
 
 func TestGetConfig(t *testing.T) {

--- a/clients/metadata/addressable.go
+++ b/clients/metadata/addressable.go
@@ -57,6 +57,9 @@ func NewAddressableClient(params types.EndpointParams, m clients.Endpointer) Add
 
 func (a *addressableRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		a.url = a.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go a.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/metadata/addressable_test.go
+++ b/clients/metadata/addressable_test.go
@@ -37,7 +37,7 @@ func TestNewAddressableClientWithConsul(t *testing.T) {
 		Url:         addressableURL,
 		Interval:    clients.ClientMonitorDefault}
 
-	ac := NewAddressableClient(params, MockEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
 
 	r, ok := ac.(*addressableRestClient)
 	if !ok {
@@ -86,7 +86,7 @@ func TestAddAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, MockEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
 
 	receivedAddressableID, err := ac.Add(&addressable, context.Background())
 	if err != nil {
@@ -131,7 +131,7 @@ func TestGetAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, MockEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
 
 	receivedAddressable, err := ac.Addressable(addressable.Id, context.Background())
 	if err != nil {
@@ -176,7 +176,7 @@ func TestGetAddressableForName(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, MockEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
 
 	receivedAddressable, err := ac.AddressableForName(addressable.Name, context.Background())
 	if err != nil {
@@ -218,7 +218,7 @@ func TestUpdateAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, MockEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
 
 	err := ac.Update(addressable, context.Background())
 	if err != nil {
@@ -257,7 +257,7 @@ func TestDeleteAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, MockEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
 
 	err := ac.Delete(addressable.Id, context.Background())
 	if err != nil {

--- a/clients/metadata/command.go
+++ b/clients/metadata/command.go
@@ -57,6 +57,9 @@ func NewCommandClient(params types.EndpointParams, m clients.Endpointer) Command
 
 func (c *commandRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		c.url = c.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go c.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/metadata/command_test.go
+++ b/clients/metadata/command_test.go
@@ -31,7 +31,7 @@ func TestNewCommandClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	cc := NewCommandClient(params, MockEndpoint{})
+	cc := NewCommandClient(params, mockCoreMetaDataEndpoint{})
 
 	r, ok := cc.(*commandRestClient)
 	if !ok {

--- a/clients/metadata/device.go
+++ b/clients/metadata/device.go
@@ -87,6 +87,9 @@ func NewDeviceClient(params types.EndpointParams, m clients.Endpointer) DeviceCl
 
 func (d *deviceRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		d.url = d.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/metadata/device_profile.go
+++ b/clients/metadata/device_profile.go
@@ -63,6 +63,9 @@ func NewDeviceProfileClient(params types.EndpointParams, m clients.Endpointer) D
 
 func (d *deviceProfileRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		d.url = d.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/metadata/device_profile_test.go
+++ b/clients/metadata/device_profile_test.go
@@ -57,7 +57,7 @@ func TestUpdateDeviceProfile(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	dpc := NewDeviceProfileClient(params, MockEndpoint{})
+	dpc := NewDeviceProfileClient(params, mockCoreMetaDataEndpoint{})
 
 	err := dpc.Update(p, context.Background())
 	if err != nil {

--- a/clients/metadata/device_service.go
+++ b/clients/metadata/device_service.go
@@ -53,6 +53,9 @@ func NewDeviceServiceClient(params types.EndpointParams, m clients.Endpointer) D
 
 func (d *deviceServiceRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		d.url = d.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/metadata/device_service_test.go
+++ b/clients/metadata/device_service_test.go
@@ -31,7 +31,7 @@ func TestNewDeviceServiceClientWithConsul(t *testing.T) {
 		Url:         deviceServiceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	dsc := NewDeviceServiceClient(params, MockEndpoint{})
+	dsc := NewDeviceServiceClient(params, mockCoreMetaDataEndpoint{})
 	r, ok := dsc.(*deviceServiceRestClient)
 	if !ok {
 		t.Error("dsc is not of expected type")

--- a/clients/metadata/device_test.go
+++ b/clients/metadata/device_test.go
@@ -68,7 +68,7 @@ func TestAddDevice(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	dc := NewDeviceClient(params, MockEndpoint{})
+	dc := NewDeviceClient(params, mockCoreMetaDataEndpoint{})
 
 	receivedDeviceId, err := dc.Add(&d, context.Background())
 	if err != nil {
@@ -89,7 +89,7 @@ func TestNewDeviceClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	dc := NewDeviceClient(params, MockEndpoint{})
+	dc := NewDeviceClient(params, mockCoreMetaDataEndpoint{})
 
 	r, ok := dc.(*deviceRestClient)
 	if !ok {
@@ -104,10 +104,9 @@ func TestNewDeviceClientWithConsul(t *testing.T) {
 	}
 }
 
-type MockEndpoint struct {
-}
+type mockCoreMetaDataEndpoint struct{}
 
-func (e MockEndpoint) Monitor(params types.EndpointParams, ch chan string) {
+func (e mockCoreMetaDataEndpoint) Monitor(params types.EndpointParams, ch chan string) {
 	switch params.ServiceKey {
 	case clients.CoreMetaDataServiceKey:
 		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48081, params.Path)
@@ -116,4 +115,8 @@ func (e MockEndpoint) Monitor(params types.EndpointParams, ch chan string) {
 	default:
 		ch <- ""
 	}
+}
+
+func (e mockCoreMetaDataEndpoint) Fetch(params types.EndpointParams) string {
+	return fmt.Sprintf("http://%s:%v%s", "localhost", 48081, params.Path)
 }

--- a/clients/metadata/provision_watcher.go
+++ b/clients/metadata/provision_watcher.go
@@ -65,6 +65,9 @@ func NewProvisionWatcherClient(params types.EndpointParams, m clients.Endpointer
 
 func (pw *provisionWatcherRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		pw.url = pw.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go pw.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/metadata/provision_watcher_test.go
+++ b/clients/metadata/provision_watcher_test.go
@@ -64,7 +64,7 @@ func TestAddProvisionWatcher(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	sc := NewProvisionWatcherClient(params, MockEndpoint{})
+	sc := NewProvisionWatcherClient(params, mockCoreMetaDataEndpoint{})
 
 	receivedProvisionWatcherID, err := sc.Add(&se, context.Background())
 	if err != nil {
@@ -85,7 +85,7 @@ func TestNewProvisionWatcherClientWithConsul(t *testing.T) {
 		Url:         provisionWatcherURL,
 		Interval:    clients.ClientMonitorDefault}
 
-	sc := NewProvisionWatcherClient(params, MockEndpoint{})
+	sc := NewProvisionWatcherClient(params, mockCoreMetaDataEndpoint{})
 
 	r, ok := sc.(*provisionWatcherRestClient)
 	if !ok {

--- a/clients/notifications/client.go
+++ b/clients/notifications/client.go
@@ -85,6 +85,9 @@ func NewNotificationsClient(params types.EndpointParams, m clients.Endpointer) N
 
 func (n *notificationsRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		n.url = n.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go n.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/notifications/client_test.go
+++ b/clients/notifications/client_test.go
@@ -9,6 +9,7 @@ package notifications
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -130,4 +131,8 @@ func (e mockNotificationEndpoint) Monitor(params types.EndpointParams, ch chan s
 	default:
 		ch <- ""
 	}
+}
+
+func (e mockNotificationEndpoint) Fetch(params types.EndpointParams) string {
+	return fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
 }

--- a/clients/scheduler/interval.go
+++ b/clients/scheduler/interval.go
@@ -60,6 +60,9 @@ func NewIntervalClient(params types.EndpointParams, m clients.Endpointer) Interv
 
 func (s *intervalRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		s.url = s.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go s.endpoint.Monitor(params, ch)
 		go func(ch chan string) {

--- a/clients/scheduler/interval_action.go
+++ b/clients/scheduler/interval_action.go
@@ -59,6 +59,9 @@ func NewIntervalActionClient(params types.EndpointParams, m clients.Endpointer) 
 
 func (s *intervalActionRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
+		//Fetch URL in real time for immediate use
+		s.url = s.endpoint.Fetch(params)
+		//Set up refresh interval to keep URL current
 		ch := make(chan string, 1)
 		go s.endpoint.Monitor(params, ch)
 		go func(ch chan string) {


### PR DESCRIPTION
Fix #150

* Added Fetch method signature to Endpointer interface. This will allow
  the immediate retrieval of a service's URL prior to initiating the
  monitor goroutine
* The original ask was to facilitate the immediate population of the
  GeneralClient's URL. However, given that this is a one line change,
  there's no reason to not do the same for the other clients. In this
  way an initial call to obtain a service endpoint will be made to the
  registry when that communication is enabled.
* Updating unit test mocks with Endpointer.Fetch method

Signed-off-by: Trevor Conn <trevor_conn@dell.com>