### PR TITLE
fix(v2dto):Remove validate call in add request DTO 

### DIFF
--- a/v2/dtos/deviceprofile.go
+++ b/v2/dtos/deviceprofile.go
@@ -27,7 +27,7 @@ type DeviceProfile struct {
 	CoreCommands       []Command         `json:"coreCommands,omitempty" yaml:"coreCommands,omitempty" validate:"dive"`
 }
 
-// ToCommandModels transforms the Command DTOs to the Command models
+// ToDeviceProfileModels transforms the DeviceProfile DTOs to the DeviceProfile models
 func ToDeviceProfileModels(deviceProfileDTO DeviceProfile) models.DeviceProfile {
 	return models.DeviceProfile{
 		Name:            deviceProfileDTO.Name,

--- a/v2/dtos/requests/device.go
+++ b/v2/dtos/requests/device.go
@@ -40,11 +40,6 @@ func (d *AddDeviceRequest) UnmarshalJSON(b []byte) error {
 	}
 
 	*d = AddDeviceRequest(alias)
-
-	// validate AddDeviceRequest DTO
-	if err := d.Validate(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/v2/dtos/requests/deviceprofile.go
+++ b/v2/dtos/requests/deviceprofile.go
@@ -41,11 +41,6 @@ func (dp *AddDeviceProfileRequest) UnmarshalJSON(b []byte) error {
 	}
 
 	*dp = AddDeviceProfileRequest(alias)
-
-	// validate AddDeviceProfileRequest DTO
-	if err := dp.Validate(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/v2/dtos/requests/deviceservice.go
+++ b/v2/dtos/requests/deviceservice.go
@@ -40,11 +40,6 @@ func (ds *AddDeviceServiceRequest) UnmarshalJSON(b []byte) error {
 	}
 
 	*ds = AddDeviceServiceRequest(alias)
-
-	// validate AddDeviceServiceRequest DTO
-	if err := ds.Validate(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -59,11 +59,6 @@ func (a *AddEventRequest) UnmarshalJSON(b []byte) error {
 	}
 
 	*a = AddEventRequest(addEvent)
-
-	// validate AddEventRequest DTO
-	if err := a.Validate(); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: Fix #306


## What is the new behavior?
In V2 API design, all the add request would be in array form when
calling add APIs.  Thus, the requests should be validated
individually, not in the UnmarshalJSON func.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
