### PR TITLE
Fix URL -> Remove Interval By ID

### DIFF
--- a/clients/scheduler/interval.go
+++ b/clients/scheduler/interval.go
@@ -59,7 +59,7 @@ func (ic *intervalRestClient) Add(ctx context.Context, interval *models.Interval
 }
 
 func (ic *intervalRestClient) Delete(ctx context.Context, id string) error {
-	return clients.DeleteRequest(ctx, "/id/"+id, ic.urlClient)
+	return clients.DeleteRequest(ctx, "/"+id, ic.urlClient)
 }
 
 func (ic *intervalRestClient) DeleteByName(ctx context.Context, name string) error {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
go-mod-core-contracts is not compliant with edgex-go about the URL of "remove interval by id" endpoint 
go-mod-core-contract construct the url like this: /api/v1/interval/id/{id}, meanwhile edgex-go exports endpoint  /api/v1/interval/{id}
Issue Number:
https://github.com/edgexfoundry/go-mod-core-contracts/issues/247

## What is the new behavior?
Change the URL from /api/v1/interval/id/{id} to /api/v1/interval/{id}


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## Are there any new imports or modules? If so, what are they used for and why? No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

Signed-off-by: Diana Atanasova <dianaa@vmware.com>