### PR TITLE
Feat (core-data): Event ID has to be UUID and pre-populated

### DIFF
--- a/models/event_test.go
+++ b/models/event_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 var TestEvent = Event{
+	ID:       "1e12bd0a-89ca-4747-ad76-a43157d6521a",
 	Pushed:   123,
 	Created:  123,
 	Device:   TestDeviceName,
@@ -45,7 +46,8 @@ func TestEvent_String(t *testing.T) {
 		want string
 	}{
 		{"event to string", TestEvent,
-			"{\"pushed\":" + strconv.FormatInt(TestEvent.Pushed, 10) +
+			"{\"id\":\"1e12bd0a-89ca-4747-ad76-a43157d6521a\"" +
+				",\"pushed\":" + strconv.FormatInt(TestEvent.Pushed, 10) +
 				",\"device\":\"" + TestDeviceName +
 				"\",\"created\":" + strconv.FormatInt(TestEvent.Created, 10) +
 				",\"modified\":" + strconv.FormatInt(TestEvent.Modified, 10) +
@@ -104,7 +106,7 @@ func Test_encodeAsCBOR(t *testing.T) {
 func TestEvent_ToXML(t *testing.T) {
 	// Since the order in map is random we have to verify the individual items exists without depending on order
 	contains := []string{
-		"<Event><ID></ID><Pushed>123</Pushed><Device>test device name</Device><Created>123</Created><Modified>123</Modified><Origin>123</Origin><Readings><Id>Thermometer</Id><Pushed>123</Pushed><Created>123</Created><Origin>123</Origin><Modified>123</Modified><Device>test device name</Device><Name>Temperature</Name><Value>45</Value><ValueType>Int16</ValueType><FloatEncoding>float16</FloatEncoding><BinaryValue>�</BinaryValue><MediaType>application/cbor</MediaType></Readings><Tags>",
+		"<Event><ID>1e12bd0a-89ca-4747-ad76-a43157d6521a</ID><Pushed>123</Pushed><Device>test device name</Device><Created>123</Created><Modified>123</Modified><Origin>123</Origin><Readings><Id>Thermometer</Id><Pushed>123</Pushed><Created>123</Created><Origin>123</Origin><Modified>123</Modified><Device>test device name</Device><Name>Temperature</Name><Value>45</Value><ValueType>Int16</ValueType><FloatEncoding>float16</FloatEncoding><BinaryValue>�</BinaryValue><MediaType>application/cbor</MediaType></Readings><Tags>",
 		"<GatewayID>Houston-0001</GatewayID>",
 		"<Latitude>29.630771</Latitude>",
 		"<Longitude>-95.377603</Longitude>",

--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -20,7 +20,7 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/Event
 type Event struct {
 	common.Versionable `json:",inline"`
-	ID                 string            `json:"id"`
+	ID                 string            `json:"id" validate:"required,uuid"`
 	Pushed             int64             `json:"pushed,omitempty"`
 	DeviceName         string            `json:"deviceName" validate:"required"`
 	Created            int64             `json:"created"`

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -137,7 +137,7 @@ func validateValueType(valueType string) bool {
 }
 
 // Convert Reading DTO to Reading model
-func ToReadingModel(r BaseReading, _ string) models.Reading {
+func ToReadingModel(r BaseReading) models.Reading {
 	var readingModel models.Reading
 	br := models.BaseReading{
 		Origin:     r.Origin,

--- a/v2/dtos/reading_test.go
+++ b/v2/dtos/reading_test.go
@@ -44,7 +44,7 @@ func Test_ToReadingModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			readingModel := ToReadingModel(tt.reading, TestDeviceName)
+			readingModel := ToReadingModel(tt.reading)
 			assert.Equal(t, expectedSimpleReading, readingModel, "ToReadingModel did not result in expected Reading model.")
 		})
 	}

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -73,7 +73,7 @@ func AddEventReqToEventModels(addRequests []AddEventRequest) (events []models.Ev
 		var e models.Event
 		readings := make([]models.Reading, len(a.Event.Readings))
 		for i, r := range a.Event.Readings {
-			readings[i] = dtos.ToReadingModel(r, a.Event.DeviceName)
+			readings[i] = dtos.ToReadingModel(r)
 		}
 
 		tags := make(map[string]string)

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -23,6 +23,7 @@ var testAddEvent = AddEventRequest{
 		RequestID: ExampleUUID,
 	},
 	Event: dtos.Event{
+		ID:         ExampleUUID,
 		DeviceName: TestDeviceName,
 		Origin:     TestOriginTime,
 		Readings: []dtos.BaseReading{{
@@ -46,6 +47,10 @@ func TestAddEventRequest_Validate(t *testing.T) {
 	noReqID.RequestID = ""
 	invalidReqID := testAddEvent
 	invalidReqID.RequestID = "xxy"
+	noEventID := testAddEvent
+	noEventID.Event.ID = ""
+	invalidEventID := testAddEvent
+	invalidEventID.Event.ID = "gj93j2-v92hvi3h"
 	noDeviceName := testAddEvent
 	noDeviceName.Event.DeviceName = ""
 	noOrigin := testAddEvent
@@ -158,6 +163,8 @@ func TestAddEventRequest_Validate(t *testing.T) {
 		{"valid AddEventRequest", valid, false},
 		{"valid AddEventRequest, no Request Id", noReqID, false},
 		{"invalid AddEventRequest, Request Id is not an uuid", invalidReqID, true},
+		{"invalid AddEventRequest, no Event Id", noEventID, true},
+		{"invalid AddEventRequest, Event Id is not an uuid", invalidEventID, true},
 		{"invalid AddEventRequest, no DeviceName", noDeviceName, true},
 		{"invalid AddEventRequest, no Origin", noOrigin, true},
 		{"invalid AddEventRequest, no Reading", noReading, true},

--- a/v2/models/event.go
+++ b/v2/models/event.go
@@ -7,13 +7,11 @@ package models
 
 // Event represents a single measurable event read from a device
 type Event struct {
-	CorrelationId string
-	Checksum      string
-	Id            string            // Id uniquely identifies an event, for example a UUID
-	Pushed        int64             // Pushed is a timestamp indicating when the event was exported. If unexported, the value is zero.
-	DeviceName    string            // DeviceName identifies the source of the event
-	Created       int64             // Created is a timestamp indicating when the event was created.
-	Origin        int64             // Origin is a timestamp that can communicate the time of the original reading, prior to event creation
-	Readings      []Reading         // Readings will contain zero to many entries for the associated readings of a given event.
-	Tags          map[string]string // Tags is an optional collection of key/value pairs that all the event to be tagged with custom information.
+	Id         string            // Id is an UUID which uniquely identifies an event.
+	Pushed     int64             // Pushed is a timestamp indicating when the event was exported. If unexported, the value is zero.
+	DeviceName string            // DeviceName identifies the source of the event
+	Created    int64             // Created is a timestamp indicating when the event was created.
+	Origin     int64             // Origin is a timestamp that can communicate the time of the original reading, prior to event creation
+	Readings   []Reading         // Readings will contain zero to many entries for the associated readings of a given event.
+	Tags       map[string]string // Tags is an optional collection of key/value pairs that all the event to be tagged with custom information.
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Event ID can be empty before sending to core-data and assigned in core-data

Issue Number: Fix #287 


## What is the new behavior?
Validate Event ID is an UUID and pre-populated

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No