### PR TITLE
Fix: Error msg should return first non-empty msg

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -100,6 +100,14 @@ func (ce CommonEdgeX) DebugMessages() string {
 
 // Message returns the first level error message without further details.
 func (ce CommonEdgeX) Message() string {
+	if ce.message == "" && ce.err != nil {
+		if w, ok := ce.err.(CommonEdgeX); ok {
+			return w.Message()
+		} else {
+			return ce.err.Error()
+		}
+	}
+
 	return ce.message
 }
 

--- a/errors/types_test.go
+++ b/errors/types_test.go
@@ -13,11 +13,14 @@ import (
 )
 
 var (
-	L1Error = fmt.Errorf("nothing")
-	L2Error = NewCommonEdgeX(KindDatabaseError, "database failed", L1Error)
-	L3Error = NewCommonEdgeXWrapper(L2Error)
-	L4Error = NewCommonEdgeX(KindUnknown, "don't know", L3Error)
-	L5Error = NewCommonEdgeX(KindCommunicationError, "network disconnected", L4Error)
+	L0Error        = NewCommonEdgeX(KindUnknown, "", nil)
+	L1Error        = fmt.Errorf("nothing")
+	L1ErrorWrapper = NewCommonEdgeXWrapper(L1Error)
+	L2ErrorWrapper = NewCommonEdgeXWrapper(L1ErrorWrapper)
+	L2Error        = NewCommonEdgeX(KindDatabaseError, "database failed", L1Error)
+	L3Error        = NewCommonEdgeXWrapper(L2Error)
+	L4Error        = NewCommonEdgeX(KindUnknown, "don't know", L3Error)
+	L5Error        = NewCommonEdgeX(KindCommunicationError, "network disconnected", L4Error)
 )
 
 func TestKind(t *testing.T) {
@@ -26,6 +29,7 @@ func TestKind(t *testing.T) {
 		err  error
 		kind ErrKind
 	}{
+		{"Check the empty CommonEdgeX", L0Error, KindUnknown},
 		{"Check the non-CommonEdgeX", L1Error, KindUnknown},
 		{"Get the first error kind with 1 error wrapped", L2Error, KindDatabaseError},
 		{"Get the first error kind with 2 error wrapped", L3Error, KindDatabaseError},
@@ -37,6 +41,29 @@ func TestKind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			k := Kind(tt.err)
 			assert.Equal(t, tt.kind, k, fmt.Sprintf("Retrieved Error Kind %s is not equal to %s.", k, tt.kind))
+		})
+	}
+}
+
+func TestMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  EdgeX
+		msg  string
+	}{
+		{"Get the first level error message from an empty error", L0Error, ""},
+		{"Get the first level error message from an empty EdgeXError with 1 error wrapped", L1ErrorWrapper, L1Error.Error()},
+		{"Get the first level error message from an empty EdgeXError with 1 empty error wrapped", L2ErrorWrapper, L1Error.Error()},
+		{"Get the first level error message from an EdgeXError with 1 error wrapped", L2Error, L2Error.message},
+		{"Get the first level error message from an empty EdgeXError with 2 error wrapped", L3Error, L2Error.message},
+		{"Get the first level error message from an EdgeXError with 3 error wrapped", L4Error, L4Error.message},
+		{"Get the first level error message from an EdgeXError with 4 error wrapped", L5Error, L5Error.message},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.err.Message()
+			assert.Equal(t, tt.msg, m, fmt.Sprintf("Returned error message %s is not equal to %s.", m, tt.msg))
 		})
 	}
 }


### PR DESCRIPTION
##  PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
errors.CommonEdgeX.Message() might return an empty string if it is just a wrapper.

Issue Number: Fix https://github.com/edgexfoundry/go-mod-core-contracts/issues/290


## What is the new behavior?
errors.CommonEdgeX.Message() should return the first non-empty message.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information