### PR TITLE
feat(v2 data): Update DTOs for UpdateEventPushed

### DIFF
--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -23,12 +23,12 @@ type AddEventRequest struct {
 	Event              dtos.Event `json:"event" validate:"required"`
 }
 
-// UpdateEventPushedByChecksumRequest defines the Request Content for PUT event as pushed DTO.
-// This object and its properties correspond to the UpdateEventPushedByChecksumRequest object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/UpdateEventPushedByChecksumRequest
-type UpdateEventPushedByChecksumRequest struct {
+// UpdateEventPushedByIdRequest defines the Request Content for PUT event as pushed DTO.
+// This object and its properties correspond to the UpdateEventPushedByIdRequest object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/UpdateEventPushedByIdRequest
+type UpdateEventPushedByIdRequest struct {
 	common.BaseRequest `json:",inline"`
-	Checksum           string `json:"checksum" validate:"required"`
+	Id                 string `json:"id" validate:"required,uuid"`
 }
 
 // Validate satisfies the Validator interface

--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -35,12 +35,12 @@ type MultiEventsResponse struct {
 	Events              []dtos.Event `json:"events"`
 }
 
-// UpdateEventPushedByChecksumResponse defines the Response Content for PUT event as pushed DTO.
-// This object and its properties correspond to the UpdateEventPushedByChecksumResponse object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/UpdateEventPushedByChecksumResponse
-type UpdateEventPushedByChecksumResponse struct {
+// UpdateEventPushedByIdResponse defines the Response Content for PUT event as pushed DTO.
+// This object and its properties correspond to the UpdateEventPushedByIdResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/UpdateEventPushedByIdResponse
+type UpdateEventPushedByIdResponse struct {
 	common.BaseResponse `json:",inline"`
-	Checksum            string `json:"checksum"`
+	Id                  string `json:"id"`
 }
 
 func NewEventCountResponseNoMessage(requestId string, statusCode int, count uint32, deviceId string) EventCountResponse {
@@ -73,13 +73,13 @@ func NewMultiEventsResponse(requestId string, message string, statusCode int, ev
 	}
 }
 
-func NewUpdateEventPushedByChecksumResponseNoMessage(requestId string, statusCode int, checksum string) UpdateEventPushedByChecksumResponse {
-	return NewUpdateEventPushedByChecksumResponse(requestId, "", statusCode, checksum)
+func NewUpdateEventPushedByIdResponseNoMessage(requestId string, statusCode int, id string) UpdateEventPushedByIdResponse {
+	return NewUpdateEventPushedByIdResponse(requestId, "", statusCode, id)
 }
 
-func NewUpdateEventPushedByChecksumResponse(requestId string, message string, statusCode int, checksum string) UpdateEventPushedByChecksumResponse {
-	return UpdateEventPushedByChecksumResponse{
+func NewUpdateEventPushedByIdResponse(requestId string, message string, statusCode int, id string) UpdateEventPushedByIdResponse {
+	return UpdateEventPushedByIdResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
-		Checksum:     checksum,
+		Id:           id,
 	}
 }

--- a/v2/dtos/responses/event_test.go
+++ b/v2/dtos/responses/event_test.go
@@ -81,26 +81,26 @@ func TestNewMultiEventsResponse(t *testing.T) {
 	assert.Equal(t, expectedEvents, actual.Events)
 }
 
-func TestNewUpdateEventPushedByChecksumResponse(t *testing.T) {
+func TestNewUpdateEventPushedByIdResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200
 	expectedMessage := "unit test message"
-	expectedChecksum := "04698a6f20feecb8bbf7cd01e59d31ba1ce17b24ba14b71a8fb370065d951f57"
-	actual := NewUpdateEventPushedByChecksumResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedChecksum)
+	expectedId := "11111111-2222-3333-4444-555555555555"
+	actual := NewUpdateEventPushedByIdResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedId)
 
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedChecksum, actual.Checksum)
+	assert.Equal(t, expectedId, actual.Id)
 }
 
-func TestNewUpdateEventPushedByChecksumResponseNoMessage(t *testing.T) {
+func TestNewUpdateEventPushedByIdResponseNoMessage(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200
-	expectedChecksum := "04698a6f20feecb8bbf7cd01e59d31ba1ce17b24ba14b71a8fb370065d951f57"
-	actual := NewUpdateEventPushedByChecksumResponseNoMessage(expectedRequestId, expectedStatusCode, expectedChecksum)
+	expectedId := "11111111-2222-3333-4444-555555555555"
+	actual := NewUpdateEventPushedByIdResponseNoMessage(expectedRequestId, expectedStatusCode, expectedId)
 
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedChecksum, actual.Checksum)
+	assert.Equal(t, expectedId, actual.Id)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#354 

## What is the new behavior?
As V2 only allows clients to update event pushed by Id, corresponding DTOs
shall be updated:

UpdateEventPushedByChecksumRequest -> UpdateEventPushedByIdRequest
UpdateEventPushedByChecksumResponse -> UpdateEventPushedByIdResponse

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No