### PR TITLE
fix: Rename deviceId to deviceName from Event DTO

### DIFF
--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -16,7 +16,7 @@ import (
 type EventCountResponse struct {
 	common.BaseResponse `json:",inline"`
 	Count               uint32
-	DeviceId            string `json:"deviceId"` // Id uniquely identifies a device
+	DeviceName          string `json:"deviceName"`
 }
 
 // EventResponse defines the Response Content for GET event DTOs.
@@ -39,11 +39,11 @@ func NewEventCountResponseNoMessage(requestId string, statusCode int, count uint
 	return NewEventCountResponse(requestId, "", statusCode, count, deviceId)
 }
 
-func NewEventCountResponse(requestId string, message string, statusCode int, count uint32, deviceId string) EventCountResponse {
+func NewEventCountResponse(requestId string, message string, statusCode int, count uint32, deviceName string) EventCountResponse {
 	return EventCountResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
 		Count:        count,
-		DeviceId:     deviceId,
+		DeviceName:   deviceName,
 	}
 }
 

--- a/v2/dtos/responses/event_test.go
+++ b/v2/dtos/responses/event_test.go
@@ -18,27 +18,27 @@ func TestNewEventCountResponse(t *testing.T) {
 	expectedStatusCode := 200
 	expectedMessage := "unit test message"
 	expectedCount := uint32(1000)
-	expectedDeviceId := "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"
-	actual := NewEventCountResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedCount, expectedDeviceId)
+	expectedDeviceName := "device1"
+	actual := NewEventCountResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedCount, expectedDeviceName)
 
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
 	assert.Equal(t, expectedCount, actual.Count)
-	assert.Equal(t, expectedDeviceId, actual.DeviceId)
+	assert.Equal(t, expectedDeviceName, actual.DeviceName)
 }
 
 func TestNewEventCountResponseNoMessage(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200
 	expectedCount := uint32(1000)
-	expectedDeviceId := "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"
-	actual := NewEventCountResponseNoMessage(expectedRequestId, expectedStatusCode, expectedCount, expectedDeviceId)
+	expectedDeviceName := "device1"
+	actual := NewEventCountResponseNoMessage(expectedRequestId, expectedStatusCode, expectedCount, expectedDeviceName)
 
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedCount, actual.Count)
-	assert.Equal(t, expectedDeviceId, actual.DeviceId)
+	assert.Equal(t, expectedDeviceName, actual.DeviceName)
 }
 
 func TestNewEventResponse(t *testing.T) {


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
Fix https://github.com/edgexfoundry/go-mod-core-contracts/issues/330


## What is the new behavior?
Rename deviceId to deviceName in EventCountResponse DTO.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No