### PR TITLE
feat(clients): Add V2 CommonClient

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -31,6 +31,13 @@ const (
 	KindServiceLocked       ErrKind = "ServiceLocked"
 	KindNotImplemented      ErrKind = "NotImplemented"
 	KindRangeNotSatisfiable ErrKind = "RangeNotSatisfiable"
+	KindClientError         ErrKind = "ClientError"
+	KindIOError             ErrKind = "IOError"
+)
+
+// Error codes are not defined in HTTP status codes
+const (
+	ClientErrorCode int = 0
 )
 
 // EdgeX provides an abstraction for all internal EdgeX errors.
@@ -200,6 +207,8 @@ func codeMapping(kind ErrKind) int {
 		return http.StatusMethodNotAllowed
 	case KindRangeNotSatisfiable:
 		return http.StatusRequestedRangeNotSatisfiable
+	case KindClientError, KindIOError:
+		return ClientErrorCode
 	default:
 		return http.StatusInternalServerError
 	}

--- a/v2/clients/http/common.go
+++ b/v2/clients/http/common.go
@@ -1,0 +1,63 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http/utils"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+)
+
+type commonClient struct {
+	baseUrl string
+}
+
+// NewCommonClient creates an instance of CommonClient
+func NewCommonClient(baseUrl string) interfaces.CommonClient {
+	return &commonClient{
+		baseUrl: baseUrl,
+	}
+}
+
+func (cc *commonClient) Configuration(ctx context.Context) (common.ConfigResponse, errors.EdgeX) {
+	cr := common.ConfigResponse{}
+	err := utils.GetRequest(ctx, &cr, cc.baseUrl+v2.ApiConfigRoute)
+	if err != nil {
+		return cr, errors.NewCommonEdgeXWrapper(err)
+	}
+	return cr, nil
+}
+
+func (cc *commonClient) Metrics(ctx context.Context) (common.MetricsResponse, errors.EdgeX) {
+	mr := common.MetricsResponse{}
+	err := utils.GetRequest(ctx, &mr, cc.baseUrl+v2.ApiMetricsRoute)
+	if err != nil {
+		return mr, errors.NewCommonEdgeXWrapper(err)
+	}
+	return mr, nil
+}
+
+func (cc *commonClient) Ping(ctx context.Context) (common.PingResponse, errors.EdgeX) {
+	pr := common.PingResponse{}
+	err := utils.GetRequest(ctx, &pr, cc.baseUrl+v2.ApiPingRoute)
+	if err != nil {
+		return pr, errors.NewCommonEdgeXWrapper(err)
+	}
+	return pr, nil
+}
+
+func (cc *commonClient) Version(ctx context.Context) (common.VersionResponse, errors.EdgeX) {
+	vr := common.VersionResponse{}
+	err := utils.GetRequest(ctx, &vr, cc.baseUrl+v2.ApiVersionRoute)
+	if err != nil {
+		return vr, errors.NewCommonEdgeXWrapper(err)
+	}
+	return vr, nil
+}

--- a/v2/clients/http/common_test.go
+++ b/v2/clients/http/common_test.go
@@ -1,0 +1,83 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+)
+
+const (
+	TestUnexpectedMsgFormatStr = "unexpected result, active: '%s' but expected: '%s'"
+)
+
+func TestGetConfig(t *testing.T) {
+	expected := common.ConfigResponse{}
+	ts := newTestServer(v2.ApiConfigRoute, common.ConfigResponse{})
+	defer ts.Close()
+
+	gc := NewCommonClient(ts.URL)
+	response, err := gc.Configuration(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expected, response)
+}
+
+func TestGetMetrics(t *testing.T) {
+	expected := common.MetricsResponse{}
+	ts := newTestServer(v2.ApiMetricsRoute, common.MetricsResponse{})
+	defer ts.Close()
+
+	gc := NewCommonClient(ts.URL)
+	response, err := gc.Metrics(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expected, response)
+}
+
+func TestPing(t *testing.T) {
+	expected := common.PingResponse{}
+	ts := newTestServer(v2.ApiPingRoute, common.PingResponse{})
+	defer ts.Close()
+
+	gc := NewCommonClient(ts.URL)
+	response, err := gc.Ping(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expected, response)
+}
+
+func TestVersion(t *testing.T) {
+	expected := common.VersionResponse{}
+	ts := newTestServer(v2.ApiVersionRoute, common.VersionResponse{})
+	defer ts.Close()
+
+	gc := NewCommonClient(ts.URL)
+	response, err := gc.Version(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expected, response)
+}
+
+func newTestServer(apiRoute string, expectedResponse interface{}) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.EscapedPath() != apiRoute {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		b, _ := json.Marshal(expectedResponse)
+		_, _ = w.Write(b)
+	}))
+}

--- a/v2/clients/http/utils/common.go
+++ b/v2/clients/http/utils/common.go
@@ -1,0 +1,63 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+
+	"github.com/google/uuid"
+)
+
+// FromContext allows for the retrieval of the specified key's value from the supplied Context.
+// If the value is not found, an empty string is returned.
+func FromContext(ctx context.Context, key string) string {
+	hdr, ok := ctx.Value(key).(string)
+	if !ok {
+		hdr = ""
+	}
+	return hdr
+}
+
+// Helper method to get the body from the response after making the request
+func getBody(resp *http.Response) ([]byte, errors.EdgeX) {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return body, errors.NewCommonEdgeX(errors.KindIOError, "failed to get the body from the response", err)
+	}
+	return body, nil
+}
+
+// Helper method to make the request and return the response
+func makeRequest(req *http.Request) (*http.Response, errors.EdgeX) {
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return resp, errors.NewCommonEdgeX(errors.KindClientError, "failed to send a http request", err)
+	}
+	return resp, nil
+}
+
+// CorrelatedRequest is a wrapper type for use in managing Correlation IDs during service to service API calls.
+type CorrelatedRequest struct {
+	*http.Request
+}
+
+// NewCorrelatedRequest will add the Correlation ID header to the supplied request. If no Correlation ID header is
+// present in the supplied context, one will be created along with a value.
+func NewCorrelatedRequest(ctx context.Context, req *http.Request) CorrelatedRequest {
+	c := CorrelatedRequest{Request: req}
+	correlation := FromContext(ctx, clients.CorrelationHeader)
+	if len(correlation) == 0 {
+		correlation = uuid.New().String()
+	}
+	c.Header.Set(clients.CorrelationHeader, correlation)
+	return c
+}

--- a/v2/clients/http/utils/get.go
+++ b/v2/clients/http/utils/get.go
@@ -1,0 +1,61 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+)
+
+// GetRequest will make a GET request to the specified URL,
+// and parse the JSON-encoded response body to the value pointed to by returnValuePointer.
+func GetRequest(ctx context.Context, returnValuePointer interface{}, url string) errors.EdgeX {
+	var body []byte
+	var err errors.EdgeX
+	if body, err = getRequestWithURL(ctx, url); err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if err := json.Unmarshal(body, returnValuePointer); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
+	}
+	return nil
+}
+
+// getRequestWithURL will make a GET request to the specified URL.
+// It returns the body as a byte array if successful and an error otherwise.
+func getRequestWithURL(ctx context.Context, url string) ([]byte, errors.EdgeX) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindClientError, "failed to create a http request", err)
+	}
+
+	c := NewCorrelatedRequest(ctx, req)
+	resp, err := makeRequest(c.Request)
+	if err != nil {
+		return nil, errors.NewCommonEdgeXWrapper(err)
+	}
+	if resp == nil {
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "the response should not be a nil", nil)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := getBody(resp)
+	if err != nil {
+		return nil, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return bodyBytes, nil
+	case http.StatusNotFound:
+		return nil, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "requested entity not found", nil)
+	default:
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "request failed", nil)
+	}
+}

--- a/v2/clients/interfaces/common.go
+++ b/v2/clients/interfaces/common.go
@@ -1,0 +1,24 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+)
+
+type CommonClient interface {
+	// Configuration obtains configuration information from the target service.
+	Configuration(ctx context.Context) (common.ConfigResponse, errors.EdgeX)
+	// Metrics obtains metrics information from the target service.
+	Metrics(ctx context.Context) (common.MetricsResponse, errors.EdgeX)
+	// Ping tests whether the service is working
+	Ping(ctx context.Context) (common.PingResponse, errors.EdgeX)
+	// Version obtains version information from the target service.
+	Version(ctx context.Context) (common.VersionResponse, errors.EdgeX)
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
No V2 CommonClient for calling operational endpoints that are present on all service V2 APIs.

## Issue Number: #364 


## What is the new behavior?
V2 CommonClient provides a client for calling the following operational endpoints that are present on all service V2 APIs:
- /config
- /metrics
- /ping
- /version

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information