### PR TITLE
fix: Provided custom XML marshaling of Event

### DIFF
--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -6,6 +6,10 @@
 package dtos
 
 import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+
 	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
@@ -22,7 +26,7 @@ type Event struct {
 	Created            int64             `json:"created"`
 	Origin             int64             `json:"origin" validate:"required"`
 	Readings           []BaseReading     `json:"readings" validate:"gt=0,dive,required"`
-	Tags               map[string]string `json:"tags,omitempty"`
+	Tags               map[string]string `json:"tags,omitempty" xml:"-"` // Have to ignore since map not supported for XML
 }
 
 func FromEventModelToDTO(event models.Event) Event {
@@ -46,4 +50,27 @@ func FromEventModelToDTO(event models.Event) Event {
 		Readings:    readings,
 		Tags:        tags,
 	}
+}
+
+// ToXML provides a XML representation of the Event as a string
+func (e Event) ToXML() (string, error) {
+	eventXml, err := xml.Marshal(e)
+	if err != nil {
+		return "", err
+	}
+
+	// The Tags field is being ignore from XML Marshaling since maps are not supported.
+	// We have to provide our own marshaling of the Tags field if it is non-empty
+	if len(e.Tags) > 0 {
+		tagsXmlElements := []string{"<Tags>"}
+		for key, value := range e.Tags {
+			tag := fmt.Sprintf("<%s>%s</%s>", key, value, key)
+			tagsXmlElements = append(tagsXmlElements, tag)
+		}
+		tagsXmlElements = append(tagsXmlElements, "</Tags>")
+		tagsXml := strings.Join(tagsXmlElements, "")
+		eventXml = []byte(strings.Replace(string(eventXml), "</Event>", tagsXml+"</Event>", 1))
+	}
+
+	return string(eventXml), nil
 }

--- a/v2/dtos/event_test.go
+++ b/v2/dtos/event_test.go
@@ -6,6 +6,7 @@
 package dtos
 
 import (
+	"fmt"
 	"testing"
 
 	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
@@ -15,29 +16,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFromEventModelToDTO(t *testing.T) {
-	valid := models.Event{
-		Id:         TestUUID,
-		Pushed:     TestTimestamp,
-		DeviceName: TestDeviceName,
-		Created:    TestTimestamp,
-		Origin:     TestTimestamp,
-		Tags: map[string]string{
-			"GatewayID": "Houston-0001",
-		},
-	}
-	expectedDTO := Event{
-		Versionable: common.Versionable{ApiVersion: v2.ApiVersion},
-		ID:          TestUUID,
-		Pushed:      TestTimestamp,
-		DeviceName:  TestDeviceName,
-		Created:     TestTimestamp,
-		Origin:      TestTimestamp,
-		Tags: map[string]string{
-			"GatewayID": "Houston-0001",
-		},
-	}
+var valid = models.Event{
+	Id:         TestUUID,
+	Pushed:     TestTimestamp,
+	DeviceName: TestDeviceName,
+	Created:    TestTimestamp,
+	Origin:     TestTimestamp,
+	Tags: map[string]string{
+		"GatewayID": "Houston-0001",
+		"Latitude":  "29.630771",
+		"Longitude": "-95.377603",
+	},
+}
 
+var expectedDTO = Event{
+	Versionable: common.Versionable{ApiVersion: v2.ApiVersion},
+	ID:          TestUUID,
+	Pushed:      TestTimestamp,
+	DeviceName:  TestDeviceName,
+	Created:     TestTimestamp,
+	Origin:      TestTimestamp,
+	Tags: map[string]string{
+		"GatewayID": "Houston-0001",
+		"Latitude":  "29.630771",
+		"Longitude": "-95.377603",
+	},
+}
+
+func TestFromEventModelToDTO(t *testing.T) {
 	tests := []struct {
 		name  string
 		event models.Event
@@ -49,5 +55,20 @@ func TestFromEventModelToDTO(t *testing.T) {
 			result := FromEventModelToDTO(tt.event)
 			assert.Equal(t, expectedDTO, result, "FromEventModelToDTO did not result in expected Event DTO.")
 		})
+	}
+}
+
+func TestEvent_ToXML(t *testing.T) {
+	// Since the order in map is random we have to verify the individual items exists without depending on order
+	contains := []string{
+		"<Event><ApiVersion>v2</ApiVersion><ID>7a1707f0-166f-4c4b-bc9d-1d54c74e0137</ID><Pushed>1594963842</Pushed><DeviceName>TestDevice</DeviceName><Created>1594963842</Created><Origin>1594963842</Origin><Tags>",
+		"<GatewayID>Houston-0001</GatewayID>",
+		"<Latitude>29.630771</Latitude>",
+		"<Longitude>-95.377603</Longitude>",
+		"</Tags></Event>",
+	}
+	actual, _ := expectedDTO.ToXML()
+	for _, item := range contains {
+		assert.Contains(t, actual, item, fmt.Sprintf("Missing item '%s'", item))
 	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Go's XML marshal doesn't support maps and throws error when marshaling event due to Tags field.

Issue Number: #276


## What is the new behavior?

Disabled XML marshaling of Event Tags field via attribute so error isn't thrown
Add custom ToXML() function that handles the Tags field after marshaling rest of Event fields.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no
## Are there any specific instructions or things that should be known prior to reviewing?
no
## Other information