### PR TITLE
refactor: Rename device field to deviceName in V2 CoreData DTO and Model

### DIFF
--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -17,7 +17,7 @@ type BaseReading struct {
 	Created       int64    `json:"created"`
 	Origin        int64    `json:"origin"`
 	Modified      int64    `json:"modified,omitempty"`
-	Device        string   `json:"device"`
+	DeviceName    string   `json:"deviceName"`
 	Name          string   `json:"name"`
 	Labels        []string `json:"labels,omitempty"`
 	BinaryReading `json:",inline"`
@@ -46,9 +46,9 @@ type SimpleReading struct {
 func ToReadingModel(r BaseReading, device string) models.Reading {
 	var readingModel models.Reading
 	br := models.BaseReading{
-		Device: device,
-		Name:   r.Name,
-		Labels: r.Labels,
+		DeviceName: device,
+		Name:       r.Name,
+		Labels:     r.Labels,
 	}
 	if r.ValueType != "" {
 		readingModel = models.SimpleReading{

--- a/v2/dtos/reading_test.go
+++ b/v2/dtos/reading_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 var testSimpleReading = BaseReading{
-	Device: TestDeviceName,
-	Name:   TestReadingName,
+	DeviceName: TestDeviceName,
+	Name:       TestReadingName,
 	SimpleReading: SimpleReading{
 		ValueType: TestValueType,
 		Value:     TestValue,
@@ -26,8 +26,8 @@ func Test_ToReadingModel(t *testing.T) {
 	valid := testSimpleReading
 	expectedSimpleReading := models.SimpleReading{
 		BaseReading: models.BaseReading{
-			Device: TestDeviceName,
-			Name:   TestReadingName,
+			DeviceName: TestDeviceName,
+			Name:       TestReadingName,
 		},
 		Value:     TestValue,
 		ValueType: TestValueType,

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -19,7 +19,7 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/AddEventRequest
 type AddEventRequest struct {
 	common.BaseRequest `json:",inline"`
-	Device             string             `json:"device" validate:"required"`
+	DeviceName         string             `json:"deviceName" validate:"required"`
 	Origin             int64              `json:"origin" validate:"required"`
 	Readings           []dtos.BaseReading `json:"readings"`
 }
@@ -41,16 +41,16 @@ func (a AddEventRequest) Validate() error {
 func (a *AddEventRequest) UnmarshalJSON(b []byte) error {
 	var addEvent struct {
 		common.BaseRequest
-		Device   string
-		Origin   int64
-		Readings []dtos.BaseReading
+		DeviceName string
+		Origin     int64
+		Readings   []dtos.BaseReading
 	}
 	if err := json.Unmarshal(b, &addEvent); err != nil {
 		return v2.NewErrContractInvalid("Failed to unmarshal request body as JSON.")
 	}
 
 	a.RequestID = addEvent.RequestID
-	a.Device = addEvent.Device
+	a.DeviceName = addEvent.DeviceName
 	a.Origin = addEvent.Origin
 	a.Readings = addEvent.Readings
 
@@ -67,9 +67,9 @@ func AddEventReqToEventModels(addRequests []AddEventRequest) (events []models.Ev
 		var e models.Event
 		readings := make([]models.Reading, len(a.Readings))
 		for i, r := range a.Readings {
-			readings[i] = dtos.ToReadingModel(r, a.Device)
+			readings[i] = dtos.ToReadingModel(r, a.DeviceName)
 		}
-		e.Device = a.Device
+		e.DeviceName = a.DeviceName
 		e.Origin = a.Origin
 		e.Readings = readings
 		events = append(events, e)

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -21,19 +21,19 @@ var testAddEvent = AddEventRequest{
 	BaseRequest: common.BaseRequest{
 		RequestID: ExampleUUID,
 	},
-	Device:   TestDeviceName,
-	Origin:   TestOriginTime,
-	Readings: nil,
+	DeviceName: TestDeviceName,
+	Origin:     TestOriginTime,
+	Readings:   nil,
 }
 
 func TestAddEventRequest_Validate(t *testing.T) {
 	valid := testAddEvent
 	noReID := testAddEvent
 	noReID.RequestID = ""
-	noDevice := testAddEvent
-	noDevice.Device = ""
+	noDeviceName := testAddEvent
+	noDeviceName.DeviceName = ""
 	noDeviceOrigin := testAddEvent
-	noDeviceOrigin.Device = ""
+	noDeviceOrigin.DeviceName = ""
 	noDeviceOrigin.Origin = 0
 	tests := []struct {
 		name        string
@@ -42,7 +42,7 @@ func TestAddEventRequest_Validate(t *testing.T) {
 	}{
 		{"valid AddEventRequest", valid, false},
 		{"invalid AddEventRequest, no Request Id", noReID, true},
-		{"invalid AddEventRequest, no Device", noDevice, true},
+		{"invalid AddEventRequest, no DeviceName", noDeviceName, true},
 		{"invalid AddEventRequest, no Origin", noDeviceOrigin, true},
 	}
 	for _, tt := range tests {
@@ -86,9 +86,9 @@ func TestAddEvent_UnmarshalJSON(t *testing.T) {
 func Test_AddEventReqToEventModels(t *testing.T) {
 	valid := []AddEventRequest{testAddEvent}
 	expectedEventModel := []models.Event{{
-		Device:   TestDeviceName,
-		Origin:   TestOriginTime,
-		Readings: []models.Reading{},
+		DeviceName: TestDeviceName,
+		Origin:     TestOriginTime,
+		Readings:   []models.Reading{},
 	}}
 	tests := []struct {
 		name      string

--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -22,13 +22,13 @@ type AddEventResponse struct {
 // This object and its properties correspond to the Event object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/Event
 type Event struct {
-	ID       string             `json:"id"`
-	Pushed   int64              `json:"pushed,omitempty"`
-	Device   string             `json:"device"`
-	Created  int64              `json:"created"`
-	Modified int64              `json:"modified,omitempty"`
-	Origin   int64              `json:"origin"`
-	Readings []dtos.BaseReading `json:"readings"`
+	ID         string             `json:"id"`
+	Pushed     int64              `json:"pushed,omitempty"`
+	DeviceName string             `json:"deviceName"`
+	Created    int64              `json:"created"`
+	Modified   int64              `json:"modified,omitempty"`
+	Origin     int64              `json:"origin"`
+	Readings   []dtos.BaseReading `json:"readings"`
 }
 
 // EventCountResponse defines the Response Content for GET event count DTO.

--- a/v2/models/event.go
+++ b/v2/models/event.go
@@ -11,7 +11,7 @@ type Event struct {
 	Checksum      string
 	Id            string    // Id uniquely identifies an event, for example a UUID
 	Pushed        int64     // Pushed is a timestamp indicating when the event was exported. If unexported, the value is zero.
-	Device        string    // Device identifies the source of the event, can be a device name or id. Usually the device name.
+	DeviceName    string    // DeviceName identifies the source of the event
 	Created       int64     // Created is a timestamp indicating when the event was created.
 	Modified      int64     // Modified is a timestamp indicating when the event was last modified.
 	Origin        int64     // Origin is a timestamp that can communicate the time of the original reading, prior to event creation

--- a/v2/models/reading.go
+++ b/v2/models/reading.go
@@ -14,7 +14,7 @@ type BaseReading struct {
 	Created     int64 // When the reading was created
 	Origin      int64
 	Modified    int64
-	Device      string
+	DeviceName  string
 	Name        string
 	Labels      []string // Custom labels assigned to a reading, added in the APIv2 specification.
 	isValidated bool     // internal member used for validation check


### PR DESCRIPTION
Fix: #251

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #251


## What is the new behavior?
In Event and Reading, there is a device field. According to Core WG meeting on July 9th 2020, rename to deviceName to make it explicit.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information