### PR TITLE
Centralize URLClient logic to the Request package

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -48,8 +48,7 @@ func NewCommandClient(params types.EndpointParams, m interfaces.Endpointer) Comm
 }
 
 func (cc *commandRestClient) Get(deviceId string, commandId string, ctx context.Context) (string, error) {
-	body, err := clients.GetRequest("/"+deviceId+"/command/"+commandId, ctx, cc.urlClient)
-	return string(body), err
+	return cc.getRequestJSONBody("/"+deviceId+"/command/"+commandId, ctx)
 }
 
 func (cc *commandRestClient) Put(deviceId string, commandId string, body string, ctx context.Context) (string, error) {
@@ -61,12 +60,7 @@ func (cc *commandRestClient) GetDeviceCommandByNames(
 	commandName string,
 	ctx context.Context) (string, error) {
 
-	body, err := clients.GetRequest("/name/"+deviceName+"/command/"+commandName, ctx, cc.urlClient)
-	if err != nil {
-		return "", err
-	}
-
-	return string(body), nil
+	return cc.getRequestJSONBody("/name/"+deviceName+"/command/"+commandName, ctx)
 }
 
 func (cc *commandRestClient) PutDeviceCommandByNames(
@@ -76,4 +70,10 @@ func (cc *commandRestClient) PutDeviceCommandByNames(
 	ctx context.Context) (string, error) {
 
 	return clients.PutRequest("/name/"+deviceName+"/command/"+commandName, []byte(body), ctx, cc.urlClient)
+}
+
+func (cc *commandRestClient) getRequestJSONBody(urlSuffix string, ctx context.Context) (string, error) {
+	body, err := clients.GetRequest(urlSuffix, ctx, cc.urlClient)
+
+	return string(body), err
 }

--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -48,22 +48,12 @@ func NewCommandClient(params types.EndpointParams, m interfaces.Endpointer) Comm
 }
 
 func (cc *commandRestClient) Get(deviceId string, commandId string, ctx context.Context) (string, error) {
-	url, err := cc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	body, err := clients.GetRequest(url+"/"+deviceId+"/command/"+commandId, ctx)
+	body, err := clients.GetRequest("/"+deviceId+"/command/"+commandId, ctx, cc.urlClient)
 	return string(body), err
 }
 
 func (cc *commandRestClient) Put(deviceId string, commandId string, body string, ctx context.Context) (string, error) {
-	url, err := cc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PutRequest(url+"/"+deviceId+"/command/"+commandId, []byte(body), ctx)
+	return clients.PutRequest("/"+deviceId+"/command/"+commandId, []byte(body), ctx, cc.urlClient)
 }
 
 func (cc *commandRestClient) GetDeviceCommandByNames(
@@ -71,13 +61,12 @@ func (cc *commandRestClient) GetDeviceCommandByNames(
 	commandName string,
 	ctx context.Context) (string, error) {
 
-	url, err := cc.urlClient.Prefix()
+	body, err := clients.GetRequest("/name/"+deviceName+"/command/"+commandName, ctx, cc.urlClient)
 	if err != nil {
 		return "", err
 	}
 
-	body, err := clients.GetRequest(url+"/name/"+deviceName+"/command/"+commandName, ctx)
-	return string(body), err
+	return string(body), nil
 }
 
 func (cc *commandRestClient) PutDeviceCommandByNames(
@@ -86,10 +75,5 @@ func (cc *commandRestClient) PutDeviceCommandByNames(
 	body string,
 	ctx context.Context) (string, error) {
 
-	urlPrefix, err := cc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PutRequest(urlPrefix+"/name/"+deviceName+"/command/"+commandName, []byte(body), ctx)
+	return clients.PutRequest("/name/"+deviceName+"/command/"+commandName, []byte(body), ctx, cc.urlClient)
 }

--- a/clients/coredata/event.go
+++ b/clients/coredata/event.go
@@ -77,12 +77,7 @@ func NewEventClient(params types.EndpointParams, m interfaces.Endpointer) EventC
 
 // Helper method to request and decode an event slice
 func (e *eventRestClient) requestEventSlice(urlSuffix string, ctx context.Context) ([]models.Event, error) {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return []models.Event{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, e.urlClient)
 	if err != nil {
 		return []models.Event{}, err
 	}
@@ -98,12 +93,7 @@ func (e *eventRestClient) requestEventSlice(urlSuffix string, ctx context.Contex
 
 // Helper method to request and decode an event
 func (e *eventRestClient) requestEvent(urlSuffix string, ctx context.Context) (models.Event, error) {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return models.Event{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, e.urlClient)
 	if err != nil {
 		return models.Event{}, err
 	}
@@ -122,21 +112,11 @@ func (e *eventRestClient) Event(id string, ctx context.Context) (models.Event, e
 }
 
 func (e *eventRestClient) EventCount(ctx context.Context) (int, error) {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return 0, err
-	}
-
-	return clients.CountRequest(urlPrefix+"/count", ctx)
+	return clients.CountRequest("/count", ctx, e.urlClient)
 }
 
 func (e *eventRestClient) EventCountForDevice(deviceId string, ctx context.Context) (int, error) {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return 0, err
-	}
-
-	return clients.CountRequest(urlPrefix+"/count/"+url.QueryEscape(deviceId), ctx)
+	return clients.CountRequest("/count/"+url.QueryEscape(deviceId), ctx, e.urlClient)
 }
 
 func (e *eventRestClient) EventsForDevice(deviceId string, limit int, ctx context.Context) ([]models.Event, error) {
@@ -166,71 +146,36 @@ func (e *eventRestClient) EventsForDeviceAndValueDescriptor(
 func (e *eventRestClient) Add(event *models.Event, ctx context.Context) (string, error) {
 	content := clients.FromContext(clients.ContentType, ctx)
 
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
 	if content == clients.ContentTypeCBOR {
-		return clients.PostRequest(urlPrefix, event.CBOR(), ctx)
+		return clients.PostRequest("", event.CBOR(), ctx, e.urlClient)
 	} else {
-		return clients.PostJsonRequest(urlPrefix, event, ctx)
+		return clients.PostJsonRequest("", event, ctx, e.urlClient)
 	}
 }
 
 func (e *eventRestClient) AddBytes(event []byte, ctx context.Context) (string, error) {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostRequest(urlPrefix, event, ctx)
+	return clients.PostRequest("", event, ctx, e.urlClient)
 }
 
 func (e *eventRestClient) Delete(id string, ctx context.Context) error {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, e.urlClient)
 }
 
 func (e *eventRestClient) DeleteForDevice(deviceId string, ctx context.Context) error {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/device/"+url.QueryEscape(deviceId), ctx)
+	return clients.DeleteRequest("/device/"+url.QueryEscape(deviceId), ctx, e.urlClient)
 }
 
 func (e *eventRestClient) DeleteOld(age int, ctx context.Context) error {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/removeold/age/"+strconv.Itoa(age), ctx)
+	return clients.DeleteRequest("/removeold/age/"+strconv.Itoa(age), ctx, e.urlClient)
 }
 
 func (e *eventRestClient) MarkPushed(id string, ctx context.Context) error {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(urlPrefix+"/id/"+id, nil, ctx)
+	_, err := clients.PutRequest("/id/"+id, nil, ctx, e.urlClient)
 	return err
 }
 
 func (e *eventRestClient) MarkPushedByChecksum(checksum string, ctx context.Context) error {
-	urlPrefix, err := e.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(urlPrefix+"/checksum/"+checksum, nil, ctx)
+	_, err := clients.PutRequest("/checksum/"+checksum, nil, ctx, e.urlClient)
 	return err
 }
 

--- a/clients/coredata/reading.go
+++ b/clients/coredata/reading.go
@@ -69,12 +69,7 @@ func NewReadingClient(params types.EndpointParams, m interfaces.Endpointer) Read
 
 // Helper method to request and decode a reading slice
 func (r *readingRestClient) requestReadingSlice(urlSuffix string, ctx context.Context) ([]models.Reading, error) {
-	urlPrefix, err := r.urlClient.Prefix()
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, r.urlClient)
 	if err != nil {
 		return []models.Reading{}, err
 	}
@@ -86,12 +81,7 @@ func (r *readingRestClient) requestReadingSlice(urlSuffix string, ctx context.Co
 
 // Helper method to request and decode a reading
 func (r *readingRestClient) requestReading(urlSuffix string, ctx context.Context) (models.Reading, error) {
-	urlPrefix, err := r.urlClient.Prefix()
-	if err != nil {
-		return models.Reading{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, r.urlClient)
 	if err != nil {
 		return models.Reading{}, err
 	}
@@ -110,12 +100,7 @@ func (r *readingRestClient) Reading(id string, ctx context.Context) (models.Read
 }
 
 func (r *readingRestClient) ReadingCount(ctx context.Context) (int, error) {
-	urlPrefix, err := r.urlClient.Prefix()
-	if err != nil {
-		return 0, err
-	}
-
-	return clients.CountRequest(urlPrefix+"/count", ctx)
+	return clients.CountRequest("/count", ctx, r.urlClient)
 }
 
 func (r *readingRestClient) ReadingsForDevice(
@@ -176,19 +161,9 @@ func (r *readingRestClient) ReadingsForInterval(
 }
 
 func (r *readingRestClient) Add(reading *models.Reading, ctx context.Context) (string, error) {
-	urlPrefix, err := r.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(urlPrefix, reading, ctx)
+	return clients.PostJsonRequest("", reading, ctx, r.urlClient)
 }
 
 func (r *readingRestClient) Delete(id string, ctx context.Context) error {
-	urlPrefix, err := r.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, r.urlClient)
 }

--- a/clients/coredata/value_descriptor.go
+++ b/clients/coredata/value_descriptor.go
@@ -152,14 +152,7 @@ func (v *valueDescriptorRestClient) ValueDescriptorsUsage(names []string, ctx co
 	q.Add("names", strings.Join(names, ","))
 	u.RawQuery = q.Encode()
 
-	// create a new URL client with an empty URL to fulfil the GetRequest contract while relying wholly on
-	// our parsed URL for the actual endpoint data
-	emptyURLClient := urlclient.New(types.EndpointParams{
-		UseRegistry: false,
-		Url:         "",
-	}, nil)
-
-	data, err := clients.GetRequest(u.String(), ctx, emptyURLClient)
+	data, err := clients.GetRequestWithURL(u.String(), ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/general/client.go
+++ b/clients/general/client.go
@@ -42,21 +42,19 @@ func NewGeneralClient(params types.EndpointParams, m interfaces.Endpointer) Gene
 }
 
 func (gc *generalRestClient) FetchConfiguration(ctx context.Context) (string, error) {
-	urlPrefix, err := gc.urlClient.Prefix()
+	body, err := clients.GetRequest(clients.ApiConfigRoute, ctx, gc.urlClient)
 	if err != nil {
 		return "", err
 	}
 
-	body, err := clients.GetRequest(urlPrefix+clients.ApiConfigRoute, ctx)
-	return string(body), err
+	return string(body), nil
 }
 
 func (gc *generalRestClient) FetchMetrics(ctx context.Context) (string, error) {
-	urlPrefix, err := gc.urlClient.Prefix()
+	body, err := clients.GetRequest(clients.ApiMetricsRoute, ctx, gc.urlClient)
 	if err != nil {
 		return "", err
 	}
 
-	body, err := clients.GetRequest(urlPrefix+clients.ApiMetricsRoute, ctx)
-	return string(body), err
+	return string(body), nil
 }

--- a/clients/logger/logger.go
+++ b/clients/logger/logger.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/go-kit/kit/log"
@@ -251,15 +250,8 @@ func (lc edgeXLogger) buildLogEntry(logLevel string, msg string, args ...interfa
 
 // Send the log as an http request
 func (lc edgeXLogger) sendLog(logEntry models.LogEntry) {
-	// create a new URL client with an empty URL to fulfil the PostJsonRequest contract while relying wholly on
-	// logTarget for the actual endpoint data
-	emptyURLClient := urlclient.New(types.EndpointParams{
-		UseRegistry: false,
-		Url:         "",
-	}, nil)
-
 	go func() {
-		_, err := clients.PostJsonRequest(lc.logTarget, logEntry, context.Background(), emptyURLClient)
+		_, err := clients.PostJsonRequestWithURL(lc.logTarget, logEntry, context.Background())
 		if err != nil {
 			fmt.Println(err.Error())
 		}

--- a/clients/logger/logger.go
+++ b/clients/logger/logger.go
@@ -31,7 +31,9 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	"github.com/go-kit/kit/log"
 )
 
@@ -249,8 +251,15 @@ func (lc edgeXLogger) buildLogEntry(logLevel string, msg string, args ...interfa
 
 // Send the log as an http request
 func (lc edgeXLogger) sendLog(logEntry models.LogEntry) {
+	// create a new URL client with an empty URL to fulfil the PostJsonRequest contract while relying wholly on
+	// logTarget for the actual endpoint data
+	emptyURLClient := urlclient.New(types.EndpointParams{
+		UseRegistry: false,
+		Url:         "",
+	}, nil)
+
 	go func() {
-		_, err := clients.PostJsonRequest(lc.logTarget, logEntry, context.Background())
+		_, err := clients.PostJsonRequest(lc.logTarget, logEntry, context.Background(), emptyURLClient)
 		if err != nil {
 			fmt.Println(err.Error())
 		}

--- a/clients/metadata/addressable.go
+++ b/clients/metadata/addressable.go
@@ -47,18 +47,12 @@ type addressableRestClient struct {
 
 // NewAddressableClient creates an instance of AddressableClient
 func NewAddressableClient(params types.EndpointParams, m interfaces.Endpointer) AddressableClient {
-	a := addressableRestClient{urlClient: urlclient.New(params, m)}
-	return &a
+	return &addressableRestClient{urlClient: urlclient.New(params, m)}
 }
 
 // Helper method to request and decode an addressable
 func (a *addressableRestClient) requestAddressable(urlSuffix string, ctx context.Context) (models.Addressable, error) {
-	urlPrefix, err := a.urlClient.Prefix()
-	if err != nil {
-		return models.Addressable{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, a.urlClient)
 	if err != nil {
 		return models.Addressable{}, err
 	}
@@ -69,12 +63,7 @@ func (a *addressableRestClient) requestAddressable(urlSuffix string, ctx context
 }
 
 func (a *addressableRestClient) Add(addr *models.Addressable, ctx context.Context) (string, error) {
-	serviceURL, err := a.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(serviceURL, addr, ctx)
+	return clients.PostJsonRequest("", addr, ctx, a.urlClient)
 }
 
 func (a *addressableRestClient) Addressable(id string, ctx context.Context) (models.Addressable, error) {
@@ -86,19 +75,9 @@ func (a *addressableRestClient) AddressableForName(name string, ctx context.Cont
 }
 
 func (a *addressableRestClient) Update(addr models.Addressable, ctx context.Context) error {
-	serviceURL, err := a.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.UpdateRequest(serviceURL, addr, ctx)
+	return clients.UpdateRequest("", addr, ctx, a.urlClient)
 }
 
 func (a *addressableRestClient) Delete(id string, ctx context.Context) error {
-	serviceURL, err := a.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(serviceURL+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, a.urlClient)
 }

--- a/clients/metadata/command.go
+++ b/clients/metadata/command.go
@@ -49,18 +49,12 @@ type commandRestClient struct {
 
 // NewCommandClient creates an instance of CommandClient
 func NewCommandClient(params types.EndpointParams, m interfaces.Endpointer) CommandClient {
-	c := commandRestClient{urlClient: urlclient.New(params, m)}
-	return &c
+	return &commandRestClient{urlClient: urlclient.New(params, m)}
 }
 
 // Helper method to request and decode a command
 func (c *commandRestClient) requestCommand(urlSuffix string, ctx context.Context) (models.Command, error) {
-	urlPrefix, err := c.urlClient.Prefix()
-	if err != nil {
-		return models.Command{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, c.urlClient)
 	if err != nil {
 		return models.Command{}, err
 	}
@@ -72,12 +66,7 @@ func (c *commandRestClient) requestCommand(urlSuffix string, ctx context.Context
 
 // Helper method to request and decode a command slice
 func (c *commandRestClient) requestCommandSlice(urlSuffix string, ctx context.Context) ([]models.Command, error) {
-	urlPrefix, err := c.urlClient.Prefix()
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, c.urlClient)
 	if err != nil {
 		return []models.Command{}, err
 	}
@@ -104,28 +93,13 @@ func (c *commandRestClient) CommandsForDeviceId(id string, ctx context.Context) 
 }
 
 func (c *commandRestClient) Add(com *models.Command, ctx context.Context) (string, error) {
-	serviceURL, err := c.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(serviceURL, com, ctx)
+	return clients.PostJsonRequest("", com, ctx, c.urlClient)
 }
 
 func (c *commandRestClient) Update(com models.Command, ctx context.Context) error {
-	serviceURL, err := c.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.UpdateRequest(serviceURL, com, ctx)
+	return clients.UpdateRequest("", com, ctx, c.urlClient)
 }
 
 func (c *commandRestClient) Delete(id string, ctx context.Context) error {
-	serviceURL, err := c.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(serviceURL+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, c.urlClient)
 }

--- a/clients/metadata/device.go
+++ b/clients/metadata/device.go
@@ -84,12 +84,7 @@ func NewDeviceClient(params types.EndpointParams, m interfaces.Endpointer) Devic
 
 // Helper method to request and decode a device
 func (d *deviceRestClient) requestDevice(urlSuffix string, ctx context.Context) (models.Device, error) {
-	urlPrefix, err := d.urlClient.Prefix()
-	if err != nil {
-		return models.Device{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, d.urlClient)
 	if err != nil {
 		return models.Device{}, err
 	}
@@ -101,12 +96,7 @@ func (d *deviceRestClient) requestDevice(urlSuffix string, ctx context.Context) 
 
 // Helper method to request and decode a device slice
 func (d *deviceRestClient) requestDeviceSlice(urlSuffix string, ctx context.Context) ([]models.Device, error) {
-	urlPrefix, err := d.urlClient.Prefix()
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, d.urlClient)
 	if err != nil {
 		return []models.Device{}, err
 	}
@@ -153,119 +143,67 @@ func (d *deviceRestClient) DevicesForProfileByName(profileName string, ctx conte
 }
 
 func (d *deviceRestClient) Add(dev *models.Device, ctx context.Context) (string, error) {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(deviceURL, dev, ctx)
+	return clients.PostJsonRequest("", dev, ctx, d.urlClient)
 }
 
 func (d *deviceRestClient) Update(dev models.Device, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.UpdateRequest(deviceURL, dev, ctx)
+	return clients.UpdateRequest("", dev, ctx, d.urlClient)
 }
 
 func (d *deviceRestClient) UpdateLastConnected(id string, time int64, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/"+id+"/lastconnected/"+strconv.FormatInt(time, 10), nil, ctx)
+	_, err := clients.PutRequest("/"+id+"/lastconnected/"+strconv.FormatInt(time, 10), nil, ctx, d.urlClient)
 	return err
 }
 
 func (d *deviceRestClient) UpdateLastConnectedByName(name string, time int64, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/name/"+url.QueryEscape(name)+"/lastconnected/"+strconv.FormatInt(time, 10), nil,
-		ctx)
+	_, err := clients.PutRequest(
+		"/name/"+url.QueryEscape(name)+"/lastconnected/"+strconv.FormatInt(time, 10),
+		nil,
+		ctx,
+		d.urlClient,
+	)
 	return err
 }
 
 func (d *deviceRestClient) UpdateLastReported(id string, time int64, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/"+id+"/lastreported/"+strconv.FormatInt(time, 10), nil, ctx)
+	_, err := clients.PutRequest("/"+id+"/lastreported/"+strconv.FormatInt(time, 10), nil, ctx, d.urlClient)
 	return err
 }
 
 func (d *deviceRestClient) UpdateLastReportedByName(name string, time int64, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/name/"+url.QueryEscape(name)+"/lastreported/"+strconv.FormatInt(time, 10),
-		nil, ctx)
+	_, err := clients.PutRequest(
+		"/name/"+url.QueryEscape(name)+"/lastreported/"+strconv.FormatInt(time, 10),
+		nil,
+		ctx,
+		d.urlClient,
+	)
 	return err
 }
 
 func (d *deviceRestClient) UpdateOpState(id string, opState string, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/"+id+"/opstate/"+opState, nil, ctx)
+	_, err := clients.PutRequest("/"+id+"/opstate/"+opState, nil, ctx, d.urlClient)
 	return err
 }
 
 func (d *deviceRestClient) UpdateOpStateByName(name string, opState string, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/name/"+url.QueryEscape(name)+"/opstate/"+opState, nil, ctx)
+	_, err := clients.PutRequest("/name/"+url.QueryEscape(name)+"/opstate/"+opState, nil, ctx, d.urlClient)
 	return err
 }
 
 func (d *deviceRestClient) UpdateAdminState(id string, adminState string, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/"+id+"/adminstate/"+adminState, nil, ctx)
+	_, err := clients.PutRequest("/"+id+"/adminstate/"+adminState, nil, ctx, d.urlClient)
 	return err
 }
 
 func (d *deviceRestClient) UpdateAdminStateByName(name string, adminState string, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(deviceURL+"/name/"+url.QueryEscape(name)+"/adminstate/"+adminState, nil, ctx)
+	_, err := clients.PutRequest("/name/"+url.QueryEscape(name)+"/adminstate/"+adminState, nil, ctx, d.urlClient)
 	return err
 }
 
 func (d *deviceRestClient) Delete(id string, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(deviceURL+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, d.urlClient)
 }
 
 func (d *deviceRestClient) DeleteByName(name string, ctx context.Context) error {
-	deviceURL, err := d.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(deviceURL+"/name/"+url.QueryEscape(name), ctx)
+	return clients.DeleteRequest("/name/"+url.QueryEscape(name), ctx, d.urlClient)
 }

--- a/clients/metadata/device_profile.go
+++ b/clients/metadata/device_profile.go
@@ -54,8 +54,7 @@ type deviceProfileRestClient struct {
 
 // Return an instance of DeviceProfileClient
 func NewDeviceProfileClient(params types.EndpointParams, m interfaces.Endpointer) DeviceProfileClient {
-	d := deviceProfileRestClient{urlClient: urlclient.New(params, m)}
-	return &d
+	return &deviceProfileRestClient{urlClient: urlclient.New(params, m)}
 }
 
 // Helper method to request and decode a device profile
@@ -63,12 +62,7 @@ func (dpc *deviceProfileRestClient) requestDeviceProfile(
 	urlSuffix string,
 	ctx context.Context) (models.DeviceProfile, error) {
 
-	urlPrefix, err := dpc.urlClient.Prefix()
-	if err != nil {
-		return models.DeviceProfile{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, dpc.urlClient)
 	if err != nil {
 		return models.DeviceProfile{}, err
 	}
@@ -83,7 +77,7 @@ func (dpc *deviceProfileRestClient) requestDeviceProfileSlice(
 	urlSuffix string,
 	ctx context.Context) ([]models.DeviceProfile, error) {
 
-	data, err := clients.GetRequest(urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, dpc.urlClient)
 	if err != nil {
 		return []models.DeviceProfile{}, err
 	}
@@ -94,30 +88,15 @@ func (dpc *deviceProfileRestClient) requestDeviceProfileSlice(
 }
 
 func (dpc *deviceProfileRestClient) Add(dp *models.DeviceProfile, ctx context.Context) (string, error) {
-	serviceURL, err := dpc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(serviceURL, dp, ctx)
+	return clients.PostJsonRequest("", dp, ctx, dpc.urlClient)
 }
 
 func (dpc *deviceProfileRestClient) Delete(id string, ctx context.Context) error {
-	serviceURL, err := dpc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(serviceURL+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, dpc.urlClient)
 }
 
 func (dpc *deviceProfileRestClient) DeleteByName(name string, ctx context.Context) error {
-	serviceURL, err := dpc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(serviceURL+"/name/"+url.QueryEscape(name), ctx)
+	return clients.DeleteRequest("/name/"+url.QueryEscape(name), ctx, dpc.urlClient)
 }
 
 func (dpc *deviceProfileRestClient) DeviceProfile(id string, ctx context.Context) (models.DeviceProfile, error) {
@@ -133,30 +112,15 @@ func (dpc *deviceProfileRestClient) DeviceProfileForName(name string, ctx contex
 }
 
 func (dpc *deviceProfileRestClient) Update(dp models.DeviceProfile, ctx context.Context) error {
-	serviceURL, err := dpc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.UpdateRequest(serviceURL, dp, ctx)
+	return clients.UpdateRequest("", dp, ctx, dpc.urlClient)
 }
 
 func (dpc *deviceProfileRestClient) Upload(yamlString string, ctx context.Context) (string, error) {
-	serviceURL, err := dpc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
 	ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeYAML)
 
-	return clients.PostRequest(serviceURL+"/upload", []byte(yamlString), ctx)
+	return clients.PostRequest("/upload", []byte(yamlString), ctx, dpc.urlClient)
 }
 
 func (dpc *deviceProfileRestClient) UploadFile(yamlFilePath string, ctx context.Context) (string, error) {
-	serviceURL, err := dpc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.UploadFileRequest(serviceURL+"/uploadfile", yamlFilePath, ctx)
+	return clients.UploadFileRequest("/uploadfile", yamlFilePath, ctx, dpc.urlClient)
 }

--- a/clients/metadata/device_service.go
+++ b/clients/metadata/device_service.go
@@ -44,49 +44,28 @@ type deviceServiceRestClient struct {
 
 // NewDeviceServiceClient creates an instance of DeviceServiceClient
 func NewDeviceServiceClient(params types.EndpointParams, m interfaces.Endpointer) DeviceServiceClient {
-	s := deviceServiceRestClient{urlClient: urlclient.New(params, m)}
-	return &s
+	return &deviceServiceRestClient{urlClient: urlclient.New(params, m)}
 }
 
 func (dsc *deviceServiceRestClient) UpdateLastConnected(id string, time int64, ctx context.Context) error {
-	serviceURL, err := dsc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(serviceURL+"/"+id+"/lastconnected/"+strconv.FormatInt(time, 10), nil, ctx)
+	_, err := clients.PutRequest("/"+id+"/lastconnected/"+strconv.FormatInt(time, 10), nil, ctx, dsc.urlClient)
 	return err
 }
 
 func (dsc *deviceServiceRestClient) UpdateLastReported(id string, time int64, ctx context.Context) error {
-	serviceURL, err := dsc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PutRequest(serviceURL+"/"+id+"/lastreported/"+strconv.FormatInt(time, 10), nil, ctx)
+	_, err := clients.PutRequest("/"+id+"/lastreported/"+strconv.FormatInt(time, 10), nil, ctx, dsc.urlClient)
 	return err
 }
 
 func (dsc *deviceServiceRestClient) Add(ds *models.DeviceService, ctx context.Context) (string, error) {
-	serviceURL, err := dsc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(serviceURL, ds, ctx)
+	return clients.PostJsonRequest("", ds, ctx, dsc.urlClient)
 }
 
 func (dsc *deviceServiceRestClient) DeviceServiceForName(
 	name string,
 	ctx context.Context) (models.DeviceService, error) {
 
-	urlPrefix, err := dsc.urlClient.Prefix()
-	if err != nil {
-		return models.DeviceService{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+"/name/"+name, ctx)
+	data, err := clients.GetRequest("/name/"+name, ctx, dsc.urlClient)
 	if err != nil {
 		return models.DeviceService{}, err
 	}

--- a/clients/metadata/provision_watcher.go
+++ b/clients/metadata/provision_watcher.go
@@ -56,8 +56,7 @@ type provisionWatcherRestClient struct {
 
 // NewProvisionWatcherClient creates an instance of ProvisionWatcherClient
 func NewProvisionWatcherClient(params types.EndpointParams, m interfaces.Endpointer) ProvisionWatcherClient {
-	pw := provisionWatcherRestClient{urlClient: urlclient.New(params, m)}
-	return &pw
+	return &provisionWatcherRestClient{urlClient: urlclient.New(params, m)}
 }
 
 // Helper method to request and decode a provision watcher
@@ -65,12 +64,7 @@ func (pwc *provisionWatcherRestClient) requestProvisionWatcher(
 	urlSuffix string,
 	ctx context.Context) (models.ProvisionWatcher, error) {
 
-	urlPrefix, err := pwc.urlClient.Prefix()
-	if err != nil {
-		return models.ProvisionWatcher{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, pwc.urlClient)
 	if err != nil {
 		return models.ProvisionWatcher{}, err
 	}
@@ -85,12 +79,7 @@ func (pwc *provisionWatcherRestClient) requestProvisionWatcherSlice(
 	urlSuffix string,
 	ctx context.Context) ([]models.ProvisionWatcher, error) {
 
-	urlPrefix, err := pwc.urlClient.Prefix()
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, pwc.urlClient)
 	if err != nil {
 		return []models.ProvisionWatcher{}, err
 	}
@@ -129,28 +118,13 @@ func (pwc *provisionWatcherRestClient) ProvisionWatchersForProfileByName(profile
 }
 
 func (pwc *provisionWatcherRestClient) Add(dev *models.ProvisionWatcher, ctx context.Context) (string, error) {
-	serviceURL, err := pwc.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(serviceURL, dev, ctx)
+	return clients.PostJsonRequest("", dev, ctx, pwc.urlClient)
 }
 
 func (pwc *provisionWatcherRestClient) Update(dev models.ProvisionWatcher, ctx context.Context) error {
-	serviceURL, err := pwc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.UpdateRequest(serviceURL, dev, ctx)
+	return clients.UpdateRequest("", dev, ctx, pwc.urlClient)
 }
 
 func (pwc *provisionWatcherRestClient) Delete(id string, ctx context.Context) error {
-	serviceURL, err := pwc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(serviceURL+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, pwc.urlClient)
 }

--- a/clients/notifications/client.go
+++ b/clients/notifications/client.go
@@ -79,11 +79,6 @@ func NewNotificationsClient(params types.EndpointParams, m interfaces.Endpointer
 }
 
 func (nc *notificationsRestClient) SendNotification(n Notification, ctx context.Context) error {
-	urlPrefix, err := nc.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	_, err = clients.PostJsonRequest(urlPrefix, n, ctx)
+	_, err := clients.PostJsonRequest("", n, ctx, nc.urlClient)
 	return err
 }

--- a/clients/scheduler/interval.go
+++ b/clients/scheduler/interval.go
@@ -55,30 +55,15 @@ func NewIntervalClient(params types.EndpointParams, m interfaces.Endpointer) Int
 }
 
 func (ic *intervalRestClient) Add(interval *models.Interval, ctx context.Context) (string, error) {
-	urlPrefix, err := ic.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(urlPrefix, interval, ctx)
+	return clients.PostJsonRequest("", interval, ctx, ic.urlClient)
 }
 
 func (ic *intervalRestClient) Delete(id string, ctx context.Context) error {
-	urlPrefix, err := ic.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, ic.urlClient)
 }
 
 func (ic *intervalRestClient) DeleteByName(name string, ctx context.Context) error {
-	urlPrefix, err := ic.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/name/"+url.QueryEscape(name), ctx)
+	return clients.DeleteRequest("/name/"+url.QueryEscape(name), ctx, ic.urlClient)
 }
 
 func (ic *intervalRestClient) Interval(id string, ctx context.Context) (models.Interval, error) {
@@ -94,22 +79,12 @@ func (ic *intervalRestClient) Intervals(ctx context.Context) ([]models.Interval,
 }
 
 func (ic *intervalRestClient) Update(interval models.Interval, ctx context.Context) error {
-	urlPrefix, err := ic.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.UpdateRequest(urlPrefix, interval, ctx)
+	return clients.UpdateRequest("", interval, ctx, ic.urlClient)
 }
 
 // helper request and decode an interval
 func (ic *intervalRestClient) requestInterval(urlSuffix string, ctx context.Context) (models.Interval, error) {
-	urlPrefix, err := ic.urlClient.Prefix()
-	if err != nil {
-		return models.Interval{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, ic.urlClient)
 	if err != nil {
 		return models.Interval{}, err
 	}
@@ -125,12 +100,7 @@ func (ic *intervalRestClient) requestInterval(urlSuffix string, ctx context.Cont
 
 // helper returns a slice of intervals
 func (ic *intervalRestClient) requestIntervalSlice(urlSuffix string, ctx context.Context) ([]models.Interval, error) {
-	urlPrefix, err := ic.urlClient.Prefix()
-	if err != nil {
-		return []models.Interval{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, ic.urlClient)
 	if err != nil {
 		return []models.Interval{}, err
 	}

--- a/clients/scheduler/interval_action.go
+++ b/clients/scheduler/interval_action.go
@@ -60,12 +60,7 @@ func (iac *intervalActionRestClient) requestIntervalAction(
 	urlSuffix string,
 	ctx context.Context) (models.IntervalAction, error) {
 
-	urlPrefix, err := iac.urlClient.Prefix()
-	if err != nil {
-		return models.IntervalAction{}, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, iac.urlClient)
 	if err != nil {
 		return models.IntervalAction{}, err
 	}
@@ -84,12 +79,7 @@ func (iac *intervalActionRestClient) requestIntervalActionSlice(
 	urlSuffix string,
 	ctx context.Context) ([]models.IntervalAction, error) {
 
-	urlPrefix, err := iac.urlClient.Prefix()
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := clients.GetRequest(urlPrefix+urlSuffix, ctx)
+	data, err := clients.GetRequest(urlSuffix, ctx, iac.urlClient)
 	if err != nil {
 		return []models.IntervalAction{}, err
 	}
@@ -104,30 +94,15 @@ func (iac *intervalActionRestClient) requestIntervalActionSlice(
 }
 
 func (iac *intervalActionRestClient) Add(ia *models.IntervalAction, ctx context.Context) (string, error) {
-	url, err := iac.urlClient.Prefix()
-	if err != nil {
-		return "", err
-	}
-
-	return clients.PostJsonRequest(url, ia, ctx)
+	return clients.PostJsonRequest("", ia, ctx, iac.urlClient)
 }
 
 func (iac *intervalActionRestClient) Delete(id string, ctx context.Context) error {
-	urlPrefix, err := iac.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/id/"+id, ctx)
+	return clients.DeleteRequest("/id/"+id, ctx, iac.urlClient)
 }
 
 func (iac *intervalActionRestClient) DeleteByName(name string, ctx context.Context) error {
-	urlPrefix, err := iac.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.DeleteRequest(urlPrefix+"/name/"+url.QueryEscape(name), ctx)
+	return clients.DeleteRequest("/name/"+url.QueryEscape(name), ctx, iac.urlClient)
 }
 
 func (iac *intervalActionRestClient) IntervalAction(id string, ctx context.Context) (models.IntervalAction, error) {
@@ -147,10 +122,5 @@ func (iac *intervalActionRestClient) IntervalActionsForTargetByName(name string,
 }
 
 func (iac *intervalActionRestClient) Update(ia models.IntervalAction, ctx context.Context) error {
-	url, err := iac.urlClient.Prefix()
-	if err != nil {
-		return err
-	}
-
-	return clients.UpdateRequest(url, ia, ctx)
+	return clients.UpdateRequest("", ia, ctx, iac.urlClient)
 }


### PR DESCRIPTION
Fixes #196.

This is the final PR for #196. This PR moves all calls of `URLPrefix` to the `request` package to reduce duplication.

There are two places I would like to call out for special review:

`ValueDescriptorsUsage()` in metadata/provision_watcher.go and
`sendLog()` in `logger/logger.go.

These two functions required me creating a new URLClient that returns an empty string to fulfill the contract and preserve functionality. I did my best, but am not tremendously happy with this solution and would like any suggestions on how to improve it.