### PR TITLE
Refactor Client Code, part 4/7: command

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -86,10 +86,10 @@ func (cc *commandRestClient) PutDeviceCommandByNames(
 	body string,
 	ctx context.Context) (string, error) {
 
-	url, err := cc.urlClient.Prefix()
+	urlPrefix, err := cc.urlClient.Prefix()
 	if err != nil {
 		return "", err
 	}
 
-	return clients.PutRequest(url+"/name/"+deviceName+"/command/"+commandName, []byte(body), ctx)
+	return clients.PutRequest(urlPrefix+"/name/"+deviceName+"/command/"+commandName, []byte(body), ctx)
 }

--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -23,9 +23,10 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient"
 )
 
-// The CommandClient interface defines interactions with the EdgeX Core Command microservice.
+// CommandClient interface defines interactions with the EdgeX Core Command microservice.
 type CommandClient interface {
 	// Get issues a GET command targeting the specified device, using the specified command id
 	Get(deviceId string, commandId string, ctx context.Context) (string, error)
@@ -38,46 +39,57 @@ type CommandClient interface {
 }
 
 type commandRestClient struct {
-	url      string
-	endpoint interfaces.Endpointer
+	urlClient interfaces.URLClient
 }
 
 // NewCommandClient creates an instance of CommandClient
 func NewCommandClient(params types.EndpointParams, m interfaces.Endpointer) CommandClient {
-	c := commandRestClient{endpoint: m}
-	c.init(params)
-	return &c
-}
-
-func (c *commandRestClient) init(params types.EndpointParams) {
-	if params.UseRegistry {
-		go func(ch chan string) {
-			for {
-				select {
-				case url := <-ch:
-					c.url = url
-				}
-			}
-		}(c.endpoint.Monitor(params))
-	} else {
-		c.url = params.Url
-	}
+	return &commandRestClient{urlClient: urlclient.New(params, m)}
 }
 
 func (cc *commandRestClient) Get(deviceId string, commandId string, ctx context.Context) (string, error) {
-	body, err := clients.GetRequest(cc.url+"/"+deviceId+"/command/"+commandId, ctx)
+	url, err := cc.urlClient.Prefix()
+	if err != nil {
+		return "", err
+	}
+
+	body, err := clients.GetRequest(url+"/"+deviceId+"/command/"+commandId, ctx)
 	return string(body), err
 }
 
 func (cc *commandRestClient) Put(deviceId string, commandId string, body string, ctx context.Context) (string, error) {
-	return clients.PutRequest(cc.url+"/"+deviceId+"/command/"+commandId, []byte(body), ctx)
+	url, err := cc.urlClient.Prefix()
+	if err != nil {
+		return "", err
+	}
+
+	return clients.PutRequest(url+"/"+deviceId+"/command/"+commandId, []byte(body), ctx)
 }
 
-func (cc *commandRestClient) GetDeviceCommandByNames(deviceName string, commandName string, ctx context.Context) (string, error) {
-	body, err := clients.GetRequest(cc.url+"/name/"+deviceName+"/command/"+commandName, ctx)
+func (cc *commandRestClient) GetDeviceCommandByNames(
+	deviceName string,
+	commandName string,
+	ctx context.Context) (string, error) {
+
+	url, err := cc.urlClient.Prefix()
+	if err != nil {
+		return "", err
+	}
+
+	body, err := clients.GetRequest(url+"/name/"+deviceName+"/command/"+commandName, ctx)
 	return string(body), err
 }
 
-func (cc *commandRestClient) PutDeviceCommandByNames(deviceName string, commandName string, body string, ctx context.Context) (string, error) {
-	return clients.PutRequest(cc.url+"/name/"+deviceName+"/command/"+commandName, []byte(body), ctx)
+func (cc *commandRestClient) PutDeviceCommandByNames(
+	deviceName string,
+	commandName string,
+	body string,
+	ctx context.Context) (string, error) {
+
+	url, err := cc.urlClient.Prefix()
+	if err != nil {
+		return "", err
+	}
+
+	return clients.PutRequest(url+"/name/"+deviceName+"/command/"+commandName, []byte(body), ctx)
 }

--- a/clients/coredata/event.go
+++ b/clients/coredata/event.go
@@ -15,9 +15,7 @@
  *
  *******************************************************************************/
 
-/*
-Package coredata provides clients used for integration with the core-data service.
-*/
+// coredata provides clients used for integration with the core-data service.
 package coredata
 
 import (
@@ -29,6 +27,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -50,7 +49,7 @@ type EventClient interface {
 	EventsForDeviceAndValueDescriptor(deviceId string, vd string, limit int, ctx context.Context) ([]models.Event, error)
 	// Add will post a new event
 	Add(event *models.Event, ctx context.Context) (string, error)
-	//AddBytes posts a new event using an array of bytes, supporting encoding of the event by the caller.
+	// AddBytes posts a new event using an array of bytes, supporting encoding of the event by the caller.
 	AddBytes(event []byte, ctx context.Context) (string, error)
 	// DeleteForDevice will delete events by the specified device name
 	DeleteForDevice(id string, ctx context.Context) error
@@ -68,37 +67,24 @@ type EventClient interface {
 }
 
 type eventRestClient struct {
-	url      string
-	endpoint interfaces.Endpointer
+	urlClient interfaces.URLClient
 }
 
 // NewEventClient creates an instance of EventClient
 func NewEventClient(params types.EndpointParams, m interfaces.Endpointer) EventClient {
-	e := eventRestClient{endpoint: m}
-	e.init(params)
-	return &e
-}
-
-func (e *eventRestClient) init(params types.EndpointParams) {
-	if params.UseRegistry {
-		go func(ch chan string) {
-			for {
-				select {
-				case url := <-ch:
-					e.url = url
-				}
-			}
-		}(e.endpoint.Monitor(params))
-	} else {
-		e.url = params.Url
-	}
+	return &eventRestClient{urlClient: urlclient.New(params, m)}
 }
 
 // Helper method to request and decode an event slice
-func (e *eventRestClient) requestEventSlice(url string, ctx context.Context) ([]models.Event, error) {
-	data, err := clients.GetRequest(url, ctx)
+func (e *eventRestClient) requestEventSlice(urlSuffix string, ctx context.Context) ([]models.Event, error) {
+	urlPrefix, err := e.urlClient.Prefix()
 	if err != nil {
-		return []models.Event{}, err
+		return nil, err
+	}
+
+	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	eSlice := make([]models.Event, 0)
@@ -107,8 +93,13 @@ func (e *eventRestClient) requestEventSlice(url string, ctx context.Context) ([]
 }
 
 // Helper method to request and decode an event
-func (e *eventRestClient) requestEvent(url string, ctx context.Context) (models.Event, error) {
-	data, err := clients.GetRequest(url, ctx)
+func (e *eventRestClient) requestEvent(urlSuffix string, ctx context.Context) (models.Event, error) {
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return models.Event{}, err
+	}
+
+	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
 	if err != nil {
 		return models.Event{}, err
 	}
@@ -119,65 +110,117 @@ func (e *eventRestClient) requestEvent(url string, ctx context.Context) (models.
 }
 
 func (e *eventRestClient) Events(ctx context.Context) ([]models.Event, error) {
-	return e.requestEventSlice(e.url, ctx)
+	return e.requestEventSlice("", ctx)
 }
 
 func (e *eventRestClient) Event(id string, ctx context.Context) (models.Event, error) {
-	return e.requestEvent(e.url+"/"+id, ctx)
+	return e.requestEvent("/"+id, ctx)
 }
 
 func (e *eventRestClient) EventCount(ctx context.Context) (int, error) {
-	return clients.CountRequest(e.url+"/count", ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return 0, err
+	}
+
+	return clients.CountRequest(urlPrefix+"/count", ctx)
 }
 
 func (e *eventRestClient) EventCountForDevice(deviceId string, ctx context.Context) (int, error) {
-	return clients.CountRequest(e.url+"/count/"+url.QueryEscape(deviceId), ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return 0, err
+	}
+
+	return clients.CountRequest(urlPrefix+"/count/"+url.QueryEscape(deviceId), ctx)
 }
 
 func (e *eventRestClient) EventsForDevice(deviceId string, limit int, ctx context.Context) ([]models.Event, error) {
-	return e.requestEventSlice(e.url+"/device/"+url.QueryEscape(deviceId)+"/"+strconv.Itoa(limit), ctx)
+	return e.requestEventSlice("/device/"+url.QueryEscape(deviceId)+"/"+strconv.Itoa(limit), ctx)
 }
 
 func (e *eventRestClient) EventsForInterval(start int, end int, limit int, ctx context.Context) ([]models.Event, error) {
-	return e.requestEventSlice(e.url+"/"+strconv.Itoa(start)+"/"+strconv.Itoa(end)+"/"+strconv.Itoa(limit), ctx)
+	return e.requestEventSlice("/"+strconv.Itoa(start)+"/"+strconv.Itoa(end)+"/"+strconv.Itoa(limit), ctx)
 }
 
-func (e *eventRestClient) EventsForDeviceAndValueDescriptor(deviceId string, vd string, limit int, ctx context.Context) ([]models.Event, error) {
-	return e.requestEventSlice(e.url+"/device/"+url.QueryEscape(deviceId)+"/valuedescriptor/"+url.QueryEscape(vd)+"/"+strconv.Itoa(limit), ctx)
+func (e *eventRestClient) EventsForDeviceAndValueDescriptor(
+	deviceId string,
+	vd string,
+	limit int,
+	ctx context.Context) ([]models.Event, error) {
+
+	return e.requestEventSlice(
+		"/device/"+url.QueryEscape(deviceId)+"/valuedescriptor/"+url.QueryEscape(vd)+"/"+strconv.Itoa(limit), ctx)
 }
 
 func (e *eventRestClient) Add(event *models.Event, ctx context.Context) (string, error) {
 	content := clients.FromContext(clients.ContentType, ctx)
+
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return "", err
+	}
+
 	if content == clients.ContentTypeCBOR {
-		return clients.PostRequest(e.url, event.CBOR(), ctx)
+		return clients.PostRequest(urlPrefix, event.CBOR(), ctx)
 	} else {
-		return clients.PostJsonRequest(e.url, event, ctx)
+		return clients.PostJsonRequest(urlPrefix, event, ctx)
 	}
 }
 
 func (e *eventRestClient) AddBytes(event []byte, ctx context.Context) (string, error) {
-	return clients.PostRequest(e.url, event, ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return "", err
+	}
+
+	return clients.PostRequest(urlPrefix, event, ctx)
 }
 
 func (e *eventRestClient) Delete(id string, ctx context.Context) error {
-	return clients.DeleteRequest(e.url+"/id/"+id, ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return err
+	}
+
+	return clients.DeleteRequest(urlPrefix+"/id/"+id, ctx)
 }
 
 func (e *eventRestClient) DeleteForDevice(deviceId string, ctx context.Context) error {
-	return clients.DeleteRequest(e.url+"/device/"+url.QueryEscape(deviceId), ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return err
+	}
+
+	return clients.DeleteRequest(urlPrefix+"/device/"+url.QueryEscape(deviceId), ctx)
 }
 
 func (e *eventRestClient) DeleteOld(age int, ctx context.Context) error {
-	return clients.DeleteRequest(e.url+"/removeold/age/"+strconv.Itoa(age), ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return err
+	}
+
+	return clients.DeleteRequest(urlPrefix+"/removeold/age/"+strconv.Itoa(age), ctx)
 }
 
 func (e *eventRestClient) MarkPushed(id string, ctx context.Context) error {
-	_, err := clients.PutRequest(e.url+"/id/"+id, nil, ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return err
+	}
+
+	_, err = clients.PutRequest(urlPrefix+"/id/"+id, nil, ctx)
 	return err
 }
 
 func (e *eventRestClient) MarkPushedByChecksum(checksum string, ctx context.Context) error {
-	_, err := clients.PutRequest(e.url+"/checksum/"+checksum, nil, ctx)
+	urlPrefix, err := e.urlClient.Prefix()
+	if err != nil {
+		return err
+	}
+
+	_, err = clients.PutRequest(urlPrefix+"/checksum/"+checksum, nil, ctx)
 	return err
 }
 

--- a/clients/coredata/event.go
+++ b/clients/coredata/event.go
@@ -79,17 +79,21 @@ func NewEventClient(params types.EndpointParams, m interfaces.Endpointer) EventC
 func (e *eventRestClient) requestEventSlice(urlSuffix string, ctx context.Context) ([]models.Event, error) {
 	urlPrefix, err := e.urlClient.Prefix()
 	if err != nil {
-		return nil, err
+		return []models.Event{}, err
 	}
 
 	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
 	if err != nil {
-		return nil, err
+		return []models.Event{}, err
 	}
 
 	eSlice := make([]models.Event, 0)
 	err = json.Unmarshal(data, &eSlice)
-	return eSlice, err
+	if err != nil {
+		return []models.Event{}, err
+	}
+
+	return eSlice, nil
 }
 
 // Helper method to request and decode an event
@@ -150,7 +154,13 @@ func (e *eventRestClient) EventsForDeviceAndValueDescriptor(
 	ctx context.Context) ([]models.Event, error) {
 
 	return e.requestEventSlice(
-		"/device/"+url.QueryEscape(deviceId)+"/valuedescriptor/"+url.QueryEscape(vd)+"/"+strconv.Itoa(limit), ctx)
+		"/device/"+
+			url.QueryEscape(deviceId)+
+			"/valuedescriptor/"+
+			url.QueryEscape(vd)+
+			"/"+strconv.Itoa(limit),
+		ctx,
+	)
 }
 
 func (e *eventRestClient) Add(event *models.Event, ctx context.Context) (string, error) {

--- a/clients/coredata/event_test.go
+++ b/clients/coredata/event_test.go
@@ -24,11 +24,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ugorji/go/codec"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/ugorji/go/codec"
 )
 
 const (

--- a/clients/coredata/event_test.go
+++ b/clients/coredata/event_test.go
@@ -23,12 +23,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
+
+	"github.com/ugorji/go/codec"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
-	"github.com/ugorji/go/codec"
 )
 
 const (
@@ -182,11 +182,12 @@ func TestNewEventClientWithConsul(t *testing.T) {
 		t.Error("ec is not of expected type")
 	}
 
-	time.Sleep(25 * time.Millisecond)
-	if len(r.url) == 0 {
+	url, err := r.urlClient.Prefix()
+
+	if err != nil {
 		t.Error("url was not initialized")
-	} else if r.url != deviceUrl {
-		t.Errorf("unexpected url value %s", r.url)
+	} else if url != deviceUrl {
+		t.Errorf("unexpected url value %s", url)
 	}
 }
 

--- a/clients/coredata/reading.go
+++ b/clients/coredata/reading.go
@@ -133,7 +133,13 @@ func (r *readingRestClient) ReadingsForNameAndDevice(
 	ctx context.Context) ([]models.Reading, error) {
 
 	return r.requestReadingSlice(
-		"/name/"+url.QueryEscape(name)+"/device/"+url.QueryEscape(deviceId)+"/"+strconv.Itoa(limit), ctx)
+		"/name/"+
+			url.QueryEscape(name)+
+			"/device/"+
+			url.QueryEscape(deviceId)+
+			"/"+strconv.Itoa(limit),
+		ctx,
+	)
 }
 
 func (r *readingRestClient) ReadingsForName(name string, limit int, ctx context.Context) ([]models.Reading, error) {

--- a/clients/coredata/reading_test.go
+++ b/clients/coredata/reading_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
@@ -116,10 +115,11 @@ func TestNewReadingClientWithConsul(t *testing.T) {
 		t.Error("rc is not of expected type")
 	}
 
-	time.Sleep(25 * time.Millisecond)
-	if len(r.url) == 0 {
+	url, err := r.urlClient.Prefix()
+
+	if err != nil {
 		t.Error("url was not initialized")
-	} else if r.url != deviceUrl {
-		t.Errorf("unexpected url value %s", r.url)
+	} else if url != deviceUrl {
+		t.Errorf("unexpected url value %s", url)
 	}
 }

--- a/clients/coredata/value_descriptor_test.go
+++ b/clients/coredata/value_descriptor_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
@@ -201,10 +200,11 @@ func TestNewValueDescriptorClientWithConsul(t *testing.T) {
 		t.Error("vdc is not of expected type")
 	}
 
-	time.Sleep(25 * time.Millisecond)
-	if len(r.url) == 0 {
+	url, err := r.urlClient.Prefix()
+
+	if err != nil {
 		t.Error("url was not initialized")
-	} else if r.url != deviceUrl {
-		t.Errorf("unexpected url value %s", r.url)
+	} else if url != deviceUrl {
+		t.Errorf("unexpected url value %s", url)
 	}
 }

--- a/clients/urlclient/factory_test.go
+++ b/clients/urlclient/factory_test.go
@@ -15,7 +15,6 @@
 package urlclient
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
@@ -37,12 +36,4 @@ func TestClientFactoryRegistry(t *testing.T) {
 	if !isRegistryClient {
 		t.Fatalf("expected type %T, found %T", registryClient{}, actualClient)
 	}
-}
-
-type mockEndpoint struct{}
-
-func (e mockEndpoint) Monitor(_ types.EndpointParams) chan string {
-	ch := make(chan string, 1)
-	ch <- fmt.Sprint("http://domain.com")
-	return ch
 }

--- a/clients/urlclient/local_test.go
+++ b/clients/urlclient/local_test.go
@@ -15,7 +15,6 @@
 package urlclient
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
@@ -27,20 +26,13 @@ func TestNewLocalClient(t *testing.T) {
 	if actualClient == nil {
 		t.Fatal("nil returned from newLocalClient")
 	}
-
-	expectedType := reflect.TypeOf(&localClient{})
-	clientType := reflect.TypeOf(actualClient)
-
-	if clientType != expectedType {
-		t.Fatalf("expected type %T, found %T", expectedType, actualClient)
-	}
 }
 
 func TestLocalClient_URLPrefix(t *testing.T) {
 	expectedURL := "http://domain.com"
-	client := newLocalClient(types.EndpointParams{Url: expectedURL})
+	urlClient := newLocalClient(types.EndpointParams{Url: expectedURL})
 
-	actualURL, err := client.Prefix()
+	actualURL, err := urlClient.Prefix()
 
 	if err != nil {
 		t.Fatalf("unexpected error %s", err.Error())

--- a/clients/urlclient/registry_test.go
+++ b/clients/urlclient/registry_test.go
@@ -84,7 +84,7 @@ func TestRegistryClient_URLPrefix_TimedOut(t *testing.T) {
 	}
 }
 
-type mockEndpoint struct{
+type mockEndpoint struct {
 	ch chan string
 }
 

--- a/clients/urlclient/registry_test.go
+++ b/clients/urlclient/registry_test.go
@@ -48,10 +48,14 @@ func TestRegistryClient_URLPrefix(t *testing.T) {
 func TestRegistryClient_URLPrefixInitialized(t *testing.T) {
 	expectedURL := "http://domain.com"
 	urlClient := newRegistryClient(types.EndpointParams{}, mockEndpoint{}, 100)
-	urlClient.initialized = true
-	urlClient.url = expectedURL
 
+	// set up prerequisite condition
 	actualURL, err := urlClient.Prefix()
+	if err != nil {
+		t.Fatalf("unexpected error in precondition %s", err.Error())
+	}
+
+	actualURL, err = urlClient.Prefix()
 
 	if err != nil {
 		t.Fatalf("unexpected error %s", err.Error())

--- a/clients/urlclient/registry_test.go
+++ b/clients/urlclient/registry_test.go
@@ -16,7 +16,6 @@ package urlclient
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -29,20 +28,13 @@ func TestNewRegistryClient(t *testing.T) {
 	if actualClient == nil {
 		t.Fatal("nil returned from newRegistryClient")
 	}
-
-	expectedType := reflect.TypeOf(&registryClient{})
-	clientType := reflect.TypeOf(actualClient)
-
-	if clientType != expectedType {
-		t.Fatalf("expected type %T, found %T", expectedType, actualClient)
-	}
 }
 
 func TestRegistryClient_URLPrefix(t *testing.T) {
 	expectedURL := "http://domain.com"
-	client := newRegistryClient(types.EndpointParams{}, mockEndpoint{}, 100)
+	urlClient := newRegistryClient(types.EndpointParams{}, mockEndpoint{}, 100)
 
-	actualURL, err := client.Prefix()
+	actualURL, err := urlClient.Prefix()
 
 	if err != nil {
 		t.Fatalf("unexpected error %s", err.Error())
@@ -55,11 +47,11 @@ func TestRegistryClient_URLPrefix(t *testing.T) {
 
 func TestRegistryClient_URLPrefixInitialized(t *testing.T) {
 	expectedURL := "http://domain.com"
-	client := newRegistryClient(types.EndpointParams{}, mockEndpoint{}, 100)
-	client.initialized = true
-	client.url = expectedURL
+	urlClient := newRegistryClient(types.EndpointParams{}, mockEndpoint{}, 100)
+	urlClient.initialized = true
+	urlClient.url = expectedURL
 
-	actualURL, err := client.Prefix()
+	actualURL, err := urlClient.Prefix()
 
 	if err != nil {
 		t.Fatalf("unexpected error %s", err.Error())
@@ -71,9 +63,9 @@ func TestRegistryClient_URLPrefixInitialized(t *testing.T) {
 }
 
 func TestRegistryClient_URLPrefix_TimedOut(t *testing.T) {
-	client := newRegistryClient(types.EndpointParams{}, mockTimeoutEndpoint{}, 1)
+	urlClient := newRegistryClient(types.EndpointParams{}, mockTimeoutEndpoint{}, 1)
 
-	actualURL, err := client.Prefix()
+	actualURL, err := urlClient.Prefix()
 
 	if err == nil || actualURL != "" {
 		t.Fatal("expected error")


### PR DESCRIPTION
This PR is the fourth part of several working on #196.

This PR refactors all of core-command's client methods.