### PR TITLE
Update Reading Validation-Allow Empty Binary Data

### DIFF
--- a/models/reading_test.go
+++ b/models/reading_test.go
@@ -69,23 +69,26 @@ func TestReadingValidation(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		r           Reading
+		reading     Reading
 		expectError bool
 	}{
 		{"valid reading", valid, false},
 		{"empty device", Reading{Name: "test", Value: "0"}, false},
-		{"invalid name", Reading{Device: "test", Value: "0"}, true},
-		{"invalid value", Reading{Device: "test", Name: "test"}, true},
+		{"missing name", Reading{Device: "test", Value: "0"}, true},
+		{"missing value", Reading{Device: "test", Name: "test"}, true},
 		{"missing media type", Reading{Name: "test", BinaryValue: TestBinaryValue}, true},
-		{"media type present", Reading{Name: "test", BinaryValue: TestBinaryValue, MediaType: TestMediaType}, false},
+		{"media type present", Reading{Name: "test", Value: "test", MediaType: TestMediaType}, false},
 		{"missing float encoding f64", Reading{Name: "test", ValueType: ValueTypeFloat64, Value: "3.14"}, true},
 		{"missing float encoding f32", Reading{Name: "test", ValueType: ValueTypeFloat32, Value: "3.14"}, true},
 		{"valid float f64", Reading{Name: "test", ValueType: ValueTypeFloat64, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
 		{"valid float f32", Reading{Name: "test", ValueType: ValueTypeFloat32, FloatEncoding: TestFloatEncoding, Value: "3.14"}, false},
+		{"valid empty binary value", Reading{Name: "test", ValueType: ValueTypeBinary}, false},
+		{"valid binary value", Reading{Name: "test", ValueType: ValueTypeBinary, BinaryValue: TestBinaryValue, MediaType: TestMediaType}, false},
+		{"missing media type for binary reading", Reading{Name: "test", ValueType: ValueTypeBinary, BinaryValue: TestBinaryValue}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.r.Validate()
+			_, err := tt.reading.Validate()
 			checkValidationError(err, tt.expectError, tt.name, t)
 		})
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Reading validation enforces a `BinaryValue`(Binary payload) for all readings that are of type `Binary`.

Issue Number: #240 


## What is the new behavior?
Reading validation allows for empty `BinaryValue` data(binary reading data).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Validation is more relaxed. However, other modules will need to obtain these changes to be able to properly `Unmarshal` binary `Reading`s and `Event`s that contain binary `Reading`s.

## Are there any specific instructions or things that should be known prior to reviewing?
See issue https://github.com/edgexfoundry/edgex-go/issues/2527 for more information.

## Other information

I tested these changes locally with `edgex-go`, specifically `core-data` to ensure we are able to properly avoid persisting binary readings and still allow the user to obtain the readings and associated events.

This issue is depended on by https://github.com/edgexfoundry/edgex-go/issues/2527