### PR TITLE
Restore clients/general directory

### DIFF
--- a/clients/general/client.go
+++ b/clients/general/client.go
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Joan Duran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// general provides a client for calling operational endpoints that are present on all service APIs.
+package general
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/interfaces"
+)
+
+type GeneralClient interface {
+	// FetchConfiguration obtains configuration information from the target service.
+	FetchConfiguration(ctx context.Context) (string, error)
+	// FetchMetrics obtains metrics information from the target service.
+	FetchMetrics(ctx context.Context) (string, error)
+}
+
+type generalRestClient struct {
+	urlClient interfaces.URLClient
+}
+
+// NewGeneralClient creates an instance of GeneralClient
+func NewGeneralClient(urlClient interfaces.URLClient) GeneralClient {
+	return &generalRestClient{
+		urlClient: urlClient,
+	}
+}
+
+func (gc *generalRestClient) FetchConfiguration(ctx context.Context) (string, error) {
+	body, err := clients.GetRequest(ctx, clients.ApiConfigRoute, gc.urlClient)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+func (gc *generalRestClient) FetchMetrics(ctx context.Context) (string, error) {
+	body, err := clients.GetRequest(ctx, clients.ApiMetricsRoute, gc.urlClient)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/clients/general/client_test.go
+++ b/clients/general/client_test.go
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Joan Duran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package general
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+)
+
+const (
+	TestUnexpectedMsgFormatStr = "unexpected result, active: '%s' but expected: '%s'"
+)
+
+func TestGetConfig(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{ 'status' : 'OK' }"))
+		if r.Method != http.MethodGet {
+			t.Errorf(TestUnexpectedMsgFormatStr, r.Method, http.MethodGet)
+		}
+		if r.URL.EscapedPath() != clients.ApiConfigRoute {
+			t.Errorf(TestUnexpectedMsgFormatStr, r.URL.EscapedPath(), clients.ApiConfigRoute)
+		}
+	}))
+
+	defer ts.Close()
+
+	mc := NewGeneralClient(local.New(ts.URL))
+
+	responseJSON, err := mc.FetchConfiguration(context.Background())
+	if err != nil {
+		t.Errorf("Fetched this for its configuration: {%v}", responseJSON)
+	}
+}
+
+func TestGetMetrics(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{ 'status' : 'OK' }"))
+		if r.Method != http.MethodGet {
+			t.Errorf(TestUnexpectedMsgFormatStr, r.Method, http.MethodGet)
+		}
+		if r.URL.EscapedPath() != clients.ApiMetricsRoute {
+			t.Errorf(TestUnexpectedMsgFormatStr, r.URL.EscapedPath(), clients.ApiMetricsRoute)
+		}
+	}))
+
+	defer ts.Close()
+
+	mc := NewGeneralClient(local.New(ts.URL))
+
+	responseJSON, err := mc.FetchMetrics(context.Background())
+	if err != nil {
+		t.Errorf("Fetched this for its configuration: {%v}", responseJSON)
+	}
+}


### PR DESCRIPTION
Fixes #237 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

This commit is a partial revert of PR #231. The SMA client remains, but the general client is restored.  I was under the mistaken impression that the SMA client would replace the general client.  This commit fixes the issue.