### PR TITLE
feat: Add a new CountResponse to replace EventCountResponse and ReadingCountResponse

### DIFF
--- a/v2/dtos/common/count.go
+++ b/v2/dtos/common/count.go
@@ -1,0 +1,17 @@
+package common
+
+// CountResponse defines the Response Content for GET count DTO.
+// This object and its properties correspond to the CountResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/CountResponse
+type CountResponse struct {
+	BaseResponse `json:",inline"`
+	Count        uint32
+}
+
+// NewCountResponse creates new CountResponse with all fields set appropriately
+func NewCountResponse(requestId string, message string, statusCode int, count uint32) CountResponse {
+	return CountResponse{
+		BaseResponse: NewBaseResponse(requestId, message, statusCode),
+		Count:        count,
+	}
+}

--- a/v2/dtos/common/count_test.go
+++ b/v2/dtos/common/count_test.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCountResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedCount := uint32(1000)
+	actual := NewCountResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedCount)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedCount, actual.Count)
+}

--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -10,15 +10,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 )
 
-// EventCountResponse defines the Response Content for GET event count DTO.
-// This object and its properties correspond to the EventCountResponse object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/EventCountResponse
-type EventCountResponse struct {
-	common.BaseResponse `json:",inline"`
-	Count               uint32
-	DeviceName          string `json:"deviceName"`
-}
-
 // EventResponse defines the Response Content for GET event DTOs.
 // This object and its properties correspond to the EventResponse object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/EventResponse
@@ -41,14 +32,6 @@ type MultiEventsResponse struct {
 type UpdateEventPushedByIdResponse struct {
 	common.BaseResponse `json:",inline"`
 	Id                  string `json:"id"`
-}
-
-func NewEventCountResponse(requestId string, message string, statusCode int, count uint32, deviceName string) EventCountResponse {
-	return EventCountResponse{
-		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
-		Count:        count,
-		DeviceName:   deviceName,
-	}
 }
 
 func NewEventResponse(requestId string, message string, statusCode int, event dtos.Event) EventResponse {

--- a/v2/dtos/responses/event_test.go
+++ b/v2/dtos/responses/event_test.go
@@ -13,21 +13,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 )
 
-func TestNewEventCountResponse(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedMessage := "unit test message"
-	expectedCount := uint32(1000)
-	expectedDeviceName := "device1"
-	actual := NewEventCountResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedCount, expectedDeviceName)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedCount, actual.Count)
-	assert.Equal(t, expectedDeviceName, actual.DeviceName)
-}
-
 func TestNewEventResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200

--- a/v2/dtos/responses/reading.go
+++ b/v2/dtos/responses/reading.go
@@ -10,14 +10,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 )
 
-// ReadingCountResponse defines the Response Content for GET reading count DTO.
-// This object and its properties correspond to the ReadingCountResponse object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/ReadingCountResponse
-type ReadingCountResponse struct {
-	common.BaseResponse `json:",inline"`
-	Count               uint32
-}
-
 // ReadingResponse defines the Response Content for GET reading DTO.
 // This object and its properties correspond to the ReadingResponse object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/ReadingResponse
@@ -32,13 +24,6 @@ type ReadingResponse struct {
 type MultiReadingsResponse struct {
 	common.BaseResponse `json:",inline"`
 	Readings            []dtos.BaseReading `json:"readings"`
-}
-
-func NewReadingCountResponse(requestId string, message string, statusCode int, count uint32) ReadingCountResponse {
-	return ReadingCountResponse{
-		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
-		Count:        count,
-	}
 }
 
 func NewReadingResponse(requestId string, message string, statusCode int, reading dtos.BaseReading) ReadingResponse {

--- a/v2/dtos/responses/reading_test.go
+++ b/v2/dtos/responses/reading_test.go
@@ -13,19 +13,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 )
 
-func TestNewReadingCountResponse(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedMessage := "unit test message"
-	expectedCount := uint32(1000)
-	actual := NewReadingCountResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedCount)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedCount, actual.Count)
-}
-
 func TestNewReadingResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The original V2 API design defines both `EventCountResponse` and `ReadingCountResponse` with exactly identical schema. These two responses seems to be redundant.

Moreover, field `deviceName` inside `EventCountResponse` seems to be redundant as a GET /event/count/device/{deviceName} request will include deviceName as part of route.

## Issue Number:
fix #376 

## What is the new behavior?
This PR implement a new `CountResponse` to replace these two count responses.  The new `CountResponse` also ditch `deviceName` field.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No