### PR TITLE
Update models to serialize zero values as empty JSON objects, part 3

### DIFF
--- a/models/sma_operation.go
+++ b/models/sma_operation.go
@@ -53,9 +53,7 @@ func (o *Operation) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-/*
- * To String function for Operation struct
- */
+// String returns a JSON encoded string representation of the model
 func (o Operation) String() string {
 	out, err := json.Marshal(o)
 	if err != nil {

--- a/models/sma_operation_test.go
+++ b/models/sma_operation_test.go
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * i compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to i writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import "testing"
+
+var TestOperationEmpty = Operation{}
+
+func TestOperation_String(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation Operation
+		want      string
+	}{
+		{"empty operation", TestOperationEmpty, testEmptyJSON},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.operation.String(); got != tt.want {
+				t.Errorf("Operation.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -19,15 +19,10 @@ import (
 	"encoding/json"
 )
 
-/*
- * A subscription for notification alerts
- *
- *
- * Subscription struct
- */
+// Subscription represents an object for notification alerts
 type Subscription struct {
 	Timestamps
-	ID                   string                  `json:"id"`
+	ID                   string                  `json:"id,omitempty"`
 	Slug                 string                  `json:"slug,omitempty"`
 	Receiver             string                  `json:"receiver,omitempty"`
 	Description          string                  `json:"description,omitempty"`
@@ -36,42 +31,7 @@ type Subscription struct {
 	Channels             []Channel               `json:"channels,omitempty"`
 }
 
-// Custom marshaling to make empty strings null
-func (s Subscription) MarshalJSON() ([]byte, error) {
-	test := struct {
-		Timestamps
-		ID                   *string                 `json:"id"`
-		Slug                 *string                 `json:"slug,omitempty"`
-		Receiver             *string                 `json:"receiver,omitempty"`
-		Description          *string                 `json:"description,omitempty"`
-		SubscribedCategories []NotificationsCategory `json:"subscribedCategories,omitempty"`
-		SubscribedLabels     []string                `json:"subscribedLabels,omitempty"`
-		Channels             []Channel               `json:"channels,omitempty"`
-	}{
-		Timestamps:           s.Timestamps,
-		SubscribedCategories: s.SubscribedCategories,
-		SubscribedLabels:     s.SubscribedLabels,
-		Channels:             s.Channels,
-	}
-
-	if s.ID != "" {
-		test.ID = &s.ID
-	}
-	if s.Slug != "" {
-		test.Slug = &s.Slug
-	}
-	if s.Receiver != "" {
-		test.Receiver = &s.Receiver
-	}
-	if s.Description != "" {
-		test.Description = &s.Description
-	}
-	return json.Marshal(test)
-}
-
-/*
- * To String function for Notification Struct
- */
+// String returns a JSON encoded string representation of the model
 func (s Subscription) String() string {
 	out, err := json.Marshal(s)
 	if err != nil {

--- a/models/subscription_test.go
+++ b/models/subscription_test.go
@@ -16,7 +16,6 @@
 package models
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -25,41 +24,14 @@ var TestSubscription = Subscription{Timestamps: testTimestamps, Slug: "test slug
 	SubscribedCategories: []NotificationsCategory{NotificationsCategory(Swhealth)}, SubscribedLabels: []string{"test label"},
 	Channels: []Channel{TestEChannel, TestRChannel}}
 
-func TestSubscription_MarshalJSON(t *testing.T) {
-	var testEmptyBytes = []byte(TestEmptySubscription.String())
-	var testSubBytes = []byte(TestSubscription.String())
-
-	tests := []struct {
-		name    string
-		sub     *Subscription
-		want    []byte
-		wantErr bool
-	}{
-		{"test empty subscription", &TestEmptySubscription, testEmptyBytes, false},
-		{"test subscription", &TestSubscription, testSubBytes, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.sub.MarshalJSON()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Subscription.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Subscription.MarshalJSON() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestSubscription_String(t *testing.T) {
 	tests := []struct {
 		name string
 		sub  *Subscription
 		want string
 	}{
-		{"test string empty subscription", &TestEmptySubscription, "{\"id\":null}"},
-		{"test subscription", &TestSubscription, "{\"created\":123,\"modified\":123,\"origin\":123,\"id\":null,\"slug\":\"test slug\",\"receiver\":\"test receiver\",\"description\":\"test description\",\"subscribedCategories\":[\"SW_HEALTH\"],\"subscribedLabels\":[\"test label\"],\"channels\":[{\"type\":\"EMAIL\",\"mailAddresses\":[\"jpwhite_mn@yahoo.com\",\"james_white2@dell.com\"]},{\"type\":\"REST\",\"url\":\"http://www.someendpoint.com/notifications\"}]}"},
+		{"test string empty subscription", &TestEmptySubscription, testEmptyJSON},
+		{"test subscription", &TestSubscription, "{\"created\":123,\"modified\":123,\"origin\":123,\"slug\":\"test slug\",\"receiver\":\"test receiver\",\"description\":\"test description\",\"subscribedCategories\":[\"SW_HEALTH\"],\"subscribedLabels\":[\"test label\"],\"channels\":[{\"type\":\"EMAIL\",\"mailAddresses\":[\"jpwhite_mn@yahoo.com\",\"james_white2@dell.com\"]},{\"type\":\"REST\",\"url\":\"http://www.someendpoint.com/notifications\"}]}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/timestamps.go
+++ b/models/timestamps.go
@@ -24,11 +24,9 @@ type Timestamps struct {
 	Origin   int64 `json:"origin,omitempty" yaml:"origin,omitempty"`
 }
 
-/*
- * String function for representing a device
- */
-func (o *Timestamps) String() string {
-	out, err := json.Marshal(o)
+// String returns a JSON encoded string representation of the model
+func (ts *Timestamps) String() string {
+	out, err := json.Marshal(ts)
 	if err != nil {
 		return err.Error()
 	}
@@ -38,8 +36,8 @@ func (o *Timestamps) String() string {
 /*
  * Compare the Created of two objects to determine given is newer
  */
-func (ba *Timestamps) compareTo(i Timestamps) int {
-	if i.Created > ba.Created {
+func (ts *Timestamps) compareTo(i Timestamps) int {
+	if i.Created > ts.Created {
 		return 1
 	}
 	return -1

--- a/models/timestamps_test.go
+++ b/models/timestamps_test.go
@@ -25,7 +25,7 @@ func TestTimestamps_String(t *testing.T) {
 		timestamps *Timestamps
 		want       string
 	}{
-		{"empty timestamps", &emptyTimestamps, "{}"},
+		{"empty timestamps", &emptyTimestamps, testEmptyJSON},
 		{"populated timestamps", &testTimestamps, "{\"created\":123,\"modified\":123,\"origin\":123}"},
 	}
 	for _, tt := range tests {

--- a/models/transmission_record.go
+++ b/models/transmission_record.go
@@ -20,31 +20,12 @@ import (
 )
 
 type TransmissionRecord struct {
-	Status   TransmissionStatus `json:"status"`
-	Response string             `json:"response"`
-	Sent     int64              `json:"sent"`
+	Status   TransmissionStatus `json:"status,omitempty"`
+	Response string             `json:"response,omitempty"`
+	Sent     int64              `json:"sent,omitempty"`
 }
 
-// Custom marshaling to make empty strings null
-func (t TransmissionRecord) MarshalJSON() ([]byte, error) {
-	test := struct {
-		Status   TransmissionStatus `json:"status"`
-		Response *string            `json:"response"`
-		Sent     int64              `json:"sent"`
-	}{
-		Status: t.Status,
-		Sent:   t.Sent,
-	}
-	// Empty strings are null
-	if t.Response != "" {
-		test.Response = &t.Response
-	}
-	return json.Marshal(test)
-}
-
-/*
- * To String function for TransmissionRecord Struct
- */
+// String returns a JSON encoded string representation of the model
 func (t TransmissionRecord) String() string {
 	out, err := json.Marshal(t)
 	if err != nil {

--- a/models/transmission_record_test.go
+++ b/models/transmission_record_test.go
@@ -16,7 +16,6 @@
 package models
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -24,37 +23,6 @@ var TestFailedTransRecord = TransmissionRecord{Response: "fail", Sent: 123, Stat
 var TestSentTransRecord = TransmissionRecord{Response: "ok", Sent: 123, Status: TransmissionStatus(Sent)}
 var TestEmptyRespTransRecord = TransmissionRecord{Sent: 123, Status: TransmissionStatus(Sent)}
 var TestEmptyTransRecord = TransmissionRecord{}
-
-func TestTransmissionRecord_MarshalJSON(t *testing.T) {
-	var failedBytes = []byte(TestFailedTransRecord.String())
-	var sentBytes = []byte(TestSentTransRecord.String())
-	var emptyRespBytes = []byte(TestEmptyRespTransRecord.String())
-	var emptyBytes = []byte(TestEmptyTransRecord.String())
-
-	tests := []struct {
-		name    string
-		recd    *TransmissionRecord
-		want    []byte
-		wantErr bool
-	}{
-		{"test failed tran record", &TestFailedTransRecord, failedBytes, false},
-		{"test sent tran record", &TestSentTransRecord, sentBytes, false},
-		{"test empty response tran record", &TestEmptyRespTransRecord, emptyRespBytes, false},
-		{"test empty tran record", &TestEmptyTransRecord, emptyBytes, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.recd.MarshalJSON()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TransmissionRecord.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("TransmissionRecord.MarshalJSON() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestTransmissionRecord_String(t *testing.T) {
 	tests := []struct {
@@ -64,8 +32,8 @@ func TestTransmissionRecord_String(t *testing.T) {
 	}{
 		{"test string of failed", &TestFailedTransRecord, "{\"status\":\"FAILED\",\"response\":\"fail\",\"sent\":123}"},
 		{"test string of sent", &TestSentTransRecord, "{\"status\":\"SENT\",\"response\":\"ok\",\"sent\":123}"},
-		{"test string of empty response", &TestEmptyRespTransRecord, "{\"status\":\"SENT\",\"response\":null,\"sent\":123}"},
-		{"test string of empty", &TestEmptyTransRecord, "{\"status\":\"\",\"response\":null,\"sent\":0}"},
+		{"test string of empty response", &TestEmptyRespTransRecord, "{\"status\":\"SENT\",\"sent\":123}"},
+		{"test string of empty", &TestEmptyTransRecord, testEmptyJSON},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/transmission_test.go
+++ b/models/transmission_test.go
@@ -21,20 +21,27 @@ import (
 )
 
 var TestEmptyTransmission = Transmission{}
-var TestTransmission = Transmission{Timestamps: testTimestamps, Notification: TestNotification, Receiver: "test receiver",
-	Channel: Channel{Type: ChannelType(Email), MailAddresses: []string{"jpwhite_mn@yahoo.com", "james_white2@dell.com"}}, Status: TransmissionStatus(Sent), ResendCount: 0, Records: []TransmissionRecord{TestSentTransRecord}}
+var TestTransmission = Transmission{
+	Timestamps:   testTimestamps,
+	Notification: TestNotification,
+	Receiver:     "test receiver",
+	Channel: Channel{
+		Type:          ChannelType(Email),
+		MailAddresses: []string{"me@brandonforster.com", "brandon.forster@dell.com"},
+	},
+	Status:      TransmissionStatus(Sent),
+	ResendCount: 0,
+	Records:     []TransmissionRecord{TestSentTransRecord},
+}
 
 func TestTransmission_MarshalJSON(t *testing.T) {
-	var emptyBytes = []byte(TestEmptyTransmission.String())
-	var tranBytes = []byte(TestTransmission.String())
 	tests := []struct {
 		name    string
 		trans   *Transmission
 		want    []byte
 		wantErr bool
 	}{
-		{"test empty transmission", &TestEmptyTransmission, emptyBytes, false},
-		{"test transmission", &TestTransmission, tranBytes, false},
+		{"test empty transmission", &TestEmptyTransmission, []byte(testEmptyJSON), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -44,7 +51,7 @@ func TestTransmission_MarshalJSON(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Transmission.MarshalJSON() = %v, want %v", got, tt.want)
+				t.Errorf("Transmission.MarshalJSON() = %v, want %v", string(got), string(tt.want))
 			}
 		})
 	}
@@ -56,8 +63,26 @@ func TestTransmission_String(t *testing.T) {
 		trans *Transmission
 		want  string
 	}{
-		{"test string of empty transmission", &TestEmptyTransmission, "{\"id\":null,\"notification\":{\"id\":null},\"channel\":{},\"resendcount\":0}"},
-		{"test string of transmission", &TestTransmission, "{\"created\":123,\"modified\":123,\"origin\":123,\"id\":null,\"notification\":{\"created\":123,\"modified\":123,\"id\":\"" + TestNotificationID + "\",\"slug\":\"test slug\",\"sender\":\"test sender\",\"category\":\"SECURITY\",\"severity\":\"CRITICAL\",\"content\":\"test content\",\"description\":\"test description\",\"status\":\"NEW\",\"labels\":[\"label1\",\"labe2\"],\"contenttype\":\"text/plain\"},\"receiver\":\"test receiver\",\"channel\":{\"type\":\"EMAIL\",\"mailAddresses\":[\"jpwhite_mn@yahoo.com\",\"james_white2@dell.com\"]},\"status\":\"SENT\",\"resendcount\":0,\"records\":[{\"status\":\"SENT\",\"response\":\"ok\",\"sent\":123}]}"},
+		{"test string of empty transmission", &TestEmptyTransmission, testEmptyJSON},
+		{"test string of transmission", &TestTransmission,
+			"{" +
+				"\"created\":123," +
+				"\"modified\":123," +
+				"\"origin\":123," +
+				"\"notification\":{\"created\":123,\"modified\":123," +
+				"\"id\":\"" + TestNotificationID + "\",\"slug\":\"test slug\",\"sender\":\"test sender\"," +
+				"\"category\":\"SECURITY\",\"severity\":\"CRITICAL\",\"content\":\"test content\"," +
+				"\"description\":\"test description\",\"status\":\"NEW\",\"labels\":[\"label1\",\"labe2\"]," +
+				"\"contenttype\":\"text/plain\"}," +
+				"\"receiver\":\"test receiver\"," +
+				"\"channel\":{\"type\":\"EMAIL\"," +
+				"\"mailAddresses\":[\"me@brandonforster.com\",\"brandon.forster@dell.com\"]}," +
+				"\"status\":\"SENT\"," +
+				"\"resendcount\":0," +
+				"\"records\":[{\"status\":\"SENT\"," +
+				"\"response\":\"ok\",\"sent\":123}]" +
+				"}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/units.go
+++ b/models/units.go
@@ -17,36 +17,12 @@ package models
 import "encoding/json"
 
 type Units struct {
-	Type         string `json:"type" yaml:"type,omitempty"`
-	ReadWrite    string `json:"readWrite" yaml:"readWrite,omitempty"`
-	DefaultValue string `json:"defaultValue" yaml:"defaultValue,omitempty"`
+	Type         string `json:"type,omitempty" yaml:"type,omitempty"`
+	ReadWrite    string `json:"readWrite,omitempty" yaml:"readWrite,omitempty"`
+	DefaultValue string `json:"defaultValue,omitempty" yaml:"defaultValue,omitempty"`
 }
 
-// Custom marshaling to make empty strings null
-func (u Units) MarshalJSON() ([]byte, error) {
-	test := struct {
-		Type         *string `json:"type,omitempty"`
-		ReadWrite    *string `json:"readWrite,omitempty"`
-		DefaultValue *string `json:"defaultValue,omitempty"`
-	}{}
-
-	// Empty strings are null
-	if u.Type != "" {
-		test.Type = &u.Type
-	}
-	if u.ReadWrite != "" {
-		test.ReadWrite = &u.ReadWrite
-	}
-	if u.DefaultValue != "" {
-		test.DefaultValue = &u.DefaultValue
-	}
-
-	return json.Marshal(test)
-}
-
-/*
- * To String function for Units
- */
+// String returns a JSON encoded string representation of the model
 func (u Units) String() string {
 	out, err := json.Marshal(u)
 	if err != nil {

--- a/models/units_test.go
+++ b/models/units_test.go
@@ -15,7 +15,6 @@
 package models
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -23,30 +22,6 @@ var TestUnitsType = "String"
 var TestUnitsRW = "R"
 var TestUnitsDV = "Degrees Fahrenheit"
 var TestUnits = Units{Type: TestUnitsType, ReadWrite: TestUnitsRW, DefaultValue: TestUnitsDV}
-
-func TestUnits_MarshalJSON(t *testing.T) {
-	var testUnitsBytes = []byte(TestUnits.String())
-	tests := []struct {
-		name    string
-		u       Units
-		want    []byte
-		wantErr bool
-	}{
-		{"successful marshalling", TestUnits, testUnitsBytes, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.u.MarshalJSON()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Units.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Units.MarshalJSON() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestUnits_String(t *testing.T) {
 	tests := []struct {
@@ -58,6 +33,7 @@ func TestUnits_String(t *testing.T) {
 			"{\"type\":\"" + TestUnitsType + "\"" +
 				",\"readWrite\":\"" + TestUnitsRW + "\"" +
 				",\"defaultValue\":\"" + TestUnitsDV + "\"}"},
+		{"units to string, empty", Units{}, testEmptyJSON},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/value-descriptor.go
+++ b/models/value-descriptor.go
@@ -27,85 +27,22 @@ const defaultValueDescriptorFormat = "%s"
  * Value Descriptor Struct
  */
 type ValueDescriptor struct {
-	Id            string      `json:"id"`
-	Created       int64       `json:"created"`
-	Description   string      `json:"description"`
-	Modified      int64       `json:"modified"`
-	Origin        int64       `json:"origin"`
-	Name          string      `json:"name"`
-	Min           interface{} `json:"min"`
-	Max           interface{} `json:"max"`
-	DefaultValue  interface{} `json:"defaultValue"`
-	Type          string      `json:"type"`
-	UomLabel      string      `json:"uomLabel"`
-	Formatting    string      `json:"formatting"`
-	Labels        []string    `json:"labels"`
-	MediaType     string      `json:"mediaType"`
-	FloatEncoding string      `json:"floatEncoding"`
+	Id            string      `json:"id,omitempty"`
+	Created       int64       `json:"created,omitempty"`
+	Description   string      `json:"description,omitempty"`
+	Modified      int64       `json:"modified,omitempty"`
+	Origin        int64       `json:"origin,omitempty"`
+	Name          string      `json:"name,omitempty"`
+	Min           interface{} `json:"min,omitempty"`
+	Max           interface{} `json:"max,omitempty"`
+	DefaultValue  interface{} `json:"defaultValue,omitempty"`
+	Type          string      `json:"type,omitempty"`
+	UomLabel      string      `json:"uomLabel,omitempty"`
+	Formatting    string      `json:"formatting,omitempty"`
+	Labels        []string    `json:"labels,omitempty"`
+	MediaType     string      `json:"mediaType,omitempty"`
+	FloatEncoding string      `json:"floatEncoding,omitempty"`
 	isValidated   bool        // internal member used for validation check
-}
-
-// Custom marshaling to make empty strings null
-func (v ValueDescriptor) MarshalJSON() ([]byte, error) {
-	test := struct {
-		Id            *string      `json:"id,omitempty"`
-		Created       int64        `json:"created,omitempty"`
-		Description   *string      `json:"description,omitempty"`
-		Modified      int64        `json:"modified,omitempty"`
-		Origin        int64        `json:"origin,omitempty"`
-		Name          *string      `json:"name,omitempty"`
-		Min           *interface{} `json:"min,omitempty"`
-		Max           *interface{} `json:"max,omitempty"`
-		DefaultValue  *interface{} `json:"defaultValue,omitempty"`
-		Type          *string      `json:"type,omitempty"`
-		UomLabel      *string      `json:"uomLabel,omitempty"`
-		Formatting    *string      `json:"formatting,omitempty"`
-		Labels        []string     `json:"labels,omitempty"`
-		MediaType     *string      `json:"mediaType,omitempty"`
-		FloatEncoding *string      `json:"floatEncoding,omitempty"`
-	}{
-		Created:  v.Created,
-		Modified: v.Modified,
-		Origin:   v.Origin,
-		Labels:   v.Labels,
-	}
-
-	// Empty strings are null
-	if v.Id != "" {
-		test.Id = &v.Id
-	}
-	if v.Name != "" {
-		test.Name = &v.Name
-	}
-	if v.Description != "" {
-		test.Description = &v.Description
-	}
-	if v.Min != "" {
-		test.Min = &v.Min
-	}
-	if v.Max != "" {
-		test.Max = &v.Max
-	}
-	if v.Min != "" {
-		test.DefaultValue = &v.DefaultValue
-	}
-	if v.Type != "" {
-		test.Type = &v.Type
-	}
-	if v.UomLabel != "" {
-		test.UomLabel = &v.UomLabel
-	}
-	if v.Formatting != "" {
-		test.Formatting = &v.Formatting
-	}
-	if v.MediaType != "" {
-		test.MediaType = &v.MediaType
-	}
-	if v.FloatEncoding != "" {
-		test.FloatEncoding = &v.FloatEncoding
-	}
-
-	return json.Marshal(test)
 }
 
 // UnmarshalJSON implements the Unmarshaler interface for the ValueDescriptor type
@@ -197,9 +134,7 @@ func (v ValueDescriptor) Validate() (bool, error) {
 	return true, nil
 }
 
-/*
- * To String function for ValueDescriptor Struct
- */
+// String returns a JSON encoded string representation of the model
 func (a ValueDescriptor) String() string {
 	out, err := json.Marshal(a)
 	if err != nil {

--- a/models/value-descriptor_test.go
+++ b/models/value-descriptor_test.go
@@ -17,7 +17,6 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -34,30 +33,6 @@ var TestFormatting = "%d"
 var TestVDLabels = []string{"temp", "room temp"}
 var TestVDFloatEncoding = ENotation
 var TestValueDescriptor = ValueDescriptor{Created: 123, Modified: 123, Origin: 123, Name: TestVDName, Description: TestVDDescription, Min: TestMin, Max: TestMax, DefaultValue: TestDefaultValue, Formatting: TestFormatting, Labels: TestVDLabels, UomLabel: TestUoMLabel, MediaType: TestMediaType, FloatEncoding: TestVDFloatEncoding}
-
-func TestValueDescriptor_MarshalJSON(t *testing.T) {
-	var resultTestVDBytes = []byte(TestValueDescriptor.String())
-	tests := []struct {
-		name    string
-		v       ValueDescriptor
-		want    []byte
-		wantErr bool
-	}{
-		{"successful marshal", TestValueDescriptor, resultTestVDBytes, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.v.MarshalJSON()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValueDescriptor.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ValueDescriptor.MarshalJSON() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestValueDescriptor_String(t *testing.T) {
 	var labelSlice, _ = json.Marshal(TestValueDescriptor.Labels)
@@ -81,6 +56,7 @@ func TestValueDescriptor_String(t *testing.T) {
 				",\"mediaType\":\"" + TestValueDescriptor.MediaType + "\"" +
 				",\"floatEncoding\":\"" + TestVDFloatEncoding + "\"" +
 				"}"},
+		{"value descriptor to string, empty", ValueDescriptor{}, testEmptyJSON},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Part 3 of 6 for #143

This work includes: sma_operation, subscription, timestamps, transmission, transmission_record, units, value-descriptor

Signed-off-by: Brandon Forster brandonforster@gmail.com