### PR TITLE
fix(metadata): Add validation tag for UpdateDTO

### DIFF
--- a/v2/dtos/autoevent.go
+++ b/v2/dtos/autoevent.go
@@ -12,7 +12,7 @@ import (
 // AutoEvent and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/AutoEvent
 type AutoEvent struct {
-	Frequency string `json:"frequency" validate:"required,autoevent-frequency"`
+	Frequency string `json:"frequency" validate:"required,edgex-dto-autoevent-frequency"`
 	OnChange  bool   `json:"onChange,omitempty"`
 	Resource  string `json:"resource" validate:"required"`
 }

--- a/v2/dtos/command.go
+++ b/v2/dtos/command.go
@@ -10,7 +10,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // Command and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/Command
 type Command struct {
-	Name string `json:"name" yaml:"name" validate:"required"`
+	Name string `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string"`
 	Get  bool   `json:"get" yaml:"get,omitempty" validate:"required_without=Put"`
 	Put  bool   `json:"put" yaml:"put,omitempty" validate:"required_without=Get"`
 }

--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -14,10 +14,10 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/Device
 type Device struct {
 	common.Versionable `json:",inline"`
-	Id                 string                        `json:"id,omitempty"`
+	Id                 string                        `json:"id,omitempty" validate:"omitempty,uuid"`
 	Created            int64                         `json:"created,omitempty"`
 	Modified           int64                         `json:"modified,omitempty"`
-	Name               string                        `json:"name" validate:"required"`
+	Name               string                        `json:"name" validate:"required,edgex-dto-none-empty-string"`
 	Description        string                        `json:"description,omitempty"`
 	AdminState         string                        `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	OperatingState     string                        `json:"operatingState" validate:"oneof='ENABLED' 'DISABLED'"`
@@ -25,8 +25,8 @@ type Device struct {
 	LastReported       int64                         `json:"lastReported,omitempty"`
 	Labels             []string                      `json:"labels,omitempty"`
 	Location           interface{}                   `json:"location,omitempty"`
-	ServiceName        string                        `json:"serviceName" validate:"required"`
-	ProfileName        string                        `json:"profileName" validate:"required"`
+	ServiceName        string                        `json:"serviceName" validate:"required,edgex-dto-none-empty-string"`
+	ProfileName        string                        `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	AutoEvents         []AutoEvent                   `json:"autoEvents,omitempty" validate:"dive"`
 	Protocols          map[string]ProtocolProperties `json:"protocols,omitempty" validate:"required,gt=0"`
 }
@@ -34,15 +34,15 @@ type Device struct {
 // UpdateDevice and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/UpdateDevice
 type UpdateDevice struct {
-	Id             *string                       `json:"id" validate:"required_without=Name"`
-	Name           *string                       `json:"name" validate:"required_without=Id"`
-	Description    *string                       `json:"description"`
+	Id             *string                       `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
+	Name           *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
+	Description    *string                       `json:"description" validate:"omitempty,edgex-dto-none-empty-string"`
 	AdminState     *string                       `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	OperatingState *string                       `json:"operatingState" validate:"omitempty,oneof='ENABLED' 'DISABLED'"`
 	LastConnected  *int64                        `json:"lastConnected"`
 	LastReported   *int64                        `json:"lastReported"`
-	ServiceName    *string                       `json:"serviceName"`
-	ProfileName    *string                       `json:"profileName"`
+	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string"`
+	ProfileName    *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string"`
 	Labels         []string                      `json:"labels"`
 	Location       interface{}                   `json:"location"`
 	AutoEvents     []AutoEvent                   `json:"autoEvents" validate:"dive"`

--- a/v2/dtos/deviceprofile.go
+++ b/v2/dtos/deviceprofile.go
@@ -14,8 +14,8 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceProfile
 type DeviceProfile struct {
 	common.Versionable `json:",inline"`
-	Id                 string            `json:"id,omitempty"`
-	Name               string            `json:"name" yaml:"name" validate:"required" `
+	Id                 string            `json:"id,omitempty" validate:"omitempty,uuid"`
+	Name               string            `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string" `
 	Manufacturer       string            `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
 	Description        string            `json:"description,omitempty" yaml:"description,omitempty"`
 	Model              string            `json:"model,omitempty" yaml:"model,omitempty"`

--- a/v2/dtos/deviceresource.go
+++ b/v2/dtos/deviceresource.go
@@ -11,7 +11,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceResource
 type DeviceResource struct {
 	Description string            `json:"description" yaml:"description,omitempty"`
-	Name        string            `json:"name" yaml:"name,omitempty" validate:"required"`
+	Name        string            `json:"name" yaml:"name,omitempty" validate:"required,edgex-dto-none-empty-string"`
 	Tag         string            `json:"tag" yaml:"tag,omitempty"`
 	Properties  PropertyValue     `json:"properties" yaml:"properties"`
 	Attributes  map[string]string `json:"attributes" yaml:"attributes,omitempty"`

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -14,8 +14,8 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceService
 type DeviceService struct {
 	common.Versionable `json:",inline"`
-	Id                 string   `json:"id,omitempty"`
-	Name               string   `json:"name" validate:"required"`
+	Id                 string   `json:"id,omitempty" validate:"omitempty,uuid"`
+	Name               string   `json:"name" validate:"required,edgex-dto-none-empty-string"`
 	Created            int64    `json:"created,omitempty"`
 	Modified           int64    `json:"modified,omitempty"`
 	Description        string   `json:"description,omitempty"`
@@ -30,9 +30,9 @@ type DeviceService struct {
 // UpdateDeviceService and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/UpdateDeviceService
 type UpdateDeviceService struct {
-	Id             *string  `json:"id" validate:"required_without=Name"`
-	Name           *string  `json:"name" validate:"required_without=Id"`
-	BaseAddress    *string  `json:"baseAddress"`
+	Id             *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
+	Name           *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
+	BaseAddress    *string  `json:"baseAddress" validate:"omitempty,uri"`
 	OperatingState *string  `json:"operatingState" validate:"omitempty,oneof='ENABLED' 'DISABLED'"`
 	Labels         []string `json:"labels"`
 	AdminState     *string  `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`

--- a/v2/dtos/profileresource.go
+++ b/v2/dtos/profileresource.go
@@ -10,7 +10,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // ProfileResource and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/ProfileResource
 type ProfileResource struct {
-	Name string              `json:"name,omitempty" yaml:"name,omitempty" validate:"required"`
+	Name string              `json:"name,omitempty" yaml:"name,omitempty" validate:"required,edgex-dto-none-empty-string"`
 	Get  []ResourceOperation `json:"get,omitempty" yaml:"get,omitempty" validate:"required_without=Set"`
 	Set  []ResourceOperation `json:"set,omitempty" yaml:"set,omitempty" validate:"required_without=Get"`
 }

--- a/v2/dtos/propertyvalue.go
+++ b/v2/dtos/propertyvalue.go
@@ -10,7 +10,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // PropertyValue and its properties care defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/PropertyValue
 type PropertyValue struct {
-	Type          string `json:"type" yaml:"type" validate:"required"`
+	Type          string `json:"type" yaml:"type" validate:"required,edgex-dto-none-empty-string"`
 	ReadWrite     string `json:"readWrite,omitempty" yaml:"readWrite,omitempty"`
 	Units         string `json:"units,omitempty" yaml:"units,omitempty"`
 	Minimum       string `json:"minimum,omitempty" yaml:"minimum,omitempty"`

--- a/v2/dtos/requests/device_test.go
+++ b/v2/dtos/requests/device_test.go
@@ -85,6 +85,7 @@ func mockUpdateDevice() dtos.UpdateDevice {
 }
 
 func TestAddDeviceRequest_Validate(t *testing.T) {
+	emptyString := " "
 	valid := testAddDevice
 	invalidFrequency := testAddDevice
 	invalidFrequency.Device.AutoEvents = testAutoEventsWithInvalidFrequency
@@ -93,11 +94,11 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 	invalidReqId := testAddDevice
 	invalidReqId.RequestId = "abc"
 	noDeviceName := testAddDevice
-	noDeviceName.Device.Name = ""
+	noDeviceName.Device.Name = emptyString
 	noServiceName := testAddDevice
-	noServiceName.Device.ServiceName = ""
+	noServiceName.Device.ServiceName = emptyString
 	noProfileName := testAddDevice
-	noProfileName.Device.ProfileName = ""
+	noProfileName.Device.ProfileName = emptyString
 	noProtocols := testAddDevice
 	noProtocols.Device.Protocols = map[string]dtos.ProtocolProperties{}
 	noAutoEventFrequency := testAddDevice
@@ -222,42 +223,85 @@ func TestUpdateDeviceRequest_UnmarshalJSON(t *testing.T) {
 }
 
 func TestUpdateDeviceRequest_Validate(t *testing.T) {
+	emptyString := " "
+	invalidUUID := "invalidUUID"
+
 	valid := testUpdateDevice
-	validWithoutId := testUpdateDevice
-	validWithoutId.Device.Id = nil
-	validWithoutDeviceName := testUpdateDevice
-	validWithoutDeviceName.Device.Name = nil
-	noReqId := testUpdateDevice
+	noReqId := valid
 	noReqId.RequestId = ""
-	invalidReqId := testUpdateDevice
-	invalidReqId.RequestId = "123"
-	noIdAndDeviceName := testUpdateDevice
-	noIdAndDeviceName.Device.Id = nil
-	noIdAndDeviceName.Device.Name = nil
+	invalidReqId := valid
+	invalidReqId.RequestId = invalidUUID
+
+	// id
+	validOnlyId := valid
+	validOnlyId.Device.Name = nil
+	invalidId := valid
+	invalidId.Device.Id = &invalidUUID
+	// name
+	validOnlyName := valid
+	validOnlyName.Device.Id = nil
+	invalidEmptyName := valid
+	invalidEmptyName.Device.Name = &emptyString
+	// no id and name
+	noIdAndName := valid
+	noIdAndName.Device.Id = nil
+	noIdAndName.Device.Name = nil
+	// description
+	validNilDescription := valid
+	validNilDescription.Device.Description = nil
+	invalidEmptyDescription := valid
+	invalidEmptyDescription.Device.Description = &emptyString
+	// ServiceName
+	validNilServiceName := valid
+	validNilServiceName.Device.ServiceName = nil
+	invalidEmptyServiceName := valid
+	invalidEmptyServiceName.Device.ServiceName = &emptyString
+	// ProfileName
+	validNilProfileName := valid
+	validNilProfileName.Device.ProfileName = nil
+	invalidEmptyProfileName := valid
+	invalidEmptyProfileName.Device.ProfileName = &emptyString
+
 	invalidState := "invalid state"
-	invalidAdminState := testUpdateDevice
+	invalidAdminState := valid
 	invalidAdminState.Device.AdminState = &invalidState
-	invalidOperatingState := testUpdateDevice
+	invalidOperatingState := valid
 	invalidOperatingState.Device.OperatingState = &invalidState
-	invalidFrequency := testUpdateDevice
+	invalidFrequency := valid
 	invalidFrequency.Device.AutoEvents = testAutoEventsWithInvalidFrequency
-	emptyProtocols := testUpdateDevice
+	emptyProtocols := valid
 	emptyProtocols.Device.Protocols = map[string]dtos.ProtocolProperties{}
+
 	tests := []struct {
 		name        string
 		req         UpdateDeviceRequest
 		expectError bool
 	}{
-		{"valid UpdateDeviceRequest", valid, false},
-		{"valid UpdateDeviceRequest without Id", validWithoutId, false},
-		{"valid UpdateDeviceRequest without Name", validWithoutDeviceName, false},
-		{"valid UpdateDeviceRequest, no Request Id", noReqId, false},
-		{"invalid UpdateDeviceRequest, Request Id is not an uuid", invalidReqId, true},
-		{"invalid UpdateDeviceRequest, invalid admin state", invalidAdminState, true},
-		{"invalid UpdateDeviceRequest, invalid operating state", invalidOperatingState, true},
-		{"invalid UpdateDeviceRequest, invalid autoEvent frequency", invalidFrequency, true},
-		{"invalid UpdateDeviceRequest, no Id and DeviceName", noIdAndDeviceName, true},
-		{"invalid UpdateDeviceRequest, empty protocols", emptyProtocols, true},
+		{"valid", valid, false},
+		{"valid, no Request Id", noReqId, false},
+		{"invalid, Request Id is not an uuid", invalidReqId, true},
+
+		{"valid, only id", validOnlyId, false},
+		{"invalid, invalid Id", invalidId, true},
+		{"valid, only name", validOnlyName, false},
+		{"invalid, empty name", invalidEmptyName, true},
+
+		{"invalid, no Id and name", noIdAndName, true},
+
+		{"valid, nil description", validNilDescription, false},
+		{"invalid, empty description", invalidEmptyDescription, true},
+
+		{"valid, nil service name", validNilServiceName, false},
+		{"invalid, empty service name", invalidEmptyServiceName, true},
+
+		{"valid, nil profile name", validNilProfileName, false},
+		{"invalid, empty profile name", invalidEmptyProfileName, true},
+
+		{"invalid, invalid admin state", invalidAdminState, true},
+		{"invalid, invalid operating state", invalidOperatingState, true},
+		{"invalid, invalid autoEvent frequency", invalidFrequency, true},
+
+		{"invalid, empty protocols", emptyProtocols, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v2/dtos/requests/deviceprofile_test.go
+++ b/v2/dtos/requests/deviceprofile_test.go
@@ -98,13 +98,15 @@ var expectedDeviceProfile = models.DeviceProfile{
 }
 
 func TestAddDeviceProfileRequest_Validate(t *testing.T) {
+	emptyString := " "
 	valid := testAddDeviceProfileReq
 	noName := testAddDeviceProfileReq
-	noName.Profile.Name = ""
+	noName.Profile.Name = emptyString
 	noDeviceResource := testAddDeviceProfileReq
 	noDeviceResource.Profile.DeviceResources = []dtos.DeviceResource{}
 	noDeviceResourceName := testAddDeviceProfileReq
 	noDeviceResourceName.Profile.DeviceResources = []dtos.DeviceResource{{
+		Name:        emptyString,
 		Description: TestDescription,
 		Tag:         TestTag,
 		Attributes:  testAttributes,
@@ -120,13 +122,15 @@ func TestAddDeviceProfileRequest_Validate(t *testing.T) {
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: dtos.PropertyValue{
+			Type:      emptyString,
 			ReadWrite: "RW",
 		},
 	}}
 	noCommandName := testAddDeviceProfileReq
 	noCommandName.Profile.CoreCommands = []dtos.Command{{
-		Get: true,
-		Put: true,
+		Name: emptyString,
+		Get:  true,
+		Put:  true,
 	}}
 	noCommandGet := testAddDeviceProfileReq
 	noCommandGet.Profile.CoreCommands = []dtos.Command{{

--- a/v2/dtos/requests/deviceservice_test.go
+++ b/v2/dtos/requests/deviceservice_test.go
@@ -55,23 +55,24 @@ func mockDeviceServiceDTO() dtos.UpdateDeviceService {
 }
 
 func TestAddDeviceServiceRequest_Validate(t *testing.T) {
+	emptyString := " "
 	valid := testAddDeviceService
 	noReqId := testAddDeviceService
 	noReqId.RequestId = ""
 	invalidReqId := testAddDeviceService
 	invalidReqId.RequestId = "jfdw324"
 	noName := testAddDeviceService
-	noName.Service.Name = ""
+	noName.Service.Name = emptyString
 	noOperatingState := testAddDeviceService
-	noOperatingState.Service.OperatingState = ""
+	noOperatingState.Service.OperatingState = emptyString
 	invalidOperatingState := testAddDeviceService
 	invalidOperatingState.Service.OperatingState = "invalid"
 	noAdminState := testAddDeviceService
-	noAdminState.Service.OperatingState = ""
+	noAdminState.Service.OperatingState = emptyString
 	invalidAdminState := testAddDeviceService
 	invalidAdminState.Service.OperatingState = "invalid"
 	noBaseAddress := testAddDeviceService
-	noBaseAddress.Service.BaseAddress = ""
+	noBaseAddress.Service.BaseAddress = emptyString
 	invalidBaseAddress := testAddDeviceService
 	invalidBaseAddress.Service.BaseAddress = "invalid"
 	tests := []struct {
@@ -174,18 +175,36 @@ func TestUpdateDeviceService_UnmarshalJSON(t *testing.T) {
 }
 
 func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
+	emptyString := " "
+	invalidUUID := "invalidUUID"
+	invalidUrl := "http127.0.0.1"
+
 	valid := testUpdateDeviceService
-	validWithoutId := valid
-	validWithoutId.Service.Id = nil
-	validWithoutName := valid
-	validWithoutName.Service.Name = nil
 	noReqId := valid
 	noReqId.RequestId = ""
 	invalidReqId := valid
-	invalidReqId.RequestId = "2h022mc"
+	invalidReqId.RequestId = invalidUUID
+
+	// id
+	validOnlyId := valid
+	validOnlyId.Service.Name = nil
+	invalidId := valid
+	invalidId.Service.Id = &invalidUUID
+	// name
+	validOnlyName := valid
+	validOnlyName.Service.Id = nil
+	invalidEmptyName := valid
+	invalidEmptyName.Service.Name = &emptyString
+	// no id and name
 	noIdAndName := valid
 	noIdAndName.Service.Id = nil
 	noIdAndName.Service.Name = nil
+	// baseAddress
+	validNilBaseAddress := valid
+	validNilBaseAddress.Service.BaseAddress = nil
+	invalidBaseAddress := valid
+	invalidBaseAddress.Service.BaseAddress = &invalidUrl
+
 	invalidOperatingState := valid
 	invalid := "invalid"
 	invalidOperatingState.Service.OperatingState = &invalid
@@ -196,14 +215,22 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 		req         UpdateDeviceServiceRequest
 		expectError bool
 	}{
-		{"valid UpdateDeviceServiceRequest", valid, false},
-		{"valid UpdateDeviceServiceRequest without Id", validWithoutId, false},
-		{"valid UpdateDeviceServiceRequest without name", validWithoutName, false},
-		{"valid UpdateDeviceServiceRequest, no Request Id", noReqId, false},
-		{"invalid UpdateDeviceServiceRequest, no Request Id", invalidReqId, true},
-		{"invalid UpdateDeviceServiceRequest, no Id and Name", noIdAndName, true},
-		{"invalid UpdateDeviceServiceRequest, invalid OperatingState", invalidOperatingState, true},
-		{"invalid UpdateDeviceServiceRequest, invalid AdminState", invalidAdminState, true},
+		{"valid", valid, false},
+		{"valid, no Request Id", noReqId, false},
+		{"invalid, Request Id is not an uuid", invalidReqId, true},
+
+		{"valid, only id", validOnlyId, false},
+		{"invalid, invalid Id", invalidId, true},
+		{"valid, only name", validOnlyName, false},
+		{"invalid, empty name", invalidEmptyName, true},
+
+		{"invalid, no Id and name", noIdAndName, true},
+
+		{"valid, nil baseAddress", validNilBaseAddress, false},
+		{"invalid, invalid baseAddress", invalidBaseAddress, true},
+
+		{"invalid, invalid OperatingState", invalidOperatingState, true},
+		{"invalid, invalid AdminState", invalidAdminState, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
- Update device service with empty name will return status code 404
- It does not allow to update the baseAddress with empty string.

## Issue Number: #362


## What is the new behavior?
UpdateDeviceDTO and UpdateDeviceServiceDTO should be able to verify the id whether is valid UUID format and the required name should not be empty.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
I tried several tag combinations, like,
- required_without and uuid tag
- required_without and gt=0 tag
- required_without and omitempty and uuid tag
- required_without and omitempty and gt=0 tag

But it didn't pass expected test cases:
- When Id exists, Id should be valid UUID
- When Name exists, Name should not be empty

So I try to write tags  **edgex-update-dto-id**, **edgex-update-dto-id** to verify Id and Name.

Please help review whether the implementation is properly.
