### PR TITLE
feat(v2 api): Add new error kind for indicating requested range not satisfiable

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -17,19 +17,20 @@ type ErrKind string
 
 const (
 	// Constant Kind identifiers which can be used to label and group errors.
-	KindUnknown            ErrKind = "Unknown"
-	KindDatabaseError      ErrKind = "Database"
-	KindCommunicationError ErrKind = "Communication"
-	KindEntityDoesNotExist ErrKind = "NotFound"
-	KindContractInvalid    ErrKind = "ContractInvalid"
-	KindServerError        ErrKind = "UnexpectedServerError"
-	KindLimitExceeded      ErrKind = "LimitExceeded"
-	KindDuplicateName      ErrKind = "DuplicateName"
-	KindInvalidId          ErrKind = "InvalidId"
-	KindServiceUnavailable ErrKind = "ServiceUnavailable"
-	KindNotAllowed         ErrKind = "NotAllowed"
-	KindServiceLocked      ErrKind = "ServiceLocked"
-	KindNotImplemented     ErrKind = "NotImplemented"
+	KindUnknown             ErrKind = "Unknown"
+	KindDatabaseError       ErrKind = "Database"
+	KindCommunicationError  ErrKind = "Communication"
+	KindEntityDoesNotExist  ErrKind = "NotFound"
+	KindContractInvalid     ErrKind = "ContractInvalid"
+	KindServerError         ErrKind = "UnexpectedServerError"
+	KindLimitExceeded       ErrKind = "LimitExceeded"
+	KindDuplicateName       ErrKind = "DuplicateName"
+	KindInvalidId           ErrKind = "InvalidId"
+	KindServiceUnavailable  ErrKind = "ServiceUnavailable"
+	KindNotAllowed          ErrKind = "NotAllowed"
+	KindServiceLocked       ErrKind = "ServiceLocked"
+	KindNotImplemented      ErrKind = "NotImplemented"
+	KindRangeNotSatisfiable ErrKind = "RangeNotSatisfiable"
 )
 
 // EdgeX provides an abstraction for all internal EdgeX errors.
@@ -197,6 +198,8 @@ func codeMapping(kind ErrKind) int {
 		return http.StatusNotImplemented
 	case KindNotAllowed:
 		return http.StatusMethodNotAllowed
+	case KindRangeNotSatisfiable:
+		return http.StatusRequestedRangeNotSatisfiable
 	default:
 		return http.StatusInternalServerError
 	}


### PR DESCRIPTION
As V2 API supports the pagination through offset and limit query string
when GET multiple objects, there is a need to add new error kind when
the requested range is not satisfiable. For example, when there are only
5 objects in the DB but users requests to retrieve objects starting from
10 (offset=9), V2 API shall return an error kind that such requested
range is not available. This new error kind shall also map to HTTP status
code 416 as indicated in the RFC 7233.

Fix #334 

Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#334 

## What is the new behavior?
A new error kind `KindRangeNotSatisfiable` is added for indicating requested range not satisfiable.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
https://tools.ietf.org/html/rfc7233#section-4.4

## Other information