### PR TITLE
feat(clients): Implement Add method for V2 EventClient

### DIFF
--- a/v2/clients/http/event.go
+++ b/v2/clients/http/event.go
@@ -1,0 +1,37 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http/utils"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+)
+
+type eventClient struct {
+	baseUrl string
+}
+
+// NewEventClient creates an instance of EventClient
+func NewEventClient(baseUrl string) interfaces.EventClient {
+	return &eventClient{
+		baseUrl: baseUrl,
+	}
+}
+
+func (ec *eventClient) Add(ctx context.Context, reqs []requests.AddEventRequest) ([]common.BaseWithIdResponse, errors.EdgeX) {
+	var br []common.BaseWithIdResponse
+	err := utils.PostRequest(ctx, &br, ec.baseUrl+v2.ApiEventRoute, reqs)
+	if err != nil {
+		return br, errors.NewCommonEdgeXWrapper(err)
+	}
+	return br, nil
+}

--- a/v2/clients/http/event_test.go
+++ b/v2/clients/http/event_test.go
@@ -1,0 +1,48 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddEvent(t *testing.T) {
+	requestId := uuid.New().String()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.EscapedPath() != v2.ApiEventRoute {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusMultiStatus)
+		br := common.NewBaseWithIdResponse(requestId, "", http.StatusMultiStatus, uuid.New().String())
+		res, _ := json.Marshal([]common.BaseWithIdResponse{br})
+		_, _ = w.Write(res)
+	}))
+	defer ts.Close()
+
+	ec := NewEventClient(ts.URL)
+	res, err := ec.Add(context.Background(), []requests.AddEventRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, requestId, res[0].RequestId)
+}

--- a/v2/clients/http/utils/post.go
+++ b/v2/clients/http/utils/post.go
@@ -1,0 +1,78 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+)
+
+// Helper method to make the post JSON request and return the body
+func PostRequest(
+	ctx context.Context,
+	returnValuePointer interface{},
+	url string,
+	data interface{}) errors.EdgeX {
+
+	jsonEncodedData, err := json.Marshal(data)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to encode input data to JSON", err)
+	}
+
+	res, err := PostRawDataRequest(ctx, url, jsonEncodedData)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if err := json.Unmarshal(res, returnValuePointer); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
+	}
+	return nil
+
+}
+
+// PostRawDataRequest will make a POST request to the specified URL.
+// It returns the body as a byte array if successful and an error otherwise.
+func PostRawDataRequest(ctx context.Context, url string, data []byte) ([]byte, errors.EdgeX) {
+	content := FromContext(ctx, clients.ContentType)
+	if content == "" {
+		content = clients.ContentTypeJSON
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindClientError, "failed to create a http request", err)
+	}
+	req.Header.Set(clients.ContentType, content)
+
+	c := NewCorrelatedRequest(ctx, req)
+	resp, err := makeRequest(c.Request)
+	if err != nil {
+		return nil, errors.NewCommonEdgeXWrapper(err)
+	}
+	if resp == nil {
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "the response should not be a nil", nil)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := getBody(resp)
+	if err != nil {
+		return nil, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusMultiStatus, http.StatusCreated:
+		return bodyBytes, nil
+	case http.StatusBadRequest:
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "bad request", nil)
+	default:
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "request failed", nil)
+	}
+}

--- a/v2/clients/interfaces/event.go
+++ b/v2/clients/interfaces/event.go
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+)
+
+// EventClient defines the interface for interactions with the Event endpoint on the EdgeX Foundry core-data service.
+type EventClient interface {
+	// Add adds new events
+	Add(ctx context.Context, reqs []requests.AddEventRequest) ([]common.BaseWithIdResponse, errors.EdgeX)
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
There is no V2 EventClient.

## Issue Number: #366 


## What is the new behavior?
Added the V2 EventClient and implemented the Add method, which is used to issue an HTTP POST request to the core-data service to add new events. This PR also introduced the HTTP POST helper function for V2 clients.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information