### PR TITLE
feat(v2dto): Add new Response DTOs to return an array of objects

### DIFF
--- a/v2/dtos/responses/device.go
+++ b/v2/dtos/responses/device.go
@@ -28,3 +28,18 @@ func NewDeviceResponse(requestId string, message string, statusCode int, device 
 		Device:       device,
 	}
 }
+
+// MultiDevicesResponse defines the Response Content for GET multiple Device DTOs.
+// This object and its properties correspond to the MultiDevicesResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/MultiDevicesResponse
+type MultiDevicesResponse struct {
+	common.BaseResponse `json:",inline"`
+	Devices             []dtos.Device `json:"devices"`
+}
+
+func NewMultiDevicesResponse(requestId string, message string, statusCode int, devices []dtos.Device) MultiDevicesResponse {
+	return MultiDevicesResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Devices:      devices,
+	}
+}

--- a/v2/dtos/responses/device_test.go
+++ b/v2/dtos/responses/device_test.go
@@ -35,3 +35,19 @@ func TestNewDeviceResponseNoMessage(t *testing.T) {
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedDevice, actual.Device)
 }
+
+func TestNewMultiDevicesResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedDevices := []dtos.Device{
+		{Name: "test device1"},
+		{Name: "test device2"},
+	}
+	actual := NewMultiDevicesResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedDevices)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedDevices, actual.Devices)
+}

--- a/v2/dtos/responses/deviceprofile.go
+++ b/v2/dtos/responses/deviceprofile.go
@@ -28,3 +28,18 @@ func NewDeviceProfileResponse(requestId string, message string, statusCode int, 
 		Profile:      deviceProfile,
 	}
 }
+
+// MultiDeviceProfilesResponse defines the Response Content for GET multiple DeviceProfile DTOs.
+// This object and its properties correspond to the MultiDeviceProfilesResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/MultiDeviceProfilesResponse
+type MultiDeviceProfilesResponse struct {
+	common.BaseResponse `json:",inline"`
+	Profiles            []dtos.DeviceProfile `json:"profiles"`
+}
+
+func NewMultiDeviceProfilesResponse(requestId string, message string, statusCode int, deviceProfiles []dtos.DeviceProfile) MultiDeviceProfilesResponse {
+	return MultiDeviceProfilesResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Profiles:     deviceProfiles,
+	}
+}

--- a/v2/dtos/responses/deviceprofile_test.go
+++ b/v2/dtos/responses/deviceprofile_test.go
@@ -35,3 +35,19 @@ func TestNewDeviceProfileResponseNoMessage(t *testing.T) {
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedDeviceProfile, actual.Profile)
 }
+
+func TestNewMultiDeviceProfilesResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedDeviceProfiles := []dtos.DeviceProfile{
+		{Name: "test device profile1"},
+		{Name: "test device profile2"},
+	}
+	actual := NewMultiDeviceProfilesResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedDeviceProfiles)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedDeviceProfiles, actual.Profiles)
+}

--- a/v2/dtos/responses/deviceservice.go
+++ b/v2/dtos/responses/deviceservice.go
@@ -28,3 +28,18 @@ func NewDeviceServiceResponse(requestId string, message string, statusCode int, 
 		Service:      deviceService,
 	}
 }
+
+// MultiDeviceServicesResponse defines the Response Content for GET multiple DeviceService DTOs.
+// This object and its properties correspond to the MultiDeviceServicesResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/MultiDeviceServicesResponse
+type MultiDeviceServicesResponse struct {
+	common.BaseResponse `json:",inline"`
+	Services            []dtos.DeviceService `json:"services"`
+}
+
+func NewMultiDeviceServicesResponse(requestId string, message string, statusCode int, deviceServices []dtos.DeviceService) MultiDeviceServicesResponse {
+	return MultiDeviceServicesResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Services:     deviceServices,
+	}
+}

--- a/v2/dtos/responses/deviceservice_test.go
+++ b/v2/dtos/responses/deviceservice_test.go
@@ -35,3 +35,19 @@ func TestNewDeviceServiceResponseNoMessage(t *testing.T) {
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedDeviceService, actual.Service)
 }
+
+func TestNewMultiDeviceServicesResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedDeviceServices := []dtos.DeviceService{
+		{Name: "test device service1"},
+		{Name: "test device service2"},
+	}
+	actual := NewMultiDeviceServicesResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedDeviceServices)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedDeviceServices, actual.Services)
+}

--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -24,7 +24,15 @@ type EventCountResponse struct {
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/EventResponse
 type EventResponse struct {
 	common.BaseResponse `json:",inline"`
-	Event               dtos.Event
+	Event               dtos.Event `json:"event"`
+}
+
+// MultiEventsResponse defines the Response Content for GET multiple event DTOs.
+// This object and its properties correspond to the MultiEventsResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/MultiEventsResponse
+type MultiEventsResponse struct {
+	common.BaseResponse `json:",inline"`
+	Events              []dtos.Event `json:"events"`
 }
 
 // UpdateEventPushedByChecksumResponse defines the Response Content for PUT event as pushed DTO.
@@ -55,6 +63,13 @@ func NewEventResponse(requestId string, message string, statusCode int, event dt
 	return EventResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
 		Event:        event,
+	}
+}
+
+func NewMultiEventsResponse(requestId string, message string, statusCode int, events []dtos.Event) MultiEventsResponse {
+	return MultiEventsResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Events:       events,
 	}
 }
 

--- a/v2/dtos/responses/event_test.go
+++ b/v2/dtos/responses/event_test.go
@@ -65,6 +65,22 @@ func TestNewEventResponseNoMessage(t *testing.T) {
 	assert.Equal(t, expectedEvent, actual.Event)
 }
 
+func TestNewMultiEventsResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedEvents := []dtos.Event{
+		{Id: "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"},
+		{Id: "11111111-2222-3333-4444-555555555555"},
+	}
+	actual := NewMultiEventsResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedEvents)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedEvents, actual.Events)
+}
+
 func TestNewUpdateEventPushedByChecksumResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200

--- a/v2/dtos/responses/reading.go
+++ b/v2/dtos/responses/reading.go
@@ -23,7 +23,15 @@ type ReadingCountResponse struct {
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/ReadingResponse
 type ReadingResponse struct {
 	common.BaseResponse `json:",inline"`
-	Reading             dtos.BaseReading
+	Reading             dtos.BaseReading `json:"reading"`
+}
+
+// MultiReadingsResponse defines the Response Content for GET multiple reading DTO.
+// This object and its properties correspond to the MultiReadingsResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/MultiReadingsResponse
+type MultiReadingsResponse struct {
+	common.BaseResponse `json:",inline"`
+	Readings            []dtos.BaseReading `json:"readings"`
 }
 
 func NewReadingCountResponseNoMessage(requestId string, statusCode int, count uint32) ReadingCountResponse {
@@ -45,5 +53,12 @@ func NewReadingResponse(requestId string, message string, statusCode int, readin
 	return ReadingResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
 		Reading:      reading,
+	}
+}
+
+func NewMultiReadingsResponse(requestId string, message string, statusCode int, readings []dtos.BaseReading) MultiReadingsResponse {
+	return MultiReadingsResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Readings:     readings,
 	}
 }

--- a/v2/dtos/responses/reading_test.go
+++ b/v2/dtos/responses/reading_test.go
@@ -60,3 +60,19 @@ func TestNewReadingResponseNoMessage(t *testing.T) {
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedReading, actual.Reading)
 }
+
+func TestNewMultiReadingsResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedReadings := []dtos.BaseReading{
+		{Id: "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"},
+		{Id: "11111111-2222-3333-4444-555555555555"},
+	}
+	actual := NewMultiReadingsResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedReadings)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedReadings, actual.Readings)
+}


### PR DESCRIPTION
Per V2 API spec, new response DTOs shall be created to return an array of objects.

- MultiEventsResponse
- MultiReadingsResponse
- MultiDevicesResponse
- MultiDeviceProfilesResponse
- MultiDeviceServicesResponse

Fix: #https://github.com/edgexfoundry/go-mod-core-contracts/issues/332

Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
https://github.com/edgexfoundry/go-mod-core-contracts/issues/332

## What is the new behavior?
Add new response DTOs to return an array of objects:

- MultiEventsResponse
- MultiReadingsResponse
- MultiDevicesResponse
- MultiDeviceProfilesResponse
- MultiDeviceServicesResponse

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
No
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information