### PR TITLE
fix (v2dto, data): pass event id from DTO to model

### DIFF
--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -81,6 +81,7 @@ func AddEventReqToEventModels(addRequests []AddEventRequest) (events []models.Ev
 			tags[tag] = value
 		}
 
+		e.Id = a.Event.ID
 		e.DeviceName = a.Event.DeviceName
 		e.Origin = a.Event.Origin
 		e.Readings = readings

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -233,6 +233,7 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 		Value: TestReadingValue,
 	}
 	expectedEventModel := []models.Event{{
+		Id:         ExampleUUID,
 		DeviceName: TestDeviceName,
 		Origin:     TestOriginTime,
 		Readings:   []models.Reading{s},


### PR DESCRIPTION



Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
event id is always empty when storing into the database.
Issue Number: Fix https://github.com/edgexfoundry/go-mod-core-contracts/issues/304


## What is the new behavior?
pass event id when converting DTO to model.
modify unit test to verify the id is passed.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No