### PR TITLE
Add minimum supported Go version 1.12 to go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/ugorji/go v1.1.4
 )
+
+go 1.12


### PR DESCRIPTION
Fix #161 

Locally, I upgraded to Go `1.12`, and tested it out via `Makefile`.