### PR TITLE
Add ValueType, MediaType, FloatEncoding to Reading

### DIFF
--- a/models/reading.go
+++ b/models/reading.go
@@ -20,31 +20,37 @@ import (
 
 // Reading contains data that was gathered from a device.
 type Reading struct {
-	Id          string `json:"id,omitempty" codec:"id,omitempty"`
-	Pushed      int64  `json:"pushed,omitempty" codec:"pushed,omitempty"`   // When the data was pushed out of EdgeX (0 - not pushed yet)
-	Created     int64  `json:"created,omitempty" codec:"created,omitempty"` // When the reading was created
-	Origin      int64  `json:"origin,omitempty" codec:"origin,omitempty"`
-	Modified    int64  `json:"modified,omitempty" codec:"modified,omitempty"`
-	Device      string `json:"device,omitempty" codec:"device,omitempty"`
-	Name        string `json:"name,omitempty" codec:"name,omitempty"`
-	Value       string `json:"value,omitempty"  codec:"value,omitempty"`            // Device sensor data value
-	BinaryValue []byte `json:"binaryValue,omitempty" codec:"binaryValue,omitempty"` // Binary data payload
-	isValidated bool   // internal member used for validation check
+	Id            string `json:"id,omitempty" codec:"id,omitempty"`
+	Pushed        int64  `json:"pushed,omitempty" codec:"pushed,omitempty"`   // When the data was pushed out of EdgeX (0 - not pushed yet)
+	Created       int64  `json:"created,omitempty" codec:"created,omitempty"` // When the reading was created
+	Origin        int64  `json:"origin,omitempty" codec:"origin,omitempty"`
+	Modified      int64  `json:"modified,omitempty" codec:"modified,omitempty"`
+	Device        string `json:"device,omitempty" codec:"device,omitempty"`
+	Name          string `json:"name,omitempty" codec:"name,omitempty"`
+	Value         string `json:"value,omitempty" codec:"value,omitempty"` // Device sensor data value
+	ValueType     string `json:"valueType,omitempty" codec:"valueType,omitempty"`
+	FloatEncoding string `json:"floatEncoding,omitempty" codec:"floatEncoding,omitempty"`
+	BinaryValue   []byte `json:"binaryValue,omitempty" codec:"binaryValue,omitempty"` // Binary data payload
+	MediaType     string `json:"mediaType,omitempty" codec:"mediaType,omitempty"`
+	isValidated   bool   // internal member used for validation check
 }
 
 // UnmarshalJSON implements the Unmarshaler interface for the Reading type
 func (r *Reading) UnmarshalJSON(data []byte) error {
 	var err error
 	type Alias struct {
-		Id          *string `json:"id"`
-		Pushed      int64   `json:"pushed"`
-		Created     int64   `json:"created"`
-		Origin      int64   `json:"origin"`
-		Modified    int64   `json:"modified"`
-		Device      *string `json:"device"`
-		Name        *string `json:"name"`
-		Value       *string `json:"value"`
-		BinaryValue []byte  `json:"binaryValue"`
+		Id            *string `json:"id"`
+		Pushed        int64   `json:"pushed"`
+		Created       int64   `json:"created"`
+		Origin        int64   `json:"origin"`
+		Modified      int64   `json:"modified"`
+		Device        *string `json:"device"`
+		Name          *string `json:"name"`
+		Value         *string `json:"value"`
+		ValueType     *string `json:"valueType"`
+		FloatEncoding *string `json:"floatEncoding"`
+		BinaryValue   []byte  `json:"binaryValue"`
+		MediaType     *string `json:"mediaType"`
 	}
 	a := Alias{}
 
@@ -65,6 +71,15 @@ func (r *Reading) UnmarshalJSON(data []byte) error {
 	}
 	if a.Value != nil {
 		r.Value = *a.Value
+	}
+	if a.ValueType != nil {
+		r.ValueType = *a.ValueType
+	}
+	if a.FloatEncoding != nil {
+		r.FloatEncoding = *a.FloatEncoding
+	}
+	if a.MediaType != nil {
+		r.MediaType = *a.MediaType
 	}
 	r.Pushed = a.Pushed
 	r.Created = a.Created

--- a/models/reading.go
+++ b/models/reading.go
@@ -18,6 +18,23 @@ import (
 	"encoding/json"
 )
 
+// Constants related to Reading ValueTypes
+const (
+	ValueTypeBool    = "Bool"
+	ValueTypeString  = "String"
+	ValueTypeUint8   = "Uint8"
+	ValueTypeUint16  = "Uint16"
+	ValueTypeUint32  = "Uint32"
+	ValueTypeUint64  = "Uint64"
+	ValueTypeInt8    = "Int8"
+	ValueTypeInt16   = "Int16"
+	ValueTypeInt32   = "Int32"
+	ValueTypeInt64   = "Int64"
+	ValueTypeFloat32 = "Float32"
+	ValueTypeFloat64 = "Float64"
+	ValueTypeBinary  = "Binary"
+)
+
 // Reading contains data that was gathered from a device.
 type Reading struct {
 	Id            string `json:"id,omitempty" codec:"id,omitempty"`
@@ -93,13 +110,22 @@ func (r *Reading) UnmarshalJSON(data []byte) error {
 
 // Validate satisfies the Validator interface
 func (r Reading) Validate() (bool, error) {
-	if !r.isValidated {
-		if r.Name == "" {
-			return false, NewErrContractInvalid("name for reading's value descriptor not specified")
-		}
-		if r.Value == "" && len(r.BinaryValue) == 0 {
-			return false, NewErrContractInvalid("reading has no value")
-		}
+	// Shortcut if Reading has already been validated
+	if r.isValidated {
+		return true, nil
+	}
+
+	if r.Name == "" {
+		return false, NewErrContractInvalid("name for reading's value descriptor not specified")
+	}
+	if r.Value == "" && len(r.BinaryValue) == 0 {
+		return false, NewErrContractInvalid("reading has no value")
+	}
+	if len(r.BinaryValue) != 0 && len(r.MediaType) == 0 {
+		return false, NewErrContractInvalid("media type must be specified for binary values")
+	}
+	if (r.ValueType == ValueTypeFloat32 || r.ValueType == ValueTypeFloat64) && len(r.FloatEncoding) == 0 {
+		return false, NewErrContractInvalid("float encoding must be specified for float values")
 	}
 	return true, nil
 }

--- a/models/reading_test.go
+++ b/models/reading_test.go
@@ -76,6 +76,12 @@ func TestReadingValidation(t *testing.T) {
 		{"empty device", Reading{Name: "test", Value: "0"}, false},
 		{"invalid name", Reading{Device: "test", Value: "0"}, true},
 		{"invalid value", Reading{Device: "test", Name: "test"}, true},
+		{"missing media type", Reading{Name: "test", BinaryValue: TestBinaryValue}, true},
+		{"media type present", Reading{Name: "test", BinaryValue: TestBinaryValue, MediaType: TestMediaType}, false},
+		{"missing float encoding f64", Reading{Name: "test", ValueType: ValueTypeFloat64, Value: "3.14"}, true},
+		{"missing float encoding f32", Reading{Name: "test", ValueType: ValueTypeFloat32, Value: "3.14"}, true},
+		{"valid float f64", Reading{Name: "test", ValueType: ValueTypeFloat64, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
+		{"valid float f32", Reading{Name: "test", ValueType: ValueTypeFloat32, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/reading_test.go
+++ b/models/reading_test.go
@@ -27,8 +27,10 @@ import (
 var TestId = "Thermometer"
 var TestValueDescriptorName = "Temperature"
 var TestValue = "45"
+var TestValueType = "Int16"
 var TestBinaryValue = []byte{0xbf}
-var TestReading = Reading{Id: TestId, Pushed: 123, Created: 123, Origin: 123, Modified: 123, Device: TestDeviceName, Name: TestValueDescriptorName, Value: TestValue, BinaryValue: TestBinaryValue}
+var TestFloatEncoding = "float16"
+var TestReading = Reading{Id: TestId, Pushed: 123, Created: 123, Origin: 123, Modified: 123, Device: TestDeviceName, Name: TestValueDescriptorName, Value: TestValue, ValueType: TestValueType, FloatEncoding: TestFloatEncoding, BinaryValue: TestBinaryValue, MediaType: TestMediaType}
 
 func TestReading_String(t *testing.T) {
 	var binarySlice, _ = json.Marshal(TestReading.BinaryValue)
@@ -46,7 +48,10 @@ func TestReading_String(t *testing.T) {
 				",\"device\":\"" + TestDeviceName + "\"" +
 				",\"name\":\"" + TestValueDescriptorName + "\"" +
 				",\"value\":\"" + TestValue + "\"" +
+				",\"valueType\":\"" + TestValueType + "\"" +
+				",\"floatEncoding\":\"" + TestFloatEncoding + "\"" +
 				",\"binaryValue\":" + fmt.Sprint(string(binarySlice)) +
+				",\"mediaType\":\"" + TestMediaType + "\"" +
 				"}"},
 		{"empty reading to string", Reading{}, testEmptyJSON},
 	}


### PR DESCRIPTION
Fixes #193.  Add some fields to Reading value as discussed
on 3/2/20 DS Working Group call and documented in discussion
at https://github.com/edgexfoundry/go-mod-core-contracts/issues/193

Signed-off-by: Daniel Harms <jdharms@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The Reading structure is missing a field for Datatype of Sensor Value.

Issue Number:
https://github.com/edgexfoundry/go-mod-core-contracts/issues/193

## What is the new behavior?
Reading type has fields for ValueType, FloatEncoding, and MediaType.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information