### PR TITLE
Update models to serialize zero values as empty JSON objects, part 2

### DIFF
--- a/models/autoevent_test.go
+++ b/models/autoevent_test.go
@@ -24,8 +24,6 @@ var TestAutoEvent = AutoEvent{Resource: "TestDevice", Frequency: "300ms", OnChan
 
 func TestAutoEvent_MarshalJSON(t *testing.T) {
 	empty := AutoEvent{}
-	resultTestBytes := []byte(TestAutoEvent.String())
-	resultEmptyTestBytes := []byte(empty.String())
 
 	tests := []struct {
 		name    string
@@ -33,8 +31,7 @@ func TestAutoEvent_MarshalJSON(t *testing.T) {
 		want    []byte
 		wantErr bool
 	}{
-		{"successful marshal", TestAutoEvent, resultTestBytes, false},
-		{"successful empty marshal", empty, resultEmptyTestBytes, false},
+		{"successful empty marshal", empty, []byte(testEmptyJSON), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -44,7 +41,7 @@ func TestAutoEvent_MarshalJSON(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DeviceService.MarshalJSON() = %v, want %v", got, tt.want)
+				t.Errorf("DeviceService.MarshalJSON() = %v, want %v", string(got), string(tt.want))
 			}
 		})
 	}

--- a/models/callbackalert.go
+++ b/models/callbackalert.go
@@ -20,21 +20,17 @@ import (
 
 // CallbackAlert indicates an action to take when a callback fires.
 type CallbackAlert struct {
-	ActionType ActionType `json:"type"`
-	Id         string     `json:"id"`
+	ActionType ActionType `json:"type,omitempty"`
+	Id         string     `json:"id,omitempty"`
 }
 
-// Custom JSON marshaling to turn empty strings into null pointers
 func (ca CallbackAlert) MarshalJSON() ([]byte, error) {
 	test := struct {
-		ActionType ActionType `json:"type"`
-		Id         *string    `json:"id"`
+		ActionType ActionType `json:"type,omitempty"`
+		Id         string     `json:"id,omitempty"`
 	}{
 		ActionType: ca.ActionType,
-	}
-
-	if ca.Id != "" {
-		test.Id = &ca.Id
+		Id: ca.Id,
 	}
 
 	return json.Marshal(test)

--- a/models/callbackalert.go
+++ b/models/callbackalert.go
@@ -24,18 +24,6 @@ type CallbackAlert struct {
 	Id         string     `json:"id,omitempty"`
 }
 
-func (ca CallbackAlert) MarshalJSON() ([]byte, error) {
-	test := struct {
-		ActionType ActionType `json:"type,omitempty"`
-		Id         string     `json:"id,omitempty"`
-	}{
-		ActionType: ca.ActionType,
-		Id:         ca.Id,
-	}
-
-	return json.Marshal(test)
-}
-
 /*
  * String function for representing a CallbackAlert
  */

--- a/models/callbackalert.go
+++ b/models/callbackalert.go
@@ -30,7 +30,7 @@ func (ca CallbackAlert) MarshalJSON() ([]byte, error) {
 		Id         string     `json:"id,omitempty"`
 	}{
 		ActionType: ca.ActionType,
-		Id: ca.Id,
+		Id:         ca.Id,
 	}
 
 	return json.Marshal(test)

--- a/models/callbackalert_test.go
+++ b/models/callbackalert_test.go
@@ -15,34 +15,33 @@
 package models
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
 
 var TestCallbackAlert = CallbackAlert{"DEVICE", "1234"}
+var TestEmptyCallbackAlert = CallbackAlert{}
 
 func TestCallbackAlert_MarshalJSON(t *testing.T) {
-	var testNoIDCallbackAlert = CallbackAlert{"DEVICE", ""}
-	var testCallbackAlertBytes = []byte(TestCallbackAlert.String())
-	var testNoIDCallbackAlertBytes = []byte(testNoIDCallbackAlert.String())
 	tests := []struct {
 		name    string
-		ca      CallbackAlert
+		ca      interface{}
 		want    []byte
 		wantErr bool
 	}{
-		{"successful marshal of callback", TestCallbackAlert, testCallbackAlertBytes, false},
-		{"successful marshal of no id callback", testNoIDCallbackAlert, testNoIDCallbackAlertBytes, false},
+		{"successful marshal of empty callback", TestEmptyCallbackAlert, []byte(testEmptyJSON), false},
+		{"unsuccessful marshal", make(chan int), nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.ca.MarshalJSON()
+			got, err := json.Marshal(tt.ca)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CallbackAlert.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CallbackAlert.MarshalJSON() = %v, want %v", got, tt.want)
+				t.Errorf("CallbackAlert.MarshalJSON() = %v, want %v", string(got), string(tt.want))
 			}
 		})
 	}
@@ -54,7 +53,8 @@ func TestCallbackAlert_String(t *testing.T) {
 		ca   CallbackAlert
 		want string
 	}{
-		{"callback alert to string", TestCallbackAlert, "{\"type\":\"DEVICE\",\"id\":\"1234\"}"},
+		{"successful callback alert to string", TestCallbackAlert, "{\"type\":\"DEVICE\",\"id\":\"1234\"}"},
+		{"successful empty callback alert to string", TestEmptyCallbackAlert, testEmptyJSON},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/channel_test.go
+++ b/models/channel_test.go
@@ -24,7 +24,6 @@ var TestRChannel = Channel{Type: ChannelType(Rest), Url: "http://www.someendpoin
 var TestEmptyChannel = Channel{}
 
 func TestChannel_String(t *testing.T) {
-
 	tests := []struct {
 		name string
 		c    *Channel
@@ -32,7 +31,7 @@ func TestChannel_String(t *testing.T) {
 	}{
 		{"email channel to string", &TestEChannel, "{\"type\":\"EMAIL\",\"mailAddresses\":[\"jpwhite_mn@yahoo.com\",\"james_white2@dell.com\"]}"},
 		{"rest channel to string ", &TestRChannel, "{\"type\":\"REST\",\"url\":\"http://www.someendpoint.com/notifications\"}"},
-		{"empty channel to string", &TestEmptyChannel, "{}"},
+		{"empty channel to string", &TestEmptyChannel, testEmptyJSON},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/comandresponse_test.go
+++ b/models/comandresponse_test.go
@@ -15,30 +15,23 @@
 package models
 
 import (
-	"strconv"
 	"testing"
 )
 
-var TestDescribedObject = DescribedObject{Timestamps: testTimestamps, Description: testDescription}
-var TestEmptyDescribedObject = DescribedObject{}
+var TestCommandResponseEmpty = CommandResponse{}
 
-func TestDescribedObject_String(t *testing.T) {
+func TestCommandResponse_String(t *testing.T) {
 	tests := []struct {
 		name string
-		o    DescribedObject
+		o    CommandResponse
 		want string
 	}{
-		{"described object to string", TestDescribedObject,
-			"{\"created\":" + strconv.FormatInt(TestDescribedObject.Created, 10) +
-				",\"modified\":" + strconv.FormatInt(TestDescribedObject.Modified, 10) +
-				",\"origin\":" + strconv.FormatInt(TestDescribedObject.Origin, 10) +
-				",\"description\":\"" + testDescription + "\"}"},
-		{"empty described object to string", TestEmptyDescribedObject, testEmptyJSON},
+		{"empty described object to string", TestCommandResponseEmpty, testEmptyJSON},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.o.String(); got != tt.want {
-				t.Errorf("DescribedObject.String() = %v, want %v", got, tt.want)
+				t.Errorf("CommandResponse.String() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/models/command.go
+++ b/models/command.go
@@ -33,23 +33,16 @@ type Command struct {
 func (c Command) MarshalJSON() ([]byte, error) {
 	test := struct {
 		Timestamps
-		Id   *string `json:"id,omitempty"`
-		Name *string `json:"name,omitempty"` // Command name (unique on the profile)
-		Get  *Get    `json:"get,omitempty"`  // Get Command
-		Put  *Put    `json:"put,omitempty"`  // Put Command
+		Id   string `json:"id,omitempty"`
+		Name string `json:"name,omitempty"` // Command name (unique on the profile)
+		Get  *Get   `json:"get,omitempty"`  // Get Command
+		Put  *Put   `json:"put,omitempty"`  // Put Command
 	}{
 		Timestamps: c.Timestamps,
+		Id:         c.Id,
+		Name:       c.Name,
 		Get:        &c.Get,
 		Put:        &c.Put,
-	}
-
-	if c.Id != "" {
-		test.Id = &c.Id
-	}
-
-	// Make empty strings null
-	if c.Name != "" {
-		test.Name = &c.Name
 	}
 
 	// Make empty structs nil pointers so they aren't marshaled

--- a/models/command_test.go
+++ b/models/command_test.go
@@ -47,7 +47,7 @@ func TestCommand_MarshalJSON(t *testing.T) {
 
 			want := []byte(tt.c.String())
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("Command.MarshalJSON() = %v, want %v", got, want)
+				t.Errorf("Command.MarshalJSON() = %v, want %v", string(got), string(want))
 			}
 		})
 	}

--- a/models/commandresponse.go
+++ b/models/commandresponse.go
@@ -23,42 +23,15 @@ import (
 
 // CommandResponse identifies a specific device along with its supported commands.
 type CommandResponse struct {
-	Id             string         `json:"id"`             // Id uniquely identifies the CommandResponse, UUID for example.
-	Name           string         `json:"name"`           // Unique name for identifying a device
-	AdminState     AdminState     `json:"adminState"`     // Admin state (locked/unlocked)
-	OperatingState OperatingState `json:"operatingState"` // Operating state (enabled/disabled)
-	LastConnected  int64          `json:"lastConnected"`  // Time (milliseconds) that the device last provided any feedback or responded to any request
-	LastReported   int64          `json:"lastReported"`   // Time (milliseconds) that the device reported data to the core microservice
-	Labels         []string       `json:"labels"`         // Other labels applied to the device to help with searching
-	Location       interface{}    `json:"location"`       // Device service specific location (interface{} is an empty interface so it can be anything)
-	Commands       []Command      `json:"commands"`       // Associated Device Profile - Describes the device
-}
-
-// MarshalJSON implements the Marshaler interface for custom marshaling to make empty strings null
-func (cr CommandResponse) MarshalJSON() ([]byte, error) {
-	res := struct {
-		Id             string         `json:"id,omitempty"`
-		Name           string         `json:"name,omitempty"`
-		AdminState     AdminState     `json:"adminState,omitempty"`
-		OperatingState OperatingState `json:"operatingState,omitempty"`
-		LastConnected  int64          `json:"lastConnected,omitempty"`
-		LastReported   int64          `json:"lastReported,omitempty"`
-		Labels         []string       `json:"labels,omitempty"`
-		Location       interface{}    `json:"location,omitempty"`
-		Commands       []Command      `json:"commands,omitempty"`
-	}{
-		Id:             cr.Id,
-		Name:           cr.Name,
-		AdminState:     cr.AdminState,
-		OperatingState: cr.OperatingState,
-		LastConnected:  cr.LastConnected,
-		LastReported:   cr.LastReported,
-		Labels:         cr.Labels,
-		Location:       cr.Location,
-		Commands:       cr.Commands,
-	}
-
-	return json.Marshal(res)
+	Id             string         `json:"id,omitempty"`             // Id uniquely identifies the CommandResponse, UUID for example.
+	Name           string         `json:"name,omitempty"`           // Unique name for identifying a device
+	AdminState     AdminState     `json:"adminState,omitempty"`     // Admin state (locked/unlocked)
+	OperatingState OperatingState `json:"operatingState,omitempty"` // Operating state (enabled/disabled)
+	LastConnected  int64          `json:"lastConnected,omitempty"`  // Time (milliseconds) that the device last provided any feedback or responded to any request
+	LastReported   int64          `json:"lastReported,omitempty"`   // Time (milliseconds) that the device reported data to the core microservice
+	Labels         []string       `json:"labels,omitempty"`         // Other labels applied to the device to help with searching
+	Location       interface{}    `json:"location,omitempty"`       // Device service specific location (interface{} is an empty interface so it can be anything)
+	Commands       []Command      `json:"commands,omitempty"`       // Associated Device Profile - Describes the device
 }
 
 /*

--- a/models/commandresponse.go
+++ b/models/commandresponse.go
@@ -37,16 +37,18 @@ type CommandResponse struct {
 // MarshalJSON implements the Marshaler interface for custom marshaling to make empty strings null
 func (cr CommandResponse) MarshalJSON() ([]byte, error) {
 	res := struct {
-		Id             *string        `json:"id"`
-		Name           *string        `json:"name"`
-		AdminState     AdminState     `json:"adminState"`
-		OperatingState OperatingState `json:"operatingState"`
-		LastConnected  int64          `json:"lastConnected"`
-		LastReported   int64          `json:"lastReported"`
-		Labels         []string       `json:"labels"`
-		Location       interface{}    `json:"location"`
-		Commands       []Command      `json:"commands"`
+		Id             string         `json:"id,omitempty"`
+		Name           string         `json:"name,omitempty"`
+		AdminState     AdminState     `json:"adminState,omitempty"`
+		OperatingState OperatingState `json:"operatingState,omitempty"`
+		LastConnected  int64          `json:"lastConnected,omitempty"`
+		LastReported   int64          `json:"lastReported,omitempty"`
+		Labels         []string       `json:"labels,omitempty"`
+		Location       interface{}    `json:"location,omitempty"`
+		Commands       []Command      `json:"commands,omitempty"`
 	}{
+		Id:             cr.Id,
+		Name:           cr.Name,
 		AdminState:     cr.AdminState,
 		OperatingState: cr.OperatingState,
 		LastConnected:  cr.LastConnected,
@@ -54,15 +56,6 @@ func (cr CommandResponse) MarshalJSON() ([]byte, error) {
 		Labels:         cr.Labels,
 		Location:       cr.Location,
 		Commands:       cr.Commands,
-	}
-
-	if cr.Id != "" {
-		res.Id = &cr.Id
-	}
-
-	// Empty strings are null
-	if cr.Name != "" {
-		res.Name = &cr.Name
 	}
 
 	return json.Marshal(res)

--- a/models/describedobject.go
+++ b/models/describedobject.go
@@ -21,12 +21,10 @@ import "encoding/json"
 // eliminated and the Description property moved to the relevant types. 4 types currently use this.
 type DescribedObject struct {
 	Timestamps  `yaml:",inline"`
-	Description string `json:"description" yaml:"description,omitempty"` // Description. Capicé?
+	Description string `json:"description,omitempty" yaml:"description,omitempty"` // Description. Capicé?
 }
 
-/*
- * String function for DescribedObject
- */
+// String returns a JSON formatted string representation of this DescribedObject
 func (o DescribedObject) String() string {
 	out, err := json.Marshal(o)
 	if err != nil {

--- a/models/device.go
+++ b/models/device.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"encoding/json"
+	"reflect"
 )
 
 // Device represents a registered device participating within the EdgeX Foundry ecosystem
@@ -43,8 +44,8 @@ type ProtocolProperties map[string]string
 func (d Device) MarshalJSON() ([]byte, error) {
 	test := struct {
 		DescribedObject
-		Id             *string                       `json:"id,omitempty"`
-		Name           *string                       `json:"name,omitempty"`
+		Id             string                        `json:"id,omitempty"`
+		Name           string                        `json:"name,omitempty"`
 		AdminState     AdminState                    `json:"adminState,omitempty"`
 		OperatingState OperatingState                `json:"operatingState,omitempty"`
 		Protocols      map[string]ProtocolProperties `json:"protocols,omitempty"`
@@ -52,10 +53,12 @@ func (d Device) MarshalJSON() ([]byte, error) {
 		LastReported   int64                         `json:"lastReported,omitempty"`
 		Labels         []string                      `json:"labels,omitempty"`
 		Location       interface{}                   `json:"location,omitempty"`
-		Service        DeviceService                 `json:"service,omitempty"`
-		Profile        DeviceProfile                 `json:"profile,omitempty"`
+		Service        *DeviceService                `json:"service,omitempty"`
+		Profile        *DeviceProfile                `json:"profile,omitempty"`
 		AutoEvents     []AutoEvent                   `json:"autoEvents,omitempty"`
 	}{
+		Id:              d.Id,
+		Name:            d.Name,
 		DescribedObject: d.DescribedObject,
 		AdminState:      d.AdminState,
 		OperatingState:  d.OperatingState,
@@ -64,18 +67,17 @@ func (d Device) MarshalJSON() ([]byte, error) {
 		LastReported:    d.LastReported,
 		Labels:          d.Labels,
 		Location:        d.Location,
-		Service:         d.Service,
-		Profile:         d.Profile,
+		Service:         &d.Service,
+		Profile:         &d.Profile,
 		AutoEvents:      d.AutoEvents,
 	}
 
-	if d.Id != "" {
-		test.Id = &d.Id
+	if reflect.DeepEqual(*test.Service, DeviceService{}) {
+		test.Service = nil
 	}
 
-	// Empty strings are null
-	if d.Name != "" {
-		test.Name = &d.Name
+	if reflect.DeepEqual(*test.Profile, DeviceProfile{}) {
+		test.Profile = nil
 	}
 
 	return json.Marshal(test)
@@ -86,8 +88,8 @@ func (d *Device) UnmarshalJSON(data []byte) error {
 	var err error
 	type Alias struct {
 		DescribedObject `json:",inline"`
-		Id              *string                       `json:"id"`
-		Name            *string                       `json:"name"`
+		Id              string                        `json:"id"`
+		Name            string                        `json:"name"`
 		AdminState      AdminState                    `json:"adminState"`
 		OperatingState  OperatingState                `json:"operatingState"`
 		Protocols       map[string]ProtocolProperties `json:"protocols"`
@@ -105,13 +107,8 @@ func (d *Device) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Check nil fields
-	if a.Id != nil {
-		d.Id = *a.Id
-	}
-	if a.Name != nil {
-		d.Name = *a.Name
-	}
+	d.Id = a.Id
+	d.Name = a.Name
 	d.DescribedObject = a.DescribedObject
 	d.AdminState = a.AdminState
 	d.OperatingState = a.OperatingState

--- a/models/device_test.go
+++ b/models/device_test.go
@@ -33,16 +33,13 @@ var TestDevice = Device{DescribedObject: TestDescribedObject, Name: TestDeviceNa
 	Labels: TestLabels, Location: TestLocation, Service: TestDeviceService, Profile: TestProfile, AutoEvents: newAutoEvent()}
 
 func TestDevice_MarshalJSON(t *testing.T) {
-	marshaled := TestDevice.String()
-	testDeviceBytes := []byte(marshaled)
-
 	tests := []struct {
 		name    string
 		d       Device
 		want    []byte
 		wantErr bool
 	}{
-		{"successful marshal", TestDevice, testDeviceBytes, false},
+		{"successful empty marshal", Device{}, []byte(testEmptyJSON), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -52,7 +49,7 @@ func TestDevice_MarshalJSON(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Device.MarshalJSON() = %v, want %v", got, tt.want)
+				t.Errorf("Device.MarshalJSON() = %v, want %v", string(got), string(tt.want))
 			}
 		})
 	}

--- a/models/deviceprofile.go
+++ b/models/deviceprofile.go
@@ -22,42 +22,15 @@ import (
 // there can be multiple matching devices within a given system.
 type DeviceProfile struct {
 	DescribedObject `yaml:",inline"`
-	Id              string            `json:"id" yaml:"id,omitempty"`
-	Name            string            `json:"name" yaml:"name,omitempty"`                 // Non-database identifier (must be unique)
-	Manufacturer    string            `json:"manufacturer" yaml:"manufacturer,omitempty"` // Manufacturer of the device
-	Model           string            `json:"model" yaml:"model,omitempty"`               // Model of the device
-	Labels          []string          `json:"labels" yaml:"labels,flow,omitempty"`        // Labels used to search for groups of profiles
-	DeviceResources []DeviceResource  `json:"deviceResources" yaml:"deviceResources,omitempty"`
-	DeviceCommands  []ProfileResource `json:"deviceCommands" yaml:"deviceCommands,omitempty"`
-	CoreCommands    []Command         `json:"coreCommands" yaml:"coreCommands,omitempty"` // List of commands to Get/Put information for devices associated with this profile
+	Id              string            `json:"id,omitempty" yaml:"id,omitempty"`
+	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`                 // Non-database identifier (must be unique)
+	Manufacturer    string            `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"` // Manufacturer of the device
+	Model           string            `json:"model,omitempty" yaml:"model,omitempty"`               // Model of the device
+	Labels          []string          `json:"labels,omitempty" yaml:"labels,flow,omitempty"`        // Labels used to search for groups of profiles
+	DeviceResources []DeviceResource  `json:"deviceResources,omitempty" yaml:"deviceResources,omitempty"`
+	DeviceCommands  []ProfileResource `json:"deviceCommands,omitempty" yaml:"deviceCommands,omitempty"`
+	CoreCommands    []Command         `json:"coreCommands,omitempty" yaml:"coreCommands,omitempty"` // List of commands to Get/Put information for devices associated with this profile
 	isValidated     bool              // internal member used for validation check
-}
-
-// MarshalJSON implements the Marshaler interface so that empty strings and arrays are null
-func (dp DeviceProfile) MarshalJSON() ([]byte, error) {
-	test := struct {
-		DescribedObject
-		Id              string            `json:"id,omitempty"`
-		Name            string            `json:"name,omitempty"`         // Non-database identifier (must be unique)
-		Manufacturer    string            `json:"manufacturer,omitempty"` // Manufacturer of the device
-		Model           string            `json:"model,omitempty"`        // Model of the device
-		Labels          []string          `json:"labels,omitempty"`       // Labels used to search for groups of profiles
-		DeviceResources []DeviceResource  `json:"deviceResources,omitempty"`
-		DeviceCommands  []ProfileResource `json:"deviceCommands,omitempty"`
-		CoreCommands    []Command         `json:"coreCommands,omitempty"` // List of commands to Get/Put information for devices associated with this profile
-	}{
-		Id:              dp.Id,
-		Name:            dp.Name,
-		Manufacturer:    dp.Manufacturer,
-		Labels:          dp.Labels,
-		DeviceResources: dp.DeviceResources,
-		DeviceCommands:  dp.DeviceCommands,
-		CoreCommands:    dp.CoreCommands,
-		Model:           dp.Model,
-		DescribedObject: dp.DescribedObject,
-	}
-
-	return json.Marshal(test)
 }
 
 // UnmarshalJSON implements the Unmarshaler interface for the DeviceProfile type

--- a/models/deviceprofile.go
+++ b/models/deviceprofile.go
@@ -37,34 +37,26 @@ type DeviceProfile struct {
 func (dp DeviceProfile) MarshalJSON() ([]byte, error) {
 	test := struct {
 		DescribedObject
-		Id              *string           `json:"id,omitempty"`
-		Name            *string           `json:"name,omitempty"`         // Non-database identifier (must be unique)
-		Manufacturer    *string           `json:"manufacturer,omitempty"` // Manufacturer of the device
-		Model           *string           `json:"model,omitempty"`        // Model of the device
+		Id              string            `json:"id,omitempty"`
+		Name            string            `json:"name,omitempty"`         // Non-database identifier (must be unique)
+		Manufacturer    string            `json:"manufacturer,omitempty"` // Manufacturer of the device
+		Model           string            `json:"model,omitempty"`        // Model of the device
 		Labels          []string          `json:"labels,omitempty"`       // Labels used to search for groups of profiles
 		DeviceResources []DeviceResource  `json:"deviceResources,omitempty"`
 		DeviceCommands  []ProfileResource `json:"deviceCommands,omitempty"`
 		CoreCommands    []Command         `json:"coreCommands,omitempty"` // List of commands to Get/Put information for devices associated with this profile
 	}{
-		Labels:          dp.Labels,
+		Id:              dp.Id,
+		Name:            dp.Name,
+		Manufacturer:    dp.Manufacturer,
+		Model:           dp.Model,
 		DescribedObject: dp.DescribedObject,
 	}
 
-	// Empty strings are null
-	if dp.Id != "" {
-		test.Id = &dp.Id
-	}
-	if dp.Name != "" {
-		test.Name = &dp.Name
-	}
-	if dp.Manufacturer != "" {
-		test.Manufacturer = &dp.Manufacturer
-	}
-	if dp.Model != "" {
-		test.Model = &dp.Model
-	}
-
 	// Empty arrays are null
+	if len(dp.Labels) > 0 {
+		test.Labels = dp.Labels
+	}
 	if len(dp.DeviceResources) > 0 {
 		test.DeviceResources = dp.DeviceResources
 	}

--- a/models/deviceprofile.go
+++ b/models/deviceprofile.go
@@ -49,22 +49,12 @@ func (dp DeviceProfile) MarshalJSON() ([]byte, error) {
 		Id:              dp.Id,
 		Name:            dp.Name,
 		Manufacturer:    dp.Manufacturer,
+		Labels:          dp.Labels,
+		DeviceResources: dp.DeviceResources,
+		DeviceCommands:  dp.DeviceCommands,
+		CoreCommands:    dp.CoreCommands,
 		Model:           dp.Model,
 		DescribedObject: dp.DescribedObject,
-	}
-
-	// Empty arrays are null
-	if len(dp.Labels) > 0 {
-		test.Labels = dp.Labels
-	}
-	if len(dp.DeviceResources) > 0 {
-		test.DeviceResources = dp.DeviceResources
-	}
-	if len(dp.DeviceCommands) > 0 {
-		test.DeviceCommands = dp.DeviceCommands
-	}
-	if len(dp.CoreCommands) > 0 {
-		test.CoreCommands = dp.CoreCommands
 	}
 
 	return json.Marshal(test)

--- a/models/deviceprofile_test.go
+++ b/models/deviceprofile_test.go
@@ -17,7 +17,6 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"testing"
 )
@@ -28,33 +27,6 @@ var TestModel = "Test Model"
 var TestProfileLabels = []string{"labe1", "label2"}
 var TestProfileDescription = "Test Description"
 var TestProfile = DeviceProfile{DescribedObject: TestDescribedObject, Name: TestProfileName, Manufacturer: TestManufacturer, Model: TestModel, Labels: TestProfileLabels, DeviceResources: []DeviceResource{TestDeviceResource}, DeviceCommands: []ProfileResource{TestProfileResource}, CoreCommands: []Command{TestCommand}}
-
-func TestDeviceProfile_MarshalJSON(t *testing.T) {
-	var emptyDeviceProfile = DeviceProfile{}
-	var resultTestBytes = []byte(TestProfile.String())
-	var resultEmptyTestBytes = []byte(emptyDeviceProfile.String())
-	tests := []struct {
-		name    string
-		dp      DeviceProfile
-		want    []byte
-		wantErr bool
-	}{
-		{"successful marshal", TestProfile, resultTestBytes, false},
-		{"successful empty marshal", emptyDeviceProfile, resultEmptyTestBytes, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.dp.MarshalJSON()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("DeviceProfile.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DeviceProfile.MarshalJSON() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestDeviceProfile_String(t *testing.T) {
 	var labelSlice, _ = json.Marshal(TestProfileLabels)

--- a/models/deviceservice.go
+++ b/models/deviceservice.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"encoding/json"
+	"reflect"
 )
 
 // DeviceService represents a service that is responsible for proxying connectivity between a set of devices and the
@@ -37,31 +38,28 @@ type DeviceService struct {
 func (ds DeviceService) MarshalJSON() ([]byte, error) {
 	test := struct {
 		DescribedObject `json:",inline"`
-		Id              *string        `json:"id"`
-		Name            *string        `json:"name"`           // time in milliseconds that the device last provided any feedback or responded to any request
-		LastConnected   int64          `json:"lastConnected"`  // time in milliseconds that the device last reported data to the core
-		LastReported    int64          `json:"lastReported"`   // operational state - either enabled or disabled
-		OperatingState  OperatingState `json:"operatingState"` // operational state - ether enabled or disableddc
-		Labels          []string       `json:"labels"`         // tags or other labels applied to the device service for search or other identification needs
-		Addressable     Addressable    `json:"addressable"`    // address (MQTT topic, HTTP address, serial bus, etc.) for reaching the service
-		AdminState      AdminState     `json:"adminState"`     // Device Service Admin State
+		Id              string         `json:"id,omitempty"`
+		Name            string         `json:"name,omitempty"`           // time in milliseconds that the device last provided any feedback or responded to any request
+		LastConnected   int64          `json:"lastConnected,omitempty"`  // time in milliseconds that the device last reported data to the core
+		LastReported    int64          `json:"lastReported,omitempty"`   // operational state - either enabled or disabled
+		OperatingState  OperatingState `json:"operatingState,omitempty"` // operational state - ether enabled or disableddc
+		Labels          []string       `json:"labels,omitempty"`         // tags or other labels applied to the device service for search or other identification needs
+		Addressable     *Addressable   `json:"addressable,omitempty"`    // address (MQTT topic, HTTP address, serial bus, etc.) for reaching the service
+		AdminState      AdminState     `json:"adminState,omitempty"`     // Device Service Admin State
 	}{
 		DescribedObject: ds.DescribedObject,
+		Id:              ds.Id,
+		Name:            ds.Name,
 		LastConnected:   ds.LastConnected,
 		LastReported:    ds.LastReported,
 		OperatingState:  ds.OperatingState,
 		Labels:          ds.Labels,
-		Addressable:     ds.Addressable,
+		Addressable:     &ds.Addressable,
 		AdminState:      ds.AdminState,
 	}
 
-	if ds.Id != "" {
-		test.Id = &ds.Id
-	}
-
-	// Empty strings are null
-	if ds.Name != "" {
-		test.Name = &ds.Name
+	if reflect.DeepEqual(*test.Addressable, Addressable{}) {
+		test.Addressable = nil
 	}
 
 	return json.Marshal(test)

--- a/models/deviceservice_test.go
+++ b/models/deviceservice_test.go
@@ -28,7 +28,6 @@ var TestDeviceService = DeviceService{DescribedObject: TestDescribedObject, Name
 func TestDeviceService_MarshalJSON(t *testing.T) {
 	var emptyDeviceService = DeviceService{}
 	var resultTestBytes = []byte(TestDeviceService.String())
-	var resultEmptyTestBytes = []byte(emptyDeviceService.String())
 
 	tests := []struct {
 		name    string
@@ -37,7 +36,7 @@ func TestDeviceService_MarshalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{"successful marshal", TestDeviceService, resultTestBytes, false},
-		{"successful empty marshal", emptyDeviceService, resultEmptyTestBytes, false},
+		{"successful empty marshal", emptyDeviceService, []byte(testEmptyJSON), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -98,7 +97,7 @@ func TestDeviceService_String(t *testing.T) {
 				",\"modified\":" + strconv.FormatInt(TestDeviceService.Modified, 10) +
 				",\"origin\":" + strconv.FormatInt(TestDeviceService.Origin, 10) +
 				",\"description\":\"" + testDescription + "\"" +
-				",\"id\":null,\"name\":\"" + TestServiceName + "\"" +
+				",\"name\":\"" + TestServiceName + "\"" +
 				",\"lastConnected\":" + strconv.FormatInt(TestLastConnected, 10) +
 				",\"lastReported\":" + strconv.FormatInt(TestLastReported, 10) +
 				",\"operatingState\":\"ENABLED\"" +


### PR DESCRIPTION
Part of the work to address #143

Addresses the following models:

CallbackAlert
Channel
Command
CommandResponse
Device
DeviceProfile
DeviceService