### PR TITLE
Endpointer Clean Up

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -50,11 +50,6 @@ func NewCommandClient(params types.EndpointParams, m clients.Endpointer) Command
 
 func (c *commandRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		c.url = c.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go c.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -62,7 +57,7 @@ func (c *commandRestClient) init(params types.EndpointParams) {
 					c.url = url
 				}
 			}
-		}(ch)
+		}(c.endpoint.Monitor(params))
 	} else {
 		c.url = params.Url
 	}

--- a/clients/command/client_test.go
+++ b/clients/command/client_test.go
@@ -16,7 +16,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -124,19 +123,8 @@ func TestPutDeviceCommandByNames(t *testing.T) {
 type MockEndpoint struct {
 }
 
-func (e MockEndpoint) Monitor(params types.EndpointParams, ch chan string) {
-	switch params.ServiceKey {
-	case clients.CoreCommandServiceKey:
-		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48082, params.Path)
-		ch <- url
-		break
-	default:
-		ch <- ""
-	}
-}
-
-func (e MockEndpoint) Fetch(params types.EndpointParams) string {
-	return fmt.Sprintf("http://%s:%v%s", "localhost", 48082, params.Path)
+func (e MockEndpoint) Monitor(params types.EndpointParams) chan string {
+	return make(chan string, 1)
 }
 
 // testHttpServer instantiates a test HTTP Server to be used for conveniently verifying a client's invocation

--- a/clients/coredata/event.go
+++ b/clients/coredata/event.go
@@ -80,11 +80,6 @@ func NewEventClient(params types.EndpointParams, m clients.Endpointer) EventClie
 
 func (e *eventRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		e.url = e.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go e.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -92,7 +87,7 @@ func (e *eventRestClient) init(params types.EndpointParams) {
 					e.url = url
 				}
 			}
-		}(ch)
+		}(e.endpoint.Monitor(params))
 	} else {
 		e.url = params.Url
 	}

--- a/clients/coredata/event_test.go
+++ b/clients/coredata/event_test.go
@@ -238,17 +238,8 @@ func TestMarshalEvent(t *testing.T) {
 
 type mockCoreDataEndpoint struct{}
 
-func (e mockCoreDataEndpoint) Monitor(params types.EndpointParams, ch chan string) {
-	switch params.ServiceKey {
-	case clients.CoreDataServiceKey:
-		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
-		ch <- url
-		break
-	default:
-		ch <- ""
-	}
-}
-
-func (e mockCoreDataEndpoint) Fetch(params types.EndpointParams) string {
-	return fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
+func (e mockCoreDataEndpoint) Monitor(params types.EndpointParams) chan string {
+	ch := make(chan string, 1)
+	ch <- fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
+	return ch
 }

--- a/clients/coredata/reading.go
+++ b/clients/coredata/reading.go
@@ -70,11 +70,6 @@ func NewReadingClient(params types.EndpointParams, m clients.Endpointer) Reading
 
 func (r *readingRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		r.url = r.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go r.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -82,7 +77,7 @@ func (r *readingRestClient) init(params types.EndpointParams) {
 					r.url = url
 				}
 			}
-		}(ch)
+		}(r.endpoint.Monitor(params))
 	} else {
 		r.url = params.Url
 	}

--- a/clients/coredata/value_descriptor.go
+++ b/clients/coredata/value_descriptor.go
@@ -67,11 +67,6 @@ func NewValueDescriptorClient(params types.EndpointParams, m clients.Endpointer)
 
 func (d *valueDescriptorRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		d.url = d.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -79,7 +74,7 @@ func (d *valueDescriptorRestClient) init(params types.EndpointParams) {
 					d.url = url
 				}
 			}
-		}(ch)
+		}(d.endpoint.Monitor(params))
 	} else {
 		d.url = params.Url
 	}

--- a/clients/endpointer.go
+++ b/clients/endpointer.go
@@ -19,10 +19,9 @@ import "github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 //Endpointer is the interface for types that need to implement or simulate integration
 //with a service discovery provider.
 type Endpointer interface {
-	//Fetch will return a string containing the URL for a service endpoint corresponding to the params.ServiceKey property.
-	Fetch(params types.EndpointParams) string
-	//Monitor is responsible for refreshing information about the service endpoint corresponding
-	//to the params.ServiceKey property on a set interval. Information about the service from the
-	//discovery provider should be used to construct a URL which will then be pushed to the supplied channel.
-	Monitor(params types.EndpointParams, ch chan string)
+	//Monitor is responsible for looking up information about the service endpoint corresponding
+	//to the params.ServiceKey property. The name "Monitor" implies that this lookup will be done
+	//at a regular interval. Information about the service from the discovery provider should be
+	//used to construct a URL which will then be pushed to the returned channel.
+	Monitor(params types.EndpointParams) chan string
 }

--- a/clients/export/distro/client.go
+++ b/clients/export/distro/client.go
@@ -45,11 +45,6 @@ func NewDistroClient(params types.EndpointParams, m clients.Endpointer) DistroCl
 
 func (d *distroRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		d.url = d.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -57,7 +52,7 @@ func (d *distroRestClient) init(params types.EndpointParams) {
 					d.url = url
 				}
 			}
-		}(ch)
+		}(d.endpoint.Monitor(params))
 	} else {
 		d.url = params.Url
 	}

--- a/clients/general/client.go
+++ b/clients/general/client.go
@@ -46,11 +46,6 @@ func NewGeneralClient(params types.EndpointParams, m clients.Endpointer) General
 
 func (gc *generalRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		gc.url = gc.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go gc.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -58,7 +53,7 @@ func (gc *generalRestClient) init(params types.EndpointParams) {
 					gc.url = url
 				}
 			}
-		}(ch)
+		}(gc.endpoint.Monitor(params))
 	} else {
 		gc.url = params.Url
 	}

--- a/clients/general/client_test.go
+++ b/clients/general/client_test.go
@@ -17,7 +17,6 @@ package general
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,11 +32,8 @@ const (
 type mockGeneralEndpoint struct {
 }
 
-func (e mockGeneralEndpoint) Monitor(params types.EndpointParams, ch chan string) {
-}
-
-func (e mockGeneralEndpoint) Fetch(params types.EndpointParams) string {
-	return fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
+func (e mockGeneralEndpoint) Monitor(params types.EndpointParams) chan string {
+	return make(chan string, 1)
 }
 
 func TestGetConfig(t *testing.T) {

--- a/clients/metadata/addressable.go
+++ b/clients/metadata/addressable.go
@@ -57,11 +57,6 @@ func NewAddressableClient(params types.EndpointParams, m clients.Endpointer) Add
 
 func (a *addressableRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		a.url = a.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go a.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -69,7 +64,7 @@ func (a *addressableRestClient) init(params types.EndpointParams) {
 					a.url = url
 				}
 			}
-		}(ch)
+		}(a.endpoint.Monitor(params))
 	} else {
 		a.url = params.Url
 	}

--- a/clients/metadata/command.go
+++ b/clients/metadata/command.go
@@ -57,11 +57,6 @@ func NewCommandClient(params types.EndpointParams, m clients.Endpointer) Command
 
 func (c *commandRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		c.url = c.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go c.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -69,7 +64,7 @@ func (c *commandRestClient) init(params types.EndpointParams) {
 					c.url = url
 				}
 			}
-		}(ch)
+		}(c.endpoint.Monitor(params))
 	} else {
 		c.url = params.Url
 	}

--- a/clients/metadata/device.go
+++ b/clients/metadata/device.go
@@ -87,11 +87,6 @@ func NewDeviceClient(params types.EndpointParams, m clients.Endpointer) DeviceCl
 
 func (d *deviceRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		d.url = d.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -99,7 +94,7 @@ func (d *deviceRestClient) init(params types.EndpointParams) {
 					d.url = url
 				}
 			}
-		}(ch)
+		}(d.endpoint.Monitor(params))
 	} else {
 		d.url = params.Url
 	}

--- a/clients/metadata/device_profile.go
+++ b/clients/metadata/device_profile.go
@@ -63,11 +63,6 @@ func NewDeviceProfileClient(params types.EndpointParams, m clients.Endpointer) D
 
 func (d *deviceProfileRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		d.url = d.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -75,7 +70,7 @@ func (d *deviceProfileRestClient) init(params types.EndpointParams) {
 					d.url = url
 				}
 			}
-		}(ch)
+		}(d.endpoint.Monitor(params))
 	} else {
 		d.url = params.Url
 	}

--- a/clients/metadata/device_service.go
+++ b/clients/metadata/device_service.go
@@ -53,11 +53,6 @@ func NewDeviceServiceClient(params types.EndpointParams, m clients.Endpointer) D
 
 func (d *deviceServiceRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		d.url = d.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go d.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -65,7 +60,7 @@ func (d *deviceServiceRestClient) init(params types.EndpointParams) {
 					d.url = url
 				}
 			}
-		}(ch)
+		}(d.endpoint.Monitor(params))
 	} else {
 		d.url = params.Url
 	}

--- a/clients/metadata/device_test.go
+++ b/clients/metadata/device_test.go
@@ -106,17 +106,8 @@ func TestNewDeviceClientWithConsul(t *testing.T) {
 
 type mockCoreMetaDataEndpoint struct{}
 
-func (e mockCoreMetaDataEndpoint) Monitor(params types.EndpointParams, ch chan string) {
-	switch params.ServiceKey {
-	case clients.CoreMetaDataServiceKey:
-		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48081, params.Path)
-		ch <- url
-		break
-	default:
-		ch <- ""
-	}
-}
-
-func (e mockCoreMetaDataEndpoint) Fetch(params types.EndpointParams) string {
-	return fmt.Sprintf("http://%s:%v%s", "localhost", 48081, params.Path)
+func (e mockCoreMetaDataEndpoint) Monitor(params types.EndpointParams) chan string {
+	ch := make(chan string, 1)
+	ch <- fmt.Sprintf("http://%s:%v%s", "localhost", 48081, params.Path)
+	return ch
 }

--- a/clients/metadata/provision_watcher.go
+++ b/clients/metadata/provision_watcher.go
@@ -65,11 +65,6 @@ func NewProvisionWatcherClient(params types.EndpointParams, m clients.Endpointer
 
 func (pw *provisionWatcherRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		pw.url = pw.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go pw.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -77,7 +72,7 @@ func (pw *provisionWatcherRestClient) init(params types.EndpointParams) {
 					pw.url = url
 				}
 			}
-		}(ch)
+		}(pw.endpoint.Monitor(params))
 	} else {
 		pw.url = params.Url
 	}

--- a/clients/notifications/client.go
+++ b/clients/notifications/client.go
@@ -85,11 +85,6 @@ func NewNotificationsClient(params types.EndpointParams, m clients.Endpointer) N
 
 func (n *notificationsRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		n.url = n.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go n.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -97,7 +92,7 @@ func (n *notificationsRestClient) init(params types.EndpointParams) {
 					n.url = url
 				}
 			}
-		}(ch)
+		}(n.endpoint.Monitor(params))
 	} else {
 		n.url = params.Url
 	}

--- a/clients/notifications/client_test.go
+++ b/clients/notifications/client_test.go
@@ -9,7 +9,6 @@ package notifications
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -119,20 +118,8 @@ func TestReceiveNotification(t *testing.T) {
 	nc.SendNotification(notification, context.Background())
 }
 
-type mockNotificationEndpoint struct {
-}
+type mockNotificationEndpoint struct{}
 
-func (e mockNotificationEndpoint) Monitor(params types.EndpointParams, ch chan string) {
-	switch params.ServiceKey {
-	case clients.CoreMetaDataServiceKey:
-		url := params.Url
-		ch <- url
-		break
-	default:
-		ch <- ""
-	}
-}
-
-func (e mockNotificationEndpoint) Fetch(params types.EndpointParams) string {
-	return fmt.Sprintf("http://%s:%v%s", "localhost", 48080, params.Path)
+func (e mockNotificationEndpoint) Monitor(params types.EndpointParams) chan string {
+	return make(chan string, 1)
 }

--- a/clients/scheduler/interval.go
+++ b/clients/scheduler/interval.go
@@ -60,11 +60,6 @@ func NewIntervalClient(params types.EndpointParams, m clients.Endpointer) Interv
 
 func (s *intervalRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		s.url = s.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go s.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -72,7 +67,7 @@ func (s *intervalRestClient) init(params types.EndpointParams) {
 					s.url = url
 				}
 			}
-		}(ch)
+		}(s.endpoint.Monitor(params))
 	} else {
 		s.url = params.Url
 	}

--- a/clients/scheduler/interval_action.go
+++ b/clients/scheduler/interval_action.go
@@ -59,11 +59,6 @@ func NewIntervalActionClient(params types.EndpointParams, m clients.Endpointer) 
 
 func (s *intervalActionRestClient) init(params types.EndpointParams) {
 	if params.UseRegistry {
-		//Fetch URL in real time for immediate use
-		s.url = s.endpoint.Fetch(params)
-		//Set up refresh interval to keep URL current
-		ch := make(chan string, 1)
-		go s.endpoint.Monitor(params, ch)
 		go func(ch chan string) {
 			for {
 				select {
@@ -71,7 +66,7 @@ func (s *intervalActionRestClient) init(params types.EndpointParams) {
 					s.url = url
 				}
 			}
-		}(ch)
+		}(s.endpoint.Monitor(params))
 	} else {
 		s.url = params.Url
 	}


### PR DESCRIPTION
Alternate Endpointer contract implementation that encapsulates go routine and stream creation and avoids exposing recently added Fetch() method.

Fixes: https://github.com/edgexfoundry/go-mod-core-contracts/issues/183

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>