### PR TITLE
feat: Update common Response DTOs (Add factory method & remove BaseResponse)

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -7,6 +7,7 @@ package v2
 
 // Constants related to defined routes in the v2 service APIs
 const (
+	ApiVersion                 = "v2"
 	ApiBase                    = "/api/v2"
 	ApiEventRoute              = ApiBase + "/event"
 	ApiAllEventRoute           = ApiEventRoute + "/" + All

--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -5,6 +5,8 @@
 
 package common
 
+import v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+
 const API_VERSION = "v2"
 
 // Request defines the base content for request DTOs (data transfer objects).
@@ -27,4 +29,21 @@ type BaseResponse struct {
 // Versionable shows the API version in DTOs
 type Versionable struct {
 	ApiVersion string `json:"apiVersion,omitempty"`
+}
+
+func NewBaseResponseNoMessage(requestId string, statusCode uint16) BaseResponse {
+	return NewBaseResponse(requestId, "", statusCode)
+}
+
+func NewBaseResponse(requestId string, message string, statusCode uint16) BaseResponse {
+	return BaseResponse{
+		Versionable: NewVersionable(),
+		RequestID:   requestId,
+		Message:     message,
+		StatusCode:  statusCode,
+	}
+}
+
+func NewVersionable() Versionable {
+	return Versionable{ApiVersion: v2.ApiVersion}
 }

--- a/v2/dtos/common/base_test.go
+++ b/v2/dtos/common/base_test.go
@@ -1,0 +1,41 @@
+//
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+)
+
+func TestNewBaseResponse(t *testing.T) {
+	expectedRequestID := "123456"
+	expectedStatusCode := uint16(200)
+	expectedMessage := "unit test message"
+	actual := NewBaseResponse(expectedRequestID, expectedMessage, expectedStatusCode)
+
+	assert.Equal(t, expectedRequestID, actual.RequestID)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+}
+
+func TestNewBaseResponseNoMessage(t *testing.T) {
+	expectedRequestID := "123456"
+	expectedStatusCode := uint16(200)
+	actual := NewBaseResponseNoMessage(expectedRequestID, expectedStatusCode)
+
+	assert.Equal(t, expectedRequestID, actual.RequestID)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Empty(t, actual.Message)
+}
+
+func TestNewVersionable(t *testing.T) {
+	actual := NewVersionable()
+	assert.Equal(t, v2.ApiVersion, actual.ApiVersion)
+}

--- a/v2/dtos/common/config.go
+++ b/v2/dtos/common/config.go
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +10,14 @@ package common
 // This object and its properties correspond to the ConfigResponse object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/ConfigResponse
 type ConfigResponse struct {
-	BaseResponse `json:",inline"`
-	Config       interface{} `json:"config"`
+	Versionable `json:",inline"`
+	Config      interface{} `json:"config"`
+}
+
+// NewConfigResponse creates new ConfigResponse with all fields set appropriately
+func NewConfigResponse(serviceConfig interface{}) ConfigResponse {
+	return ConfigResponse{
+		Versionable: NewVersionable(),
+		Config:      serviceConfig,
+	}
 }

--- a/v2/dtos/common/config_test.go
+++ b/v2/dtos/common/config_test.go
@@ -1,0 +1,38 @@
+//
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+)
+
+func TestNewConfigResponse(t *testing.T) {
+	type testConfig struct {
+		Name string
+		Host string
+		Port int
+	}
+
+	expected := testConfig{
+		Name: "UnitTest",
+		Host: "localhost",
+		Port: 8080,
+	}
+
+	target := NewConfigResponse(expected)
+
+	assert.Equal(t, v2.ApiVersion, target.ApiVersion)
+	data, _ := json.Marshal(target.Config)
+	actual := testConfig{}
+	json.Unmarshal(data, &actual)
+	assert.Equal(t, expected, actual)
+}

--- a/v2/dtos/common/metrics.go
+++ b/v2/dtos/common/metrics.go
@@ -1,15 +1,12 @@
 //
 // Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package common
 
-// MetricsResponse defines the providing memory and cpu utilization stats of the service.
-// This object and its properties correspond to the MetricsResponse object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/MetricsResponse
-type MetricsResponse struct {
-	BaseResponse   `json:",inline"`
+type Metrics struct {
 	MemAlloc       uint64 `json:"memAlloc"`
 	MemFrees       uint64 `json:"memFrees"`
 	MemLiveObjects uint64 `json:"memLiveObjects"`
@@ -17,4 +14,20 @@ type MetricsResponse struct {
 	MemSys         uint64 `json:"memSys"`
 	MemTotalAlloc  uint64 `json:"memTotalAlloc"`
 	CpuBusyAvg     uint8  `json:"cpuBusyAvg"`
+}
+
+// MetricsResponse defines the providing memory and cpu utilization stats of the service.
+// This object and its properties correspond to the MetricsResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/MetricsResponse
+type MetricsResponse struct {
+	Versionable `json:",inline"`
+	Metrics     `json:",inline"`
+}
+
+// NewMetricsResponse creates new MetricsResponse with all fields set appropriately
+func NewMetricsResponse(metrics Metrics) MetricsResponse {
+	return MetricsResponse{
+		Versionable: NewVersionable(),
+		Metrics:     metrics,
+	}
 }

--- a/v2/dtos/common/metrics_test.go
+++ b/v2/dtos/common/metrics_test.go
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+)
+
+func TestNewMetricsResponse(t *testing.T) {
+	expected := Metrics{
+		MemAlloc:       uint64(234),
+		MemFrees:       uint64(1204),
+		MemLiveObjects: uint64(999),
+		MemSys:         uint64(123456789),
+		MemTotalAlloc:  uint64(9999999),
+		MemMallocs:     uint64(1589),
+		CpuBusyAvg:     uint8(99),
+	}
+	target := NewMetricsResponse(expected)
+
+	actual := target.Metrics
+	assert.Equal(t, v2.ApiVersion, target.ApiVersion)
+	assert.Equal(t, expected, actual)
+}

--- a/v2/dtos/common/ping.go
+++ b/v2/dtos/common/ping.go
@@ -1,14 +1,27 @@
 //
 // Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package common
 
+import (
+	"time"
+)
+
 // PingResponse defines the content of response content for POST Ping DTO
 // This object and its properties correspond to the Ping object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/PingResponse
 type PingResponse struct {
-	BaseResponse `json:",inline"`
-	Timestamp    string `json:"timestamp"`
+	Versionable `json:",inline"`
+	Timestamp   string `json:"timestamp"`
+}
+
+// NewPingResponse creates new PingResponse with all fields set appropriately
+func NewPingResponse() PingResponse {
+	return PingResponse{
+		Versionable: NewVersionable(),
+		Timestamp:   time.Now().Format(time.UnixDate),
+	}
 }

--- a/v2/dtos/common/ping_test.go
+++ b/v2/dtos/common/ping_test.go
@@ -1,0 +1,24 @@
+//
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+)
+
+func TestNewPingResponse(t *testing.T) {
+	target := NewPingResponse()
+
+	assert.Equal(t, v2.ApiVersion, target.ApiVersion)
+	_, err := time.Parse(time.UnixDate, target.Timestamp)
+	assert.NoError(t, err)
+}

--- a/v2/dtos/common/version.go
+++ b/v2/dtos/common/version.go
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,13 +10,30 @@ package common
 // This object and its properties correspond to the VersionResponse object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/VersionResponse
 type VersionResponse struct {
-	BaseResponse `json:",inline"`
-	Version      string `json:"version"`
+	Versionable `json:",inline"`
+	Version     string `json:"version"`
 }
 
 // VersionSdkResponse defines the latest sdk version supported by the service.
 // This object and its properties correspond to the VersionSdkResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/VersionSdkResponse
 type VersionSdkResponse struct {
 	VersionResponse `json:",inline"`
 	SdkVersion      string `json:"sdk_version"`
+}
+
+// NewVersionResponse creates new VersionResponse with all fields set appropriately
+func NewVersionResponse(version string) VersionResponse {
+	return VersionResponse{
+		Versionable: NewVersionable(),
+		Version:     version,
+	}
+}
+
+// NewVersionSdkResponse creates new VersionSdkResponse with all fields set appropriately
+func NewVersionSdkResponse(appVersion string, sdkVersion string) VersionSdkResponse {
+	return VersionSdkResponse{
+		VersionResponse: NewVersionResponse(appVersion),
+		SdkVersion:      sdkVersion,
+	}
 }

--- a/v2/dtos/common/version_test.go
+++ b/v2/dtos/common/version_test.go
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+)
+
+func TestNewVersionResponse(t *testing.T) {
+	expectedVersion := "1.2.2"
+	target := NewVersionResponse(expectedVersion)
+
+	assert.Equal(t, v2.ApiVersion, target.ApiVersion)
+	assert.Equal(t, expectedVersion, target.Version)
+}
+
+func TestNewVersionSdkResponse(t *testing.T) {
+	expectedVersion := "1.3.0"
+	expectedSdkVersion := "1.2.1"
+	target := NewVersionSdkResponse(expectedVersion, expectedSdkVersion)
+
+	assert.Equal(t, v2.ApiVersion, target.ApiVersion)
+	assert.Equal(t, expectedVersion, target.Version)
+	assert.Equal(t, expectedSdkVersion, target.SdkVersion)
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
BaseResponse in the common DTOs (Ping, config, metrics, version) is no longer needed 
No common factory methods for created the common DTOs .

Issue Number: #259 

## What is the new behavior?

BaseResponse removed from common DTOs.
No common factory methods for created the common DTOs

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information