### PR TITLE
fix: Don't in-line `Metrics` property on MetricsResponse so that it matches swagger

### DIFF
--- a/v2/dtos/common/metrics.go
+++ b/v2/dtos/common/metrics.go
@@ -21,7 +21,7 @@ type Metrics struct {
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/MetricsResponse
 type MetricsResponse struct {
 	Versionable `json:",inline"`
-	Metrics     `json:",inline"`
+	Metrics     Metrics `json:"metrics"`
 }
 
 // NewMetricsResponse creates new MetricsResponse with all fields set appropriately


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Metrics property on MetricsResonse was in-lined, thus not matching the swagger definition.

Issue Number: #280


## What is the new behavior?

Metrics property on MetricsResonse was no longer in-lined, thus it now matches the swagger definition.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information