### PR TITLE
Client init functions now use provided URL as default in all cases

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -49,6 +49,8 @@ func NewCommandClient(params types.EndpointParams, m clients.Endpointer) Command
 }
 
 func (c *commandRestClient) init(params types.EndpointParams) {
+	c.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -58,8 +60,6 @@ func (c *commandRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(c.endpoint.Monitor(params))
-	} else {
-		c.url = params.Url
 	}
 }
 

--- a/clients/coredata/event.go
+++ b/clients/coredata/event.go
@@ -79,6 +79,8 @@ func NewEventClient(params types.EndpointParams, m clients.Endpointer) EventClie
 }
 
 func (e *eventRestClient) init(params types.EndpointParams) {
+	e.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -88,8 +90,6 @@ func (e *eventRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(e.endpoint.Monitor(params))
-	} else {
-		e.url = params.Url
 	}
 }
 

--- a/clients/coredata/reading.go
+++ b/clients/coredata/reading.go
@@ -69,6 +69,8 @@ func NewReadingClient(params types.EndpointParams, m clients.Endpointer) Reading
 }
 
 func (r *readingRestClient) init(params types.EndpointParams) {
+	r.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -78,8 +80,6 @@ func (r *readingRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(r.endpoint.Monitor(params))
-	} else {
-		r.url = params.Url
 	}
 }
 

--- a/clients/coredata/value_descriptor.go
+++ b/clients/coredata/value_descriptor.go
@@ -66,6 +66,8 @@ func NewValueDescriptorClient(params types.EndpointParams, m clients.Endpointer)
 }
 
 func (d *valueDescriptorRestClient) init(params types.EndpointParams) {
+	d.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -75,8 +77,6 @@ func (d *valueDescriptorRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(d.endpoint.Monitor(params))
-	} else {
-		d.url = params.Url
 	}
 }
 

--- a/clients/general/client.go
+++ b/clients/general/client.go
@@ -45,6 +45,8 @@ func NewGeneralClient(params types.EndpointParams, m clients.Endpointer) General
 }
 
 func (gc *generalRestClient) init(params types.EndpointParams) {
+	gc.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -54,8 +56,6 @@ func (gc *generalRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(gc.endpoint.Monitor(params))
-	} else {
-		gc.url = params.Url
 	}
 }
 

--- a/clients/metadata/addressable.go
+++ b/clients/metadata/addressable.go
@@ -56,6 +56,8 @@ func NewAddressableClient(params types.EndpointParams, m clients.Endpointer) Add
 }
 
 func (a *addressableRestClient) init(params types.EndpointParams) {
+	a.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -65,8 +67,6 @@ func (a *addressableRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(a.endpoint.Monitor(params))
-	} else {
-		a.url = params.Url
 	}
 }
 

--- a/clients/metadata/command.go
+++ b/clients/metadata/command.go
@@ -56,6 +56,8 @@ func NewCommandClient(params types.EndpointParams, m clients.Endpointer) Command
 }
 
 func (c *commandRestClient) init(params types.EndpointParams) {
+	c.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -65,8 +67,6 @@ func (c *commandRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(c.endpoint.Monitor(params))
-	} else {
-		c.url = params.Url
 	}
 }
 

--- a/clients/metadata/device.go
+++ b/clients/metadata/device.go
@@ -86,6 +86,8 @@ func NewDeviceClient(params types.EndpointParams, m clients.Endpointer) DeviceCl
 }
 
 func (d *deviceRestClient) init(params types.EndpointParams) {
+	d.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -95,8 +97,6 @@ func (d *deviceRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(d.endpoint.Monitor(params))
-	} else {
-		d.url = params.Url
 	}
 }
 

--- a/clients/metadata/device_profile.go
+++ b/clients/metadata/device_profile.go
@@ -62,6 +62,8 @@ func NewDeviceProfileClient(params types.EndpointParams, m clients.Endpointer) D
 }
 
 func (d *deviceProfileRestClient) init(params types.EndpointParams) {
+	d.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -71,8 +73,6 @@ func (d *deviceProfileRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(d.endpoint.Monitor(params))
-	} else {
-		d.url = params.Url
 	}
 }
 

--- a/clients/metadata/device_service.go
+++ b/clients/metadata/device_service.go
@@ -52,6 +52,8 @@ func NewDeviceServiceClient(params types.EndpointParams, m clients.Endpointer) D
 }
 
 func (d *deviceServiceRestClient) init(params types.EndpointParams) {
+	d.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -61,8 +63,6 @@ func (d *deviceServiceRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(d.endpoint.Monitor(params))
-	} else {
-		d.url = params.Url
 	}
 }
 

--- a/clients/metadata/provision_watcher.go
+++ b/clients/metadata/provision_watcher.go
@@ -64,6 +64,8 @@ func NewProvisionWatcherClient(params types.EndpointParams, m clients.Endpointer
 }
 
 func (pw *provisionWatcherRestClient) init(params types.EndpointParams) {
+	pw.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -73,8 +75,6 @@ func (pw *provisionWatcherRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(pw.endpoint.Monitor(params))
-	} else {
-		pw.url = params.Url
 	}
 }
 

--- a/clients/notifications/client.go
+++ b/clients/notifications/client.go
@@ -84,6 +84,8 @@ func NewNotificationsClient(params types.EndpointParams, m clients.Endpointer) N
 }
 
 func (n *notificationsRestClient) init(params types.EndpointParams) {
+	n.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -93,8 +95,6 @@ func (n *notificationsRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(n.endpoint.Monitor(params))
-	} else {
-		n.url = params.Url
 	}
 }
 

--- a/clients/scheduler/interval.go
+++ b/clients/scheduler/interval.go
@@ -59,6 +59,8 @@ func NewIntervalClient(params types.EndpointParams, m clients.Endpointer) Interv
 }
 
 func (s *intervalRestClient) init(params types.EndpointParams) {
+	s.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -68,8 +70,6 @@ func (s *intervalRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(s.endpoint.Monitor(params))
-	} else {
-		s.url = params.Url
 	}
 }
 

--- a/clients/scheduler/interval_action.go
+++ b/clients/scheduler/interval_action.go
@@ -58,6 +58,8 @@ func NewIntervalActionClient(params types.EndpointParams, m clients.Endpointer) 
 }
 
 func (s *intervalActionRestClient) init(params types.EndpointParams) {
+	s.url = params.Url
+
 	if params.UseRegistry {
 		go func(ch chan string) {
 			for {
@@ -67,8 +69,6 @@ func (s *intervalActionRestClient) init(params types.EndpointParams) {
 				}
 			}
 		}(s.endpoint.Monitor(params))
-	} else {
-		s.url = params.Url
 	}
 }
 


### PR DESCRIPTION
This behavior was noticed while investigating https://github.com/edgexfoundry/edgex-go/issues/2237. If the client's init function is called just-in-time and a registry is used, a race condition between the URL update and the service call occurs and the service call wins in all observed cases, and the call will proceed with an empty URL for the service endpoint in the client. This change attempts to ensure that there is always *some* URL in the service client, even if that URL is not the latest (because we haven't had a chance to get an update from the gofunc yet)

Signed-off-by: Brandon Forster <brandonforster@gmail.com>