### PR TITLE
refactor: remove all ResponseNoMessage funcs in V2

### DIFF
--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -37,10 +37,6 @@ type BaseWithIdResponse struct {
 	Id           string `json:"id"`
 }
 
-func NewBaseResponseNoMessage(requestId string, statusCode int) BaseResponse {
-	return NewBaseResponse(requestId, "", statusCode)
-}
-
 func NewBaseResponse(requestId string, message string, statusCode int) BaseResponse {
 	return BaseResponse{
 		Versionable: NewVersionable(),
@@ -52,10 +48,6 @@ func NewBaseResponse(requestId string, message string, statusCode int) BaseRespo
 
 func NewVersionable() Versionable {
 	return Versionable{ApiVersion: v2.ApiVersion}
-}
-
-func NewBaseWithIdResponseNoMessage(requestId string, statusCode int, id string) BaseWithIdResponse {
-	return NewBaseWithIdResponse(requestId, "", statusCode, id)
 }
 
 func NewBaseWithIdResponse(requestId string, message string, statusCode int, id string) BaseWithIdResponse {

--- a/v2/dtos/common/base_test.go
+++ b/v2/dtos/common/base_test.go
@@ -25,16 +25,6 @@ func TestNewBaseResponse(t *testing.T) {
 	assert.Equal(t, expectedMessage, actual.Message)
 }
 
-func TestNewBaseResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	actual := NewBaseResponseNoMessage(expectedRequestId, expectedStatusCode)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Empty(t, actual.Message)
-}
-
 func TestNewVersionable(t *testing.T) {
 	actual := NewVersionable()
 	assert.Equal(t, v2.ApiVersion, actual.ApiVersion)
@@ -50,16 +40,5 @@ func TestNewBaseWithIdResponse(t *testing.T) {
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedId, actual.Id)
-}
-
-func TestNewBaseWithIdResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedId := "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"
-	actual := NewBaseWithIdResponseNoMessage(expectedRequestId, expectedStatusCode, expectedId)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedId, actual.Id)
 }

--- a/v2/dtos/responses/device.go
+++ b/v2/dtos/responses/device.go
@@ -18,10 +18,6 @@ type DeviceResponse struct {
 	Device              dtos.Device `json:"device"`
 }
 
-func NewDeviceResponseNoMessage(requestId string, statusCode int, device dtos.Device) DeviceResponse {
-	return NewDeviceResponse(requestId, "", statusCode, device)
-}
-
 func NewDeviceResponse(requestId string, message string, statusCode int, device dtos.Device) DeviceResponse {
 	return DeviceResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),

--- a/v2/dtos/responses/device_test.go
+++ b/v2/dtos/responses/device_test.go
@@ -25,17 +25,6 @@ func TestNewDeviceResponse(t *testing.T) {
 	assert.Equal(t, expectedDevice, actual.Device)
 }
 
-func TestNewDeviceResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedDevice := dtos.Device{Name: "test device"}
-	actual := NewDeviceResponseNoMessage(expectedRequestId, expectedStatusCode, expectedDevice)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedDevice, actual.Device)
-}
-
 func TestNewMultiDevicesResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200

--- a/v2/dtos/responses/deviceprofile.go
+++ b/v2/dtos/responses/deviceprofile.go
@@ -18,10 +18,6 @@ type DeviceProfileResponse struct {
 	Profile             dtos.DeviceProfile `json:"profile"`
 }
 
-func NewDeviceProfileResponseNoMessage(requestId string, statusCode int, deviceProfile dtos.DeviceProfile) DeviceProfileResponse {
-	return NewDeviceProfileResponse(requestId, "", statusCode, deviceProfile)
-}
-
 func NewDeviceProfileResponse(requestId string, message string, statusCode int, deviceProfile dtos.DeviceProfile) DeviceProfileResponse {
 	return DeviceProfileResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),

--- a/v2/dtos/responses/deviceprofile_test.go
+++ b/v2/dtos/responses/deviceprofile_test.go
@@ -25,17 +25,6 @@ func TestNewDeviceProfileResponse(t *testing.T) {
 	assert.Equal(t, expectedDeviceProfile, actual.Profile)
 }
 
-func TestNewDeviceProfileResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedDeviceProfile := dtos.DeviceProfile{Name: "test device profile"}
-	actual := NewDeviceProfileResponseNoMessage(expectedRequestId, expectedStatusCode, expectedDeviceProfile)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedDeviceProfile, actual.Profile)
-}
-
 func TestNewMultiDeviceProfilesResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200

--- a/v2/dtos/responses/deviceservice.go
+++ b/v2/dtos/responses/deviceservice.go
@@ -18,10 +18,6 @@ type DeviceServiceResponse struct {
 	Service             dtos.DeviceService `json:"service"`
 }
 
-func NewDeviceServiceResponseNoMessage(requestId string, statusCode int, deviceService dtos.DeviceService) DeviceServiceResponse {
-	return NewDeviceServiceResponse(requestId, "", statusCode, deviceService)
-}
-
 func NewDeviceServiceResponse(requestId string, message string, statusCode int, deviceService dtos.DeviceService) DeviceServiceResponse {
 	return DeviceServiceResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),

--- a/v2/dtos/responses/deviceservice_test.go
+++ b/v2/dtos/responses/deviceservice_test.go
@@ -25,17 +25,6 @@ func TestNewDeviceServiceResponse(t *testing.T) {
 	assert.Equal(t, expectedDeviceService, actual.Service)
 }
 
-func TestNewDeviceServiceResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedDeviceService := dtos.DeviceService{Name: "test device service"}
-	actual := NewDeviceServiceResponseNoMessage(expectedRequestId, expectedStatusCode, expectedDeviceService)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedDeviceService, actual.Service)
-}
-
 func TestNewMultiDeviceServicesResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200

--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -43,20 +43,12 @@ type UpdateEventPushedByIdResponse struct {
 	Id                  string `json:"id"`
 }
 
-func NewEventCountResponseNoMessage(requestId string, statusCode int, count uint32, deviceId string) EventCountResponse {
-	return NewEventCountResponse(requestId, "", statusCode, count, deviceId)
-}
-
 func NewEventCountResponse(requestId string, message string, statusCode int, count uint32, deviceName string) EventCountResponse {
 	return EventCountResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
 		Count:        count,
 		DeviceName:   deviceName,
 	}
-}
-
-func NewEventResponseNoMessage(requestId string, statusCode int, event dtos.Event) EventResponse {
-	return NewEventResponse(requestId, "", statusCode, event)
 }
 
 func NewEventResponse(requestId string, message string, statusCode int, event dtos.Event) EventResponse {
@@ -71,10 +63,6 @@ func NewMultiEventsResponse(requestId string, message string, statusCode int, ev
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
 		Events:       events,
 	}
-}
-
-func NewUpdateEventPushedByIdResponseNoMessage(requestId string, statusCode int, id string) UpdateEventPushedByIdResponse {
-	return NewUpdateEventPushedByIdResponse(requestId, "", statusCode, id)
 }
 
 func NewUpdateEventPushedByIdResponse(requestId string, message string, statusCode int, id string) UpdateEventPushedByIdResponse {

--- a/v2/dtos/responses/event_test.go
+++ b/v2/dtos/responses/event_test.go
@@ -28,19 +28,6 @@ func TestNewEventCountResponse(t *testing.T) {
 	assert.Equal(t, expectedDeviceName, actual.DeviceName)
 }
 
-func TestNewEventCountResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedCount := uint32(1000)
-	expectedDeviceName := "device1"
-	actual := NewEventCountResponseNoMessage(expectedRequestId, expectedStatusCode, expectedCount, expectedDeviceName)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedCount, actual.Count)
-	assert.Equal(t, expectedDeviceName, actual.DeviceName)
-}
-
 func TestNewEventResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200
@@ -51,17 +38,6 @@ func TestNewEventResponse(t *testing.T) {
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedEvent, actual.Event)
-}
-
-func TestNewEventResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedEvent := dtos.Event{Id: "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"}
-	actual := NewEventResponseNoMessage(expectedRequestId, expectedStatusCode, expectedEvent)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedEvent, actual.Event)
 }
 
@@ -91,16 +67,5 @@ func TestNewUpdateEventPushedByIdResponse(t *testing.T) {
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedId, actual.Id)
-}
-
-func TestNewUpdateEventPushedByIdResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedId := "11111111-2222-3333-4444-555555555555"
-	actual := NewUpdateEventPushedByIdResponseNoMessage(expectedRequestId, expectedStatusCode, expectedId)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedId, actual.Id)
 }

--- a/v2/dtos/responses/reading.go
+++ b/v2/dtos/responses/reading.go
@@ -34,19 +34,11 @@ type MultiReadingsResponse struct {
 	Readings            []dtos.BaseReading `json:"readings"`
 }
 
-func NewReadingCountResponseNoMessage(requestId string, statusCode int, count uint32) ReadingCountResponse {
-	return NewReadingCountResponse(requestId, "", statusCode, count)
-}
-
 func NewReadingCountResponse(requestId string, message string, statusCode int, count uint32) ReadingCountResponse {
 	return ReadingCountResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
 		Count:        count,
 	}
-}
-
-func NewReadingResponseNoMessage(requestId string, statusCode int, reading dtos.BaseReading) ReadingResponse {
-	return NewReadingResponse(requestId, "", statusCode, reading)
 }
 
 func NewReadingResponse(requestId string, message string, statusCode int, reading dtos.BaseReading) ReadingResponse {

--- a/v2/dtos/responses/reading_test.go
+++ b/v2/dtos/responses/reading_test.go
@@ -26,17 +26,6 @@ func TestNewReadingCountResponse(t *testing.T) {
 	assert.Equal(t, expectedCount, actual.Count)
 }
 
-func TestNewReadingCountResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedCount := uint32(1000)
-	actual := NewReadingCountResponseNoMessage(expectedRequestId, expectedStatusCode, expectedCount)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedCount, actual.Count)
-}
-
 func TestNewReadingResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200
@@ -47,17 +36,6 @@ func TestNewReadingResponse(t *testing.T) {
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedReading, actual.Reading)
-}
-
-func TestNewReadingResponseNoMessage(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedReading := dtos.BaseReading{Id: "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"}
-	actual := NewReadingResponseNoMessage(expectedRequestId, expectedStatusCode, expectedReading)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedReading, actual.Reading)
 }
 


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
Fix https://github.com/edgexfoundry/go-mod-core-contracts/issues/342


## What is the new behavior?
In 15-OCT-2020 Core WG meeting, we decided to remove all the xxResponseNoMessage helper functions to reduce the future development and unit test effort.
Users could call NewXXResponse with empty string in the message
peremeter instead.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
