### PR TITLE
Implement strategy pattern on RegistryClient URLClient

### DIFF
--- a/clients/command/client.go
+++ b/clients/command/client.go
@@ -43,8 +43,12 @@ type commandRestClient struct {
 }
 
 // NewCommandClient creates an instance of CommandClient
-func NewCommandClient(params types.EndpointParams, m interfaces.Endpointer) CommandClient {
-	return &commandRestClient{urlClient: urlclient.New(params, m)}
+func NewCommandClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) CommandClient {
+
+	return &commandRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 func (cc *commandRestClient) Get(deviceId string, commandId string, ctx context.Context) (string, error) {

--- a/clients/command/client_test.go
+++ b/clients/command/client_test.go
@@ -39,7 +39,7 @@ func TestGetDeviceCommandById(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault,
 	}
 
-	cc := NewCommandClient(params, MockEndpoint{})
+	cc := NewCommandClient(params, MockEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	res, _ := cc.Get("device1", "command1", context.Background())
 
@@ -63,7 +63,7 @@ func TestPutDeviceCommandById(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault,
 	}
 
-	cc := NewCommandClient(params, MockEndpoint{})
+	cc := NewCommandClient(params, MockEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	res, _ := cc.Put("device1", "command1", "body", context.Background())
 
@@ -87,7 +87,7 @@ func TestGetDeviceByName(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault,
 	}
 
-	cc := NewCommandClient(params, MockEndpoint{})
+	cc := NewCommandClient(params, MockEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	res, _ := cc.GetDeviceCommandByNames("device1", "command1", context.Background())
 
@@ -111,7 +111,7 @@ func TestPutDeviceCommandByNames(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault,
 	}
 
-	cc := NewCommandClient(params, MockEndpoint{})
+	cc := NewCommandClient(params, MockEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	res, _ := cc.PutDeviceCommandByNames("device1", "command1", "body", context.Background())
 

--- a/clients/coredata/event.go
+++ b/clients/coredata/event.go
@@ -71,8 +71,11 @@ type eventRestClient struct {
 }
 
 // NewEventClient creates an instance of EventClient
-func NewEventClient(params types.EndpointParams, m interfaces.Endpointer) EventClient {
-	return &eventRestClient{urlClient: urlclient.New(params, m)}
+func NewEventClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) EventClient {
+	return &eventRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode an event slice

--- a/clients/coredata/event_test.go
+++ b/clients/coredata/event_test.go
@@ -66,7 +66,7 @@ func TestMarkPushed(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockCoreDataEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	err := ec.MarkPushed(TestId, context.Background())
 
@@ -101,7 +101,7 @@ func TestMarkPushedByChecksum(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockCoreDataEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	err := ec.MarkPushedByChecksum(TestChecksum, context.Background())
 
@@ -144,7 +144,7 @@ func TestGetEvents(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockCoreDataEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	eArr, err := ec.Events(context.Background())
 	if err != nil {
@@ -175,7 +175,7 @@ func TestNewEventClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	ec := NewEventClient(params, mockCoreDataEndpoint{})
+	ec := NewEventClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := ec.(*eventRestClient)
 	if !ok {
@@ -199,7 +199,7 @@ func TestMarshalEvent(t *testing.T) {
 	regularEvent := testEvent
 	regularEvent.Readings = append(regularEvent.Readings, testReading)
 
-	client := NewEventClient(types.EndpointParams{Url: "test"}, mockCoreDataEndpoint{})
+	client := NewEventClient(types.EndpointParams{Url: "test"}, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	tests := []struct {
 		name        string

--- a/clients/coredata/reading.go
+++ b/clients/coredata/reading.go
@@ -63,8 +63,12 @@ type readingRestClient struct {
 }
 
 // NewReadingClient creates an instance of a ReadingClient
-func NewReadingClient(params types.EndpointParams, m interfaces.Endpointer) ReadingClient {
-	return &readingRestClient{urlClient: urlclient.New(params, m)}
+func NewReadingClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) ReadingClient {
+
+	return &readingRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode a reading slice

--- a/clients/coredata/reading_test.go
+++ b/clients/coredata/reading_test.go
@@ -76,7 +76,7 @@ func TestGetReadings(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	rc := NewReadingClient(params, mockCoreDataEndpoint{})
+	rc := NewReadingClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	rArr, err := rc.Readings(context.Background())
 	if err != nil {
@@ -108,7 +108,7 @@ func TestNewReadingClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	rc := NewReadingClient(params, mockCoreDataEndpoint{})
+	rc := NewReadingClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := rc.(*readingRestClient)
 	if !ok {

--- a/clients/coredata/value_descriptor.go
+++ b/clients/coredata/value_descriptor.go
@@ -60,8 +60,12 @@ type valueDescriptorRestClient struct {
 	urlClient interfaces.URLClient
 }
 
-func NewValueDescriptorClient(params types.EndpointParams, m interfaces.Endpointer) ValueDescriptorClient {
-	return &valueDescriptorRestClient{urlClient: urlclient.New(params, m)}
+func NewValueDescriptorClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) ValueDescriptorClient {
+
+	return &valueDescriptorRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode a valuedescriptor slice

--- a/clients/coredata/value_descriptor_test.go
+++ b/clients/coredata/value_descriptor_test.go
@@ -80,7 +80,7 @@ func TestGetvaluedescriptors(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	vdArr, err := vdc.ValueDescriptors(context.Background())
 	if err != nil {
@@ -133,7 +133,7 @@ func TestValueDescriptorUsage(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 	usage, err := vdc.ValueDescriptorsUsage([]string{testValueDesciptorDescription1, testValueDesciptorDescription2}, context.Background())
 	if err != nil {
 		t.Errorf(err.Error())
@@ -160,7 +160,7 @@ func TestValueDescriptorUsageSerializationError(t *testing.T) {
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 	_, err := vdc.ValueDescriptorsUsage([]string{testValueDesciptorDescription1, testValueDesciptorDescription2}, context.Background())
 	if err == nil {
 		t.Error("Expected an error")
@@ -176,7 +176,7 @@ func TestValueDescriptorUsageGetRequestError(t *testing.T) {
 		Url:         "!@#",
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 	_, err := vdc.ValueDescriptorsUsage([]string{testValueDesciptorDescription1, testValueDesciptorDescription2}, context.Background())
 	if err == nil {
 		t.Error("Expected an error")
@@ -193,7 +193,7 @@ func TestNewValueDescriptorClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{})
+	vdc := NewValueDescriptorClient(params, mockCoreDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := vdc.(*valueDescriptorRestClient)
 	if !ok {

--- a/clients/general/client.go
+++ b/clients/general/client.go
@@ -37,8 +37,12 @@ type generalRestClient struct {
 }
 
 // NewGeneralClient creates an instance of GeneralClient
-func NewGeneralClient(params types.EndpointParams, m interfaces.Endpointer) GeneralClient {
-	return &generalRestClient{urlClient: urlclient.New(params, m)}
+func NewGeneralClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) GeneralClient {
+
+	return &generalRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 func (gc *generalRestClient) FetchConfiguration(ctx context.Context) (string, error) {

--- a/clients/general/client_test.go
+++ b/clients/general/client_test.go
@@ -61,7 +61,7 @@ func TestGetConfig(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault,
 	}
 
-	mc := NewGeneralClient(params, mockGeneralEndpoint{})
+	mc := NewGeneralClient(params, mockGeneralEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	responseJSON, err := mc.FetchConfiguration(context.Background())
 	if err != nil {
@@ -94,7 +94,7 @@ func TestGetMetrics(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault,
 	}
 
-	mc := NewGeneralClient(params, mockGeneralEndpoint{})
+	mc := NewGeneralClient(params, mockGeneralEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	responseJSON, err := mc.FetchMetrics(context.Background())
 	if err != nil {

--- a/clients/metadata/addressable.go
+++ b/clients/metadata/addressable.go
@@ -46,8 +46,12 @@ type addressableRestClient struct {
 }
 
 // NewAddressableClient creates an instance of AddressableClient
-func NewAddressableClient(params types.EndpointParams, m interfaces.Endpointer) AddressableClient {
-	return &addressableRestClient{urlClient: urlclient.New(params, m)}
+func NewAddressableClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) AddressableClient {
+
+	return &addressableRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode an addressable

--- a/clients/metadata/addressable_test.go
+++ b/clients/metadata/addressable_test.go
@@ -37,7 +37,7 @@ func TestNewAddressableClientWithConsul(t *testing.T) {
 		Url:         addressableURL,
 		Interval:    clients.ClientMonitorDefault}
 
-	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := ac.(*addressableRestClient)
 	if !ok {
@@ -87,7 +87,7 @@ func TestAddAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	receivedAddressableID, err := ac.Add(&addressable, context.Background())
 	if err != nil {
@@ -132,7 +132,7 @@ func TestGetAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	receivedAddressable, err := ac.Addressable(addressable.Id, context.Background())
 	if err != nil {
@@ -177,7 +177,7 @@ func TestGetAddressableForName(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	receivedAddressable, err := ac.AddressableForName(addressable.Name, context.Background())
 	if err != nil {
@@ -219,7 +219,7 @@ func TestUpdateAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	err := ac.Update(addressable, context.Background())
 	if err != nil {
@@ -258,7 +258,7 @@ func TestDeleteAddressable(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{})
+	ac := NewAddressableClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	err := ac.Delete(addressable.Id, context.Background())
 	if err != nil {

--- a/clients/metadata/command.go
+++ b/clients/metadata/command.go
@@ -48,8 +48,12 @@ type commandRestClient struct {
 }
 
 // NewCommandClient creates an instance of CommandClient
-func NewCommandClient(params types.EndpointParams, m interfaces.Endpointer) CommandClient {
-	return &commandRestClient{urlClient: urlclient.New(params, m)}
+func NewCommandClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) CommandClient {
+
+	return &commandRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode a command

--- a/clients/metadata/command_test.go
+++ b/clients/metadata/command_test.go
@@ -30,7 +30,7 @@ func TestNewCommandClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	cc := NewCommandClient(params, mockCoreMetaDataEndpoint{})
+	cc := NewCommandClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := cc.(*commandRestClient)
 	if !ok {

--- a/clients/metadata/device.go
+++ b/clients/metadata/device.go
@@ -78,8 +78,12 @@ type deviceRestClient struct {
 }
 
 // NewDeviceClient creates an instance of DeviceClient
-func NewDeviceClient(params types.EndpointParams, m interfaces.Endpointer) DeviceClient {
-	return &deviceRestClient{urlClient: urlclient.New(params, m)}
+func NewDeviceClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) DeviceClient {
+
+	return &deviceRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode a device

--- a/clients/metadata/device_profile.go
+++ b/clients/metadata/device_profile.go
@@ -53,8 +53,12 @@ type deviceProfileRestClient struct {
 }
 
 // Return an instance of DeviceProfileClient
-func NewDeviceProfileClient(params types.EndpointParams, m interfaces.Endpointer) DeviceProfileClient {
-	return &deviceProfileRestClient{urlClient: urlclient.New(params, m)}
+func NewDeviceProfileClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) DeviceProfileClient {
+
+	return &deviceProfileRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode a device profile

--- a/clients/metadata/device_profile_test.go
+++ b/clients/metadata/device_profile_test.go
@@ -34,7 +34,7 @@ func TestNewDeviceProfileClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	dpc := NewDeviceProfileClient(params, mockCoreMetaDataEndpoint{})
+	dpc := NewDeviceProfileClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := dpc.(*deviceProfileRestClient)
 	if !ok {
@@ -82,7 +82,7 @@ func TestUpdateDeviceProfile(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	dpc := NewDeviceProfileClient(params, mockCoreMetaDataEndpoint{})
+	dpc := NewDeviceProfileClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	err := dpc.Update(p, context.Background())
 	if err != nil {

--- a/clients/metadata/device_service.go
+++ b/clients/metadata/device_service.go
@@ -43,8 +43,12 @@ type deviceServiceRestClient struct {
 }
 
 // NewDeviceServiceClient creates an instance of DeviceServiceClient
-func NewDeviceServiceClient(params types.EndpointParams, m interfaces.Endpointer) DeviceServiceClient {
-	return &deviceServiceRestClient{urlClient: urlclient.New(params, m)}
+func NewDeviceServiceClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) DeviceServiceClient {
+
+	return &deviceServiceRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 func (dsc *deviceServiceRestClient) UpdateLastConnected(id string, time int64, ctx context.Context) error {

--- a/clients/metadata/device_service_test.go
+++ b/clients/metadata/device_service_test.go
@@ -30,7 +30,7 @@ func TestNewDeviceServiceClientWithConsul(t *testing.T) {
 		Url:         deviceServiceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	dsc := NewDeviceServiceClient(params, mockCoreMetaDataEndpoint{})
+	dsc := NewDeviceServiceClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 	r, ok := dsc.(*deviceServiceRestClient)
 	if !ok {
 		t.Error("dsc is not of expected type")

--- a/clients/metadata/device_test.go
+++ b/clients/metadata/device_test.go
@@ -67,7 +67,7 @@ func TestAddDevice(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	dc := NewDeviceClient(params, mockCoreMetaDataEndpoint{})
+	dc := NewDeviceClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	receivedDeviceId, err := dc.Add(&d, context.Background())
 	if err != nil {
@@ -88,7 +88,7 @@ func TestNewDeviceClientWithConsul(t *testing.T) {
 		Url:         deviceUrl,
 		Interval:    clients.ClientMonitorDefault}
 
-	dc := NewDeviceClient(params, mockCoreMetaDataEndpoint{})
+	dc := NewDeviceClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := dc.(*deviceRestClient)
 	if !ok {

--- a/clients/metadata/provision_watcher.go
+++ b/clients/metadata/provision_watcher.go
@@ -55,8 +55,12 @@ type provisionWatcherRestClient struct {
 }
 
 // NewProvisionWatcherClient creates an instance of ProvisionWatcherClient
-func NewProvisionWatcherClient(params types.EndpointParams, m interfaces.Endpointer) ProvisionWatcherClient {
-	return &provisionWatcherRestClient{urlClient: urlclient.New(params, m)}
+func NewProvisionWatcherClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) ProvisionWatcherClient {
+
+	return &provisionWatcherRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode a provision watcher

--- a/clients/metadata/provision_watcher_test.go
+++ b/clients/metadata/provision_watcher_test.go
@@ -63,7 +63,7 @@ func TestAddProvisionWatcher(t *testing.T) {
 		UseRegistry: false,
 		Url:         url,
 		Interval:    clients.ClientMonitorDefault}
-	sc := NewProvisionWatcherClient(params, mockCoreMetaDataEndpoint{})
+	sc := NewProvisionWatcherClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	receivedProvisionWatcherID, err := sc.Add(&se, context.Background())
 	if err != nil {
@@ -84,7 +84,7 @@ func TestNewProvisionWatcherClientWithConsul(t *testing.T) {
 		Url:         provisionWatcherURL,
 		Interval:    clients.ClientMonitorDefault}
 
-	sc := NewProvisionWatcherClient(params, mockCoreMetaDataEndpoint{})
+	sc := NewProvisionWatcherClient(params, mockCoreMetaDataEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	r, ok := sc.(*provisionWatcherRestClient)
 	if !ok {

--- a/clients/notifications/client.go
+++ b/clients/notifications/client.go
@@ -74,8 +74,12 @@ type Notification struct {
 }
 
 // NewNotificationsClient creates an instance of NotificationsClient
-func NewNotificationsClient(params types.EndpointParams, m interfaces.Endpointer) NotificationsClient {
-	return &notificationsRestClient{urlClient: urlclient.New(params, m)}
+func NewNotificationsClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) NotificationsClient {
+
+	return &notificationsRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 func (nc *notificationsRestClient) SendNotification(n Notification, ctx context.Context) error {

--- a/clients/notifications/client_test.go
+++ b/clients/notifications/client_test.go
@@ -103,7 +103,7 @@ func TestReceiveNotification(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault,
 	}
 
-	nc := NewNotificationsClient(params, mockNotificationEndpoint{})
+	nc := NewNotificationsClient(params, mockNotificationEndpoint{}, types.URLClientParams{Interval: 500, Timeout: 10})
 
 	notification := Notification{
 		Sender:      TestNotificationSender,

--- a/clients/scheduler/interval.go
+++ b/clients/scheduler/interval.go
@@ -50,8 +50,12 @@ type intervalRestClient struct {
 }
 
 // NewIntervalClient creates an instance of IntervalClient
-func NewIntervalClient(params types.EndpointParams, m interfaces.Endpointer) IntervalClient {
-	return &intervalRestClient{urlClient: urlclient.New(params, m)}
+func NewIntervalClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) IntervalClient {
+
+	return &intervalRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 func (ic *intervalRestClient) Add(interval *models.Interval, ctx context.Context) (string, error) {

--- a/clients/scheduler/interval_action.go
+++ b/clients/scheduler/interval_action.go
@@ -51,8 +51,12 @@ type intervalActionRestClient struct {
 }
 
 // NewIntervalActionClient creates an instance of IntervalActionClient
-func NewIntervalActionClient(params types.EndpointParams, m interfaces.Endpointer) IntervalActionClient {
-	return &intervalActionRestClient{urlClient: urlclient.New(params, m)}
+func NewIntervalActionClient(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) IntervalActionClient {
+
+	return &intervalActionRestClient{urlClient: urlclient.New(endpointParams, m, urlClientParams)}
 }
 
 // Helper method to request and decode an interval action

--- a/clients/types/urlclient_params.go
+++ b/clients/types/urlclient_params.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 Dell Inc.
+ * Copyright 2020 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,12 +15,9 @@
 // Package types provides supporting types that facilitate the various service client implementations.
 package types
 
-// EndpointParams is a type that allows for the passing of common parameters to service clients
+// URLClientParams is a type that allows for the passing of common parameters to service clients
 // for initialization.
-type EndpointParams struct {
-	ServiceKey  string // The key of the service as found in the service registry (e.g. Consul)
-	Path        string // The path to the service's endpoint following port number in the URL
-	UseRegistry bool   // An indication of whether or not endpoint information should be obtained from a service registry provider.
-	Url         string // If a service registry is not being used, then provide the full URL endpoint
-	Interval    int    // The interval in milliseconds governing how often the client polls to keep the endpoint current
+type URLClientParams struct {
+	Interval int // The interval in milliseconds governing how often the client polls to check for a URL update
+	Timeout  int // The interval in seconds governing how long the client checks for a URL update before giving up.
 }

--- a/clients/urlclient/errors/errors.go
+++ b/clients/urlclient/errors/errors.go
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// errors defines a set of errors that urlclient will use.
+package errors
+
+type timeoutError struct{}
+
+func NewTimeoutError() timeoutError {
+	return timeoutError{}
+}
+
+func (timeoutError) Error() string {
+	return "unable to initialize client"
+}

--- a/clients/urlclient/factory.go
+++ b/clients/urlclient/factory.go
@@ -19,12 +19,13 @@ package urlclient
 import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/retry"
 )
 
 // New provides the correct concrete implementation of the URLClient given the params provided.
 func New(params types.EndpointParams, m interfaces.Endpointer) interfaces.URLClient {
 	if params.UseRegistry {
-		return newRegistryClient(params, m, 10)
+		return newRegistryClient(params, m, retry.NewPeriodicRetry(500, 10))
 	}
 	return newLocalClient(params)
 }

--- a/clients/urlclient/factory.go
+++ b/clients/urlclient/factory.go
@@ -23,9 +23,13 @@ import (
 )
 
 // New provides the correct concrete implementation of the URLClient given the params provided.
-func New(params types.EndpointParams, m interfaces.Endpointer) interfaces.URLClient {
-	if params.UseRegistry {
-		return newRegistryClient(params, m, retry.NewPeriodicRetry(500, 10))
+func New(
+	endpointParams types.EndpointParams,
+	m interfaces.Endpointer,
+	urlClientParams types.URLClientParams) interfaces.URLClient {
+
+	if endpointParams.UseRegistry {
+		return newRegistryClient(endpointParams, m, retry.NewPeriodicRetry(urlClientParams))
 	}
-	return newLocalClient(params)
+	return newLocalClient(endpointParams)
 }

--- a/clients/urlclient/factory_test.go
+++ b/clients/urlclient/factory_test.go
@@ -20,8 +20,10 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 )
 
+var urlClientParams = types.URLClientParams{Interval: 500, Timeout: 1}
+
 func TestClientFactoryLocal(t *testing.T) {
-	actualClient := New(types.EndpointParams{UseRegistry: false}, mockEndpoint{})
+	actualClient := New(types.EndpointParams{UseRegistry: false}, mockEndpoint{}, urlClientParams)
 	_, isLocalClient := actualClient.(*localClient)
 
 	if !isLocalClient {
@@ -30,7 +32,7 @@ func TestClientFactoryLocal(t *testing.T) {
 }
 
 func TestClientFactoryRegistry(t *testing.T) {
-	actualClient := New(types.EndpointParams{UseRegistry: true}, mockEndpoint{})
+	actualClient := New(types.EndpointParams{UseRegistry: true}, mockEndpoint{}, urlClientParams)
 	_, isRegistryClient := actualClient.(*registryClient)
 
 	if !isRegistryClient {

--- a/clients/urlclient/interfaces/retry.go
+++ b/clients/urlclient/interfaces/retry.go
@@ -22,7 +22,7 @@ package interfaces
 // the URL that should be passed back to the RegistryClient should be returned by the RetryStrategy.
 type RetryStrategy interface {
 	// Retry defines the actual behavior of the RegistryClient and how it processes the URL.
-	Retry(isInitialized *bool, url *string) (string, error)
+	Retry(url *string) (string, error)
 
 	// IsLocked communicates whether the value of the URL is currently being updated or not.
 	IsLocked() bool

--- a/clients/urlclient/interfaces/retry.go
+++ b/clients/urlclient/interfaces/retry.go
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// interfaces defines contracts specific to the urlclient package
+package interfaces
+
+// RetryStrategy defines some way to verify that a RegistryClient has received data.
+// It accomplishes this by monitoring the values pointed to in its parameters,
+// which communicate the state of the RegistryClient.
+// When the values pointed to by the parameters are in the desired state,
+// the URL that should be passed back to the RegistryClient should be returned by the RetryStrategy.
+type RetryStrategy interface {
+	// Retry defines the actual behavior of the RegistryClient and how it processes the URL.
+	Retry(isInitialized *bool, url *string) (string, error)
+
+	// IsLocked communicates whether the value of the URL is currently being updated or not.
+	IsLocked() bool
+
+	// SetLock updates the value of the lock.
+	SetLock(value bool)
+}

--- a/clients/urlclient/registry.go
+++ b/clients/urlclient/registry.go
@@ -46,7 +46,6 @@ func newRegistryClient(
 			select {
 			case url := <-ch:
 				e.url = url
-				e.initialized = true
 				strategy.SetLock(false)
 			}
 		}
@@ -58,5 +57,5 @@ func newRegistryClient(
 // Prefix waits for URLClient to be updated for timeout seconds. If a value is loaded in that time, it returns it.
 // Otherwise, it returns an error.
 func (c *registryClient) Prefix() (string, error) {
-	return c.strategy.Retry(&c.initialized, &c.url)
+	return c.strategy.Retry(&c.url)
 }

--- a/clients/urlclient/registry_test.go
+++ b/clients/urlclient/registry_test.go
@@ -31,7 +31,7 @@ func TestNewRegistryClient(t *testing.T) {
 	actualClient := newRegistryClient(
 		types.EndpointParams{UseRegistry: true},
 		mockEndpoint{},
-		retry.NewPeriodicRetry(500, 10),
+		retry.NewPeriodicRetry(types.URLClientParams{Interval: 500, Timeout: 10}),
 	)
 
 	if actualClient == nil {
@@ -40,7 +40,7 @@ func TestNewRegistryClient(t *testing.T) {
 }
 
 func TestRegistryClient_Prefix_Periodic(t *testing.T) {
-	strategy := retry.NewPeriodicRetry(500, 10)
+	strategy := retry.NewPeriodicRetry(types.URLClientParams{Interval: 500, Timeout: 10})
 
 	expectedURL := "http://domain.com"
 	testEndpoint := mockEndpoint{ch: make(chan string, 1)}
@@ -66,7 +66,7 @@ func TestRegistryClient_Prefix_Periodic(t *testing.T) {
 
 func TestRegistryClient_Prefix_Periodic_Initialized(t *testing.T) {
 	// use impossible timing to ensure that if hit, the retry logic will error out
-	strategy := retry.NewPeriodicRetry(100000, 1)
+	strategy := retry.NewPeriodicRetry(types.URLClientParams{Interval: 100000000, Timeout: 10})
 
 	expectedURL := "http://domain.com"
 	testEndpoint := mockEndpoint{ch: make(chan string, 1)}
@@ -96,7 +96,7 @@ func TestRegistryClient_Prefix_Periodic_TimedOut(t *testing.T) {
 	urlClient := newRegistryClient(
 		types.EndpointParams{},
 		mockEndpoint{},
-		retry.NewPeriodicRetry(100000, 1),
+		retry.NewPeriodicRetry(types.URLClientParams{Interval: 100000000, Timeout: 10}),
 	)
 
 	actualURL, err := urlClient.Prefix()

--- a/clients/urlclient/registry_test.go
+++ b/clients/urlclient/registry_test.go
@@ -96,7 +96,7 @@ func TestRegistryClient_Prefix_Periodic_TimedOut(t *testing.T) {
 	urlClient := newRegistryClient(
 		types.EndpointParams{},
 		mockEndpoint{},
-		retry.NewPeriodicRetry(types.URLClientParams{Interval: 100000000, Timeout: 10}),
+		retry.NewPeriodicRetry(types.URLClientParams{Interval: 100000000, Timeout: 1}),
 	)
 
 	actualURL, err := urlClient.Prefix()

--- a/clients/urlclient/retry/once.go
+++ b/clients/urlclient/retry/once.go
@@ -31,11 +31,8 @@ func NewOnce() *once {
 }
 
 // Retry is designed to poll for the data one time. If successful, it returns the data, otherwise it returns an error.
-func (o *once) Retry(isInitialized *bool, url *string) (string, error) {
-	o.SetLock(true)
-	defer o.SetLock(false)
-
-	if *isInitialized {
+func (o *once) Retry(url *string) (string, error) {
+	if !o.isLocked {
 		return *url, nil
 	}
 

--- a/clients/urlclient/retry/once.go
+++ b/clients/urlclient/retry/once.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// retry contains implementations of the retry interface.
+// These implementations should be designed to poll for data on some frequency defined by the implementation and
+// return that data if successful, an error otherwise.
+package retry
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/errors"
+)
+
+// once is designed to poll for the data one time. If successful, it returns the data, otherwise it returns an error.
+type once struct {
+	isLocked bool
+}
+
+func NewOnce() *once {
+	return &once{true}
+}
+
+// Retry is designed to poll for the data one time. If successful, it returns the data, otherwise it returns an error.
+func (o *once) Retry(isInitialized *bool, url *string) (string, error) {
+	o.SetLock(true)
+	defer o.SetLock(false)
+
+	if *isInitialized {
+		return *url, nil
+	}
+
+	return "", errors.NewTimeoutError()
+}
+
+// IsLocked communicates whether the value of the URL is currently being updated or not.
+func (o *once) IsLocked() bool {
+	return o.isLocked
+}
+
+// SetLock updates the value of the lock.
+func (o *once) SetLock(value bool) {
+	o.isLocked = value
+}

--- a/clients/urlclient/retry/periodic.go
+++ b/clients/urlclient/retry/periodic.go
@@ -44,8 +44,8 @@ func NewPeriodicRetry(params types.URLClientParams) *periodic {
 }
 
 // Retry is designed to poll for the data on a regular frequency until the timeout happens.
-func (p *periodic) Retry(isInitialized *bool, url *string) (string, error) {
-	if *isInitialized {
+func (p *periodic) Retry(url *string) (string, error) {
+	if !p.isLocked {
 		return *url, nil
 	}
 
@@ -59,7 +59,7 @@ func (p *periodic) Retry(isInitialized *bool, url *string) (string, error) {
 		case <-timer:
 			return "", errors.NewTimeoutError()
 		case <-ticker:
-			if *isInitialized && len(*url) != 0 {
+			if !p.isLocked && len(*url) != 0 {
 				return *url, nil
 			}
 			// do not handle uninitialized case here, we need to keep trying

--- a/clients/urlclient/retry/periodic.go
+++ b/clients/urlclient/retry/periodic.go
@@ -18,6 +18,7 @@ package retry
 import (
 	"time"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/errors"
 )
 
@@ -34,10 +35,10 @@ type periodic struct {
 // poll for the data on a regular frequency until the timeout happens.
 // tickTime defines the interval in milliseconds for how often the URL should be queried.
 // timeout defines the interval in seconds for how long the algorithm should query before giving up.
-func NewPeriodicRetry(tickTime int, timeout int) *periodic {
+func NewPeriodicRetry(params types.URLClientParams) *periodic {
 	return &periodic{
-		tickTime: time.Duration(tickTime),
-		timeout:  time.Duration(timeout),
+		tickTime: time.Duration(params.Interval),
+		timeout:  time.Duration(params.Timeout),
 		isLocked: true,
 	}
 }

--- a/clients/urlclient/retry/periodic.go
+++ b/clients/urlclient/retry/periodic.go
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// retry contains implementations of the retry interface.
+package retry
+
+import (
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/errors"
+)
+
+// periodic is designed to poll for the data on a regular frequency until the timeout happens.
+// tickTime defines the interval in milliseconds for how often the URL should be queried.
+// timeout defines the interval in seconds for how long the algorithm should query before giving up.
+type periodic struct {
+	tickTime time.Duration
+	timeout  time.Duration
+	isLocked bool
+}
+
+// NewPeriodicRetry provides an implementation of Retry that is designed to
+// poll for the data on a regular frequency until the timeout happens.
+// tickTime defines the interval in milliseconds for how often the URL should be queried.
+// timeout defines the interval in seconds for how long the algorithm should query before giving up.
+func NewPeriodicRetry(tickTime int, timeout int) *periodic {
+	return &periodic{
+		tickTime: time.Duration(tickTime),
+		timeout:  time.Duration(timeout),
+		isLocked: true,
+	}
+}
+
+// Retry is designed to poll for the data on a regular frequency until the timeout happens.
+func (p *periodic) Retry(isInitialized *bool, url *string) (string, error) {
+	if *isInitialized {
+		return *url, nil
+	}
+
+	p.SetLock(true)
+	defer p.SetLock(false)
+
+	timer := time.After(p.timeout * time.Second)
+	ticker := time.Tick(p.tickTime * time.Millisecond)
+	for {
+		select {
+		case <-timer:
+			return "", errors.NewTimeoutError()
+		case <-ticker:
+			if *isInitialized && len(*url) != 0 {
+				return *url, nil
+			}
+			// do not handle uninitialized case here, we need to keep trying
+		}
+	}
+}
+
+// IsLocked communicates whether the value of the URL is currently being updated or not.
+func (p *periodic) IsLocked() bool {
+	return p.isLocked
+}
+
+// SetLock updates the value of the lock.
+func (p *periodic) SetLock(value bool) {
+	p.isLocked = value
+}


### PR DESCRIPTION
Fixes #204.

Includes deterministic tests.

To verify, run `make test`.

Signed-off-by: Brandon Forster <me@brandonforster.com>