### PR TITLE
fix: RequestId in V2 API can be empty or uuid

### DIFF
--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -11,7 +11,7 @@ import v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 // This object and its properties correspond to the BaseRequest object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BaseRequest
 type BaseRequest struct {
-	RequestID string `json:"requestId" validate:"uuid"`
+	RequestID string `json:"requestId" validate:"len=0|uuid"`
 }
 
 // BaseResponse defines the base content for response DTOs (data transfer objects).

--- a/v2/dtos/requests/device_test.go
+++ b/v2/dtos/requests/device_test.go
@@ -88,8 +88,10 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 	valid := testAddDevice
 	invalidFrequency := testAddDevice
 	invalidFrequency.Device.AutoEvents = testAutoEventsWithInvalidFrequency
-	noReID := testAddDevice
-	noReID.RequestID = ""
+	noReqID := testAddDevice
+	noReqID.RequestID = ""
+	invalidReqID := testAddDevice
+	invalidReqID.RequestID = "abc"
 	noDeviceName := testAddDevice
 	noDeviceName.Device.Name = ""
 	noServiceName := testAddDevice
@@ -113,7 +115,8 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 	}{
 		{"valid AddDeviceRequest", valid, false},
 		{"invalid AddDeviceRequest, invalid autoEvent frequency", invalidFrequency, true},
-		{"invalid AddDeviceRequest, no Request Id", noReID, true},
+		{"valid AddDeviceRequest, no Request Id", noReqID, false},
+		{"invalid AddDeviceRequest, Request Id is not an uuid", invalidReqID, true},
 		{"invalid AddDeviceRequest, no DeviceName", noDeviceName, true},
 		{"invalid AddDeviceRequest, no ServiceName", noServiceName, true},
 		{"invalid AddDeviceRequest, no ProfileName", noProfileName, true},
@@ -224,8 +227,10 @@ func TestUpdateDeviceRequest_Validate(t *testing.T) {
 	validWithoutId.Device.Id = nil
 	validWithoutDeviceName := testUpdateDevice
 	validWithoutDeviceName.Device.Name = nil
-	noReID := testUpdateDevice
-	noReID.RequestID = ""
+	noReqID := testUpdateDevice
+	noReqID.RequestID = ""
+	invalidReqID := testUpdateDevice
+	invalidReqID.RequestID = "123"
 	noIdAndDeviceName := testUpdateDevice
 	noIdAndDeviceName.Device.Id = nil
 	noIdAndDeviceName.Device.Name = nil
@@ -246,7 +251,8 @@ func TestUpdateDeviceRequest_Validate(t *testing.T) {
 		{"valid UpdateDeviceRequest", valid, false},
 		{"valid UpdateDeviceRequest without Id", validWithoutId, false},
 		{"valid UpdateDeviceRequest without Name", validWithoutDeviceName, false},
-		{"invalid UpdateDeviceRequest, no Request Id", noReID, true},
+		{"valid UpdateDeviceRequest, no Request Id", noReqID, false},
+		{"invalid UpdateDeviceRequest, Request Id is not an uuid", invalidReqID, true},
 		{"invalid UpdateDeviceRequest, invalid admin state", invalidAdminState, true},
 		{"invalid UpdateDeviceRequest, invalid operating state", invalidOperatingState, true},
 		{"invalid UpdateDeviceRequest, invalid autoEvent frequency", invalidFrequency, true},

--- a/v2/dtos/requests/deviceservice_test.go
+++ b/v2/dtos/requests/deviceservice_test.go
@@ -56,8 +56,10 @@ func mockDeviceServiceDTO() dtos.UpdateDeviceService {
 
 func TestAddDeviceServiceRequest_Validate(t *testing.T) {
 	valid := testAddDeviceService
-	noReID := testAddDeviceService
-	noReID.RequestID = ""
+	noReqID := testAddDeviceService
+	noReqID.RequestID = ""
+	invalidReqID := testAddDeviceService
+	invalidReqID.RequestID = "jfdw324"
 	noName := testAddDeviceService
 	noName.Service.Name = ""
 	noOperatingState := testAddDeviceService
@@ -78,7 +80,8 @@ func TestAddDeviceServiceRequest_Validate(t *testing.T) {
 		expectError   bool
 	}{
 		{"valid AddDeviceServiceRequest", valid, false},
-		{"invalid AddDeviceServiceRequest, no Request Id", noReID, true},
+		{"valid AddDeviceServiceRequest, no Request Id", noReqID, false},
+		{"invalid AddDeviceServiceRequest, Request Id is not an uuid", invalidReqID, true},
 		{"invalid AddDeviceServiceRequest, no Name", noName, true},
 		{"invalid AddDeviceServiceRequest, no OperatingState", noOperatingState, true},
 		{"invalid AddDeviceServiceRequest, invalid OperatingState", invalidOperatingState, true},
@@ -176,8 +179,10 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 	validWithoutId.Service.Id = nil
 	validWithoutName := valid
 	validWithoutName.Service.Name = nil
-	noReID := valid
-	noReID.RequestID = ""
+	noReqID := valid
+	noReqID.RequestID = ""
+	invalidReqID := valid
+	invalidReqID.RequestID = "2h022mc"
 	noIdAndName := valid
 	noIdAndName.Service.Id = nil
 	noIdAndName.Service.Name = nil
@@ -194,7 +199,8 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 		{"valid UpdateDeviceServiceRequest", valid, false},
 		{"valid UpdateDeviceServiceRequest without Id", validWithoutId, false},
 		{"valid UpdateDeviceServiceRequest without name", validWithoutName, false},
-		{"invalid UpdateDeviceServiceRequest, no Request Id", noReID, true},
+		{"valid UpdateDeviceServiceRequest, no Request Id", noReqID, false},
+		{"invalid UpdateDeviceServiceRequest, no Request Id", invalidReqID, true},
 		{"invalid UpdateDeviceServiceRequest, no Id and Name", noIdAndName, true},
 		{"invalid UpdateDeviceServiceRequest, invalid OperatingState", invalidOperatingState, true},
 		{"invalid UpdateDeviceServiceRequest, invalid AdminState", invalidAdminState, true},

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -42,8 +42,10 @@ var testAddEvent = AddEventRequest{
 
 func TestAddEventRequest_Validate(t *testing.T) {
 	valid := testAddEvent
-	noReID := testAddEvent
-	noReID.RequestID = ""
+	noReqID := testAddEvent
+	noReqID.RequestID = ""
+	invalidReqID := testAddEvent
+	invalidReqID.RequestID = "xxy"
 	noDeviceName := testAddEvent
 	noDeviceName.Event.DeviceName = ""
 	noOrigin := testAddEvent
@@ -154,7 +156,8 @@ func TestAddEventRequest_Validate(t *testing.T) {
 		expectError bool
 	}{
 		{"valid AddEventRequest", valid, false},
-		{"invalid AddEventRequest, no Request Id", noReID, true},
+		{"valid AddEventRequest, no Request Id", noReqID, false},
+		{"invalid AddEventRequest, Request Id is not an uuid", invalidReqID, true},
 		{"invalid AddEventRequest, no DeviceName", noDeviceName, true},
 		{"invalid AddEventRequest, no Origin", noOrigin, true},
 		{"invalid AddEventRequest, no Reading", noReading, true},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
In the original implementation, RequestId cannot be empty.

Issue Number: Fix #282 


## What is the new behavior?
RequestId can be empty.  If it contains value, it has to be uuid.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information