### PR TITLE
Remove the field ExpectedValues (from SetConfigResponse) as it is redundant.

### DIFF
--- a/responses/configuration/set.go
+++ b/responses/configuration/set.go
@@ -8,27 +8,21 @@ import (
 
 //SetConfigResponse is for SMA to use when responding to an incoming request to PUT (i.e. UPDATE) a resource.
 type SetConfigResponse struct {
-	Code           string   `json:"code" yaml:"code,omitempty"`                     //HTTP code to return (e.g. 200, 500, etc.)
-	Description    string   `json:"description" yaml:"description,omitempty"`       //info allied with preceding HTTP code
-	ExpectedValues []string `json:"expectedValues" yaml:"expectedValues,omitempty"` //expected values to return
-	isValidated    bool     //internal member used for validation check
+	Success     bool   `json:"success"`               // Success or failure of request itself.
+	Description string `json:"description,omitempty"` // Info allied with the preceding result.
+	isValidated bool   // internal member used for validation check
 }
 
 // Custom marshalling to make empty strings null
 func (sc SetConfigResponse) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Code           *string  `json:"code,omitempty"`
-		Description    *string  `json:"description,omitempty"`
-		ExpectedValues []string `json:"expectedValues,omitempty"`
-		isValidated    bool
-	}{
-		ExpectedValues: sc.ExpectedValues,
-	}
+		Success     bool    `json:"success"`
+		Description *string `json:"description,omitempty"`
+		isValidated bool
+	}{}
 
-	// Empty strings are null
-	if sc.Code != "" {
-		test.Code = &sc.Code
-	}
+	test.Success = sc.Success
+
 	if sc.Description != "" {
 		test.Description = &sc.Description
 	}
@@ -49,9 +43,8 @@ func (sc SetConfigResponse) String() string {
 func (sc *SetConfigResponse) UnmarshalJSON(data []byte) error {
 	var err error
 	test := struct {
-		Code           *string  `json:"code,omitempty"`
-		Description    *string  `json:"description,omitempty"`
-		ExpectedValues []string `json:"expectedValues,omitempty"`
+		Success     bool    `json:"success"`
+		Description *string `json:"description,omitempty"`
 	}{}
 
 	//Verify that incoming string will unmarshal successfully
@@ -59,17 +52,10 @@ func (sc *SetConfigResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	//If verified, copy the fields
-	if test.Code != nil {
-		sc.Code = *test.Code
-	}
+	sc.Success = test.Success
 
 	if test.Description != nil {
 		sc.Description = *test.Description
-	}
-
-	if test.ExpectedValues != nil {
-		sc.ExpectedValues = test.ExpectedValues
 	}
 
 	sc.isValidated, err = sc.Validate()
@@ -79,14 +65,8 @@ func (sc *SetConfigResponse) UnmarshalJSON(data []byte) error {
 
 // Validate satisfies the Validator interface
 func (sc SetConfigResponse) Validate() (bool, error) {
-	if sc.Code == "" {
-		return false, models.NewErrContractInvalid(fmt.Sprintf("invalid Code %s", sc.Code))
-	}
 	if sc.Description == "" {
 		return false, models.NewErrContractInvalid(fmt.Sprintf("invalid Description %s", sc.Description))
-	}
-	if sc.ExpectedValues == nil {
-		return false, models.NewErrContractInvalid(fmt.Sprintf("invalid ExpectedValues %v", sc.ExpectedValues))
 	}
 	return true, nil
 }

--- a/responses/configuration/set_test.go
+++ b/responses/configuration/set_test.go
@@ -11,11 +11,10 @@ func TestGetValidation(t *testing.T) {
 		up          SetConfigResponse
 		expectError bool
 	}{
-		{"valid   - all parameters (Code, Description,ExpectedValues) proper", SetConfigResponse{Code: "Logging.EnableRemote", Description: "true", ExpectedValues: []string{"abc", "def"}}, false},
-		{"invalid - no parameter (Code, Description,ExpectedValues) proper", SetConfigResponse{Code: "", Description: "", ExpectedValues: nil}, true},
-		{"invalid - some parameters (Code, Description) proper, others not proper", SetConfigResponse{Code: "Logging.EnableRemote", Description: "false", ExpectedValues: nil}, true},
-		{"invalid - some parameters (Code, ExpectedValues) proper, others not proper", SetConfigResponse{Code: "Logging.EnableRemote", Description: "", ExpectedValues: []string{"abc", "def"}}, true},
-		{"invalid - some parameters (Description,ExpectedValues) proper, others not proper", SetConfigResponse{Code: "", Description: "true", ExpectedValues: []string{"abc", "def"}}, true},
+		{"valid   - all parameters (Success, Description) proper", SetConfigResponse{Success: true, Description: "Success"}, false},
+		{"valid   - all parameters (Success, Description) proper", SetConfigResponse{Success: false, Description: "Success"}, false},
+		{"invalid - one parameter (Success) proper, other not proper", SetConfigResponse{Success: true, Description: ""}, true},
+		{"invalid - one parameter (Success) proper, other not proper", SetConfigResponse{Success: false, Description: ""}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix #152 
- This is a follow up to #128 (External Entity Requests SMA to Set Configuration).