### PR TITLE
fix(notifications): add ContentType to client struct

### DIFF
--- a/clients/notifications/client.go
+++ b/clients/notifications/client.go
@@ -64,6 +64,7 @@ type Notification struct {
 	Category    CategoryEnum `json:"category"`              // Allows for categorization of notifications
 	Severity    SeverityEnum `json:"severity"`              // Denotes the severity of a notification
 	Content     string       `json:"content"`               // Content contains the body of the notification
+	ContentType string       `json:"contenttype,omitempty"` // ContentType contains the content type of the notification
 	Description string       `json:"description,omitempty"` // Description content for the notification
 	Status      StatusEnum   `json:"status,omitempty"`      // Status reflects a simple workflow assignment for the notification
 	Labels      []string     `json:"labels,omitempty"`      // Labels allows the notification to be further described/classified

--- a/clients/notifications/client_test.go
+++ b/clients/notifications/client_test.go
@@ -34,6 +34,7 @@ const (
 	TestNotificationStatus      = NEW
 	TestNotificationLabel1      = "Label One"
 	TestNotificationLabel2      = "Label Two"
+	TestNotificationContentType = "Content Type"
 )
 
 func TestReceiveNotification(t *testing.T) {
@@ -69,6 +70,10 @@ func TestReceiveNotification(t *testing.T) {
 			t.Errorf(TestUnexpectedMsgFormatStr, receivedNotification.Content, TestNotificationContent)
 		}
 
+		if receivedNotification.ContentType != TestNotificationContentType {
+			t.Errorf(TestUnexpectedMsgFormatStr, receivedNotification.ContentType, TestNotificationContentType)
+		}
+
 		if receivedNotification.Description != TestNotificationDescription {
 			t.Errorf(TestUnexpectedMsgFormatStr, receivedNotification.Description, TestNotificationDescription)
 		}
@@ -100,6 +105,7 @@ func TestReceiveNotification(t *testing.T) {
 		Category:    TestNotificationCategory,
 		Severity:    TestNotificationSeverity,
 		Content:     TestNotificationContent,
+		ContentType: TestNotificationContentType,
 		Description: TestNotificationDescription,
 		Status:      TestNotificationStatus,
 		Labels:      []string{TestNotificationLabel1, TestNotificationLabel2},


### PR DESCRIPTION
ContentType can now be set for notifications when using the REST api
directly, this adds support to the client

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:

#314 

## What is the new behavior?

ContentType available on struct used by notification client

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information