### PR TITLE
Fix(all):use "X-Correlation-ID" in header

### DIFF
--- a/clients/constants.go
+++ b/clients/constants.go
@@ -20,8 +20,8 @@ package clients
 //
 // Miscellaneous constants
 const (
-	ClientMonitorDefault = 15000            // Defaults the interval at which a given service client will refresh its endpoint from the Registry, if used
-	CorrelationHeader    = "correlation-id" // Sets the key of the Correlation ID HTTP header
+	ClientMonitorDefault = 15000              // Defaults the interval at which a given service client will refresh its endpoint from the Registry, if used
+	CorrelationHeader    = "X-Correlation-ID" // Sets the key of the Correlation ID HTTP header
 )
 
 // Constants related to defined routes in the service APIs


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
"Correlation-Id" as the http header key

Issue Number: Fix https://github.com/edgexfoundry/go-mod-core-contracts/issues/316


## What is the new behavior?
Replace CorrelationHeader constant to "X-Correlation-ID" because it is the more common key.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No
