### PR TITLE
feat(V2 PI): Add new constant for comma separator to split labels

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -72,6 +72,7 @@ const (
 
 // Constants related to the default value of query strings in the v2 service APIs
 const (
-	DefaultOffset = 0
-	DefaultLimit  = 20
+	DefaultOffset  = 0
+	DefaultLimit   = 20
+	CommaSeparator = ","
 )


### PR DESCRIPTION
Per V2 APi spec, more than one label may be specified via a comma-delimited
list. The default separator--comma--should be added as a constant to do the
string split.

Fix #340 

Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#340 

## What is the new behavior?
Per V2 APi spec, more than one label may be specified via a comma-delimited
list. The default separator--comma--should be added as a constant to do the
string split.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
No
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information