### PR TITLE
feat(V2 API): Add new constants and default value for offset, limit, and labels

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -65,4 +65,13 @@ const (
 	Name          = "name"
 	Manufacturer  = "manufacturer"
 	Model         = "model"
+	Offset        = "offset" //query string to specify the number of items to skip before starting to collect the result set.
+	Limit         = "limit"  //query string to specify the numbers of items to return
+	Labels        = "labels" //query string to specify associated user-defined labels for querying a given object. More than one label may be specified via a comma-delimited list
+)
+
+// Constants related to the default value of query strings in the v2 service APIs
+const (
+	DefaultOffset = 0
+	DefaultLimit  = 20
 )


### PR DESCRIPTION
GET ALL of V2 API allows users to specify following query strings as part of URL to achieve pagination and query criteria:

- offset: the number of items to skip before starting to collect the result set.
- limit: the numbers of items to return (default:20)
- labels: allows for querying a given object by associated user-defined label. More than one label may be specified via a comma-delimited list
This commit adds constants for these query strings and their default values.

Fix #338 

Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#338 

## What is the new behavior?
New constants are added as shown below:  
`Offset`: the number of items to skip before starting to collect the result set.
`Limit`: the numbers of items to return (default:20)
`Labels`: allows for querying a given object by associated user-defined label. More than one label may be specified via a comma-delimited list
`DefaultOffset`
`DefaultLimit`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
No
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information