### PR TITLE
refactor(meta): V2 Device OperatingState value change

### DIFF
--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -20,7 +20,7 @@ type Device struct {
 	Name               string                        `json:"name" validate:"required,edgex-dto-none-empty-string"`
 	Description        string                        `json:"description,omitempty"`
 	AdminState         string                        `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
-	OperatingState     string                        `json:"operatingState" validate:"oneof='ENABLED' 'DISABLED'"`
+	OperatingState     string                        `json:"operatingState" validate:"oneof='UP' 'DOWN' 'UNKNOWN'"`
 	LastConnected      int64                         `json:"lastConnected,omitempty"`
 	LastReported       int64                         `json:"lastReported,omitempty"`
 	Labels             []string                      `json:"labels,omitempty"`
@@ -38,7 +38,7 @@ type UpdateDevice struct {
 	Name           *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
 	Description    *string                       `json:"description" validate:"omitempty,edgex-dto-none-empty-string"`
 	AdminState     *string                       `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
-	OperatingState *string                       `json:"operatingState" validate:"omitempty,oneof='ENABLED' 'DISABLED'"`
+	OperatingState *string                       `json:"operatingState" validate:"omitempty,oneof='UP' 'DOWN' 'UNKNOWN'"`
 	LastConnected  *int64                        `json:"lastConnected"`
 	LastReported   *int64                        `json:"lastReported"`
 	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string"`

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -21,7 +21,6 @@ type DeviceService struct {
 	Description        string   `json:"description,omitempty"`
 	LastConnected      int64    `json:"lastConnected,omitempty"`
 	LastReported       int64    `json:"lastReported,omitempty"`
-	OperatingState     string   `json:"operatingState" validate:"oneof='ENABLED' 'DISABLED'"`
 	Labels             []string `json:"labels,omitempty"`
 	BaseAddress        string   `json:"baseAddress" validate:"required,uri"`
 	AdminState         string   `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
@@ -30,12 +29,11 @@ type DeviceService struct {
 // UpdateDeviceService and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/UpdateDeviceService
 type UpdateDeviceService struct {
-	Id             *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name           *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
-	BaseAddress    *string  `json:"baseAddress" validate:"omitempty,uri"`
-	OperatingState *string  `json:"operatingState" validate:"omitempty,oneof='ENABLED' 'DISABLED'"`
-	Labels         []string `json:"labels"`
-	AdminState     *string  `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
+	Id          *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
+	Name        *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
+	BaseAddress *string  `json:"baseAddress" validate:"omitempty,uri"`
+	Labels      []string `json:"labels"`
+	AdminState  *string  `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 }
 
 // ToDeviceServiceModel transforms the DeviceService DTO to the DeviceService Model
@@ -47,7 +45,6 @@ func ToDeviceServiceModel(dto DeviceService) models.DeviceService {
 	ds.LastReported = dto.LastReported
 	ds.LastConnected = dto.LastConnected
 	ds.BaseAddress = dto.BaseAddress
-	ds.OperatingState = models.OperatingState(dto.OperatingState)
 	ds.Labels = dto.Labels
 	ds.AdminState = models.AdminState(dto.AdminState)
 	return ds
@@ -62,7 +59,6 @@ func FromDeviceServiceModelToDTO(ds models.DeviceService) DeviceService {
 	dto.LastReported = ds.LastReported
 	dto.LastConnected = ds.LastConnected
 	dto.BaseAddress = ds.BaseAddress
-	dto.OperatingState = string(ds.OperatingState)
 	dto.Labels = ds.Labels
 	dto.AdminState = string(ds.AdminState)
 	return dto

--- a/v2/dtos/requests/device_test.go
+++ b/v2/dtos/requests/device_test.go
@@ -43,7 +43,7 @@ var testAddDevice = AddDeviceRequest{
 		ServiceName:    TestDeviceServiceName,
 		ProfileName:    TestDeviceProfileName,
 		AdminState:     models.Locked,
-		OperatingState: models.Enabled,
+		OperatingState: models.Up,
 		Labels:         testDeviceLabels,
 		Location:       testDeviceLocation,
 		AutoEvents:     testAutoEvents,
@@ -64,7 +64,7 @@ func mockUpdateDevice() dtos.UpdateDevice {
 	testName := TestDeviceName
 	testDescription := TestDescription
 	testAdminState := models.Locked
-	testOperatingState := models.Enabled
+	testOperatingState := models.Up
 	testDeviceServiceName := TestDeviceServiceName
 	testProfileName := TestDeviceProfileName
 	d := dtos.UpdateDevice{}
@@ -172,7 +172,7 @@ func Test_AddDeviceReqToDeviceModels(t *testing.T) {
 			ServiceName:    TestDeviceServiceName,
 			ProfileName:    TestDeviceProfileName,
 			AdminState:     models.Locked,
-			OperatingState: models.Enabled,
+			OperatingState: models.Up,
 			Labels:         testDeviceLabels,
 			Location:       testDeviceLocation,
 			AutoEvents: []models.AutoEvent{
@@ -366,7 +366,7 @@ func TestReplaceDeviceModelFieldsWithDTO(t *testing.T) {
 
 	assert.Equal(t, TestDescription, device.Description)
 	assert.Equal(t, models.AdminState(models.Locked), device.AdminState)
-	assert.Equal(t, models.OperatingState(models.Enabled), device.OperatingState)
+	assert.Equal(t, models.OperatingState(models.Up), device.OperatingState)
 	assert.Equal(t, testNowTime, device.LastConnected)
 	assert.Equal(t, testNowTime, device.LastReported)
 	assert.Equal(t, TestDeviceServiceName, device.ServiceName)

--- a/v2/dtos/requests/deviceservice.go
+++ b/v2/dtos/requests/deviceservice.go
@@ -92,9 +92,6 @@ func (ds *UpdateDeviceServiceRequest) UnmarshalJSON(b []byte) error {
 
 // ReplaceDeviceServiceModelFieldsWithDTO replace existing DeviceService's fields with DTO patch
 func ReplaceDeviceServiceModelFieldsWithDTO(ds *models.DeviceService, patch dtos.UpdateDeviceService) {
-	if patch.OperatingState != nil {
-		ds.OperatingState = models.OperatingState(*patch.OperatingState)
-	}
 	if patch.AdminState != nil {
 		ds.AdminState = models.AdminState(*patch.AdminState)
 	}

--- a/v2/dtos/requests/deviceservice_test.go
+++ b/v2/dtos/requests/deviceservice_test.go
@@ -23,11 +23,10 @@ var testAddDeviceService = AddDeviceServiceRequest{
 		RequestId: ExampleUUID,
 	},
 	Service: dtos.DeviceService{
-		Name:           TestDeviceServiceName,
-		BaseAddress:    TestBaseAddress,
-		OperatingState: models.Enabled,
-		Labels:         []string{"MODBUS", "TEMP"},
-		AdminState:     models.Locked,
+		Name:        TestDeviceServiceName,
+		BaseAddress: TestBaseAddress,
+		Labels:      []string{"MODBUS", "TEMP"},
+		AdminState:  models.Locked,
 	},
 }
 
@@ -42,13 +41,11 @@ func mockDeviceServiceDTO() dtos.UpdateDeviceService {
 	testUUID := ExampleUUID
 	testName := TestDeviceServiceName
 	testBaseAddress := TestBaseAddress
-	testOperatingState := models.Enabled
 	testAdminState := models.Locked
 	ds := dtos.UpdateDeviceService{}
 	ds.Id = &testUUID
 	ds.Name = &testName
 	ds.BaseAddress = &testBaseAddress
-	ds.OperatingState = &testOperatingState
 	ds.AdminState = &testAdminState
 	ds.Labels = testLabels
 	return ds
@@ -63,14 +60,10 @@ func TestAddDeviceServiceRequest_Validate(t *testing.T) {
 	invalidReqId.RequestId = "jfdw324"
 	noName := testAddDeviceService
 	noName.Service.Name = emptyString
-	noOperatingState := testAddDeviceService
-	noOperatingState.Service.OperatingState = emptyString
-	invalidOperatingState := testAddDeviceService
-	invalidOperatingState.Service.OperatingState = "invalid"
 	noAdminState := testAddDeviceService
-	noAdminState.Service.OperatingState = emptyString
+	noAdminState.Service.AdminState = emptyString
 	invalidAdminState := testAddDeviceService
-	invalidAdminState.Service.OperatingState = "invalid"
+	invalidAdminState.Service.AdminState = "invalid"
 	noBaseAddress := testAddDeviceService
 	noBaseAddress.Service.BaseAddress = emptyString
 	invalidBaseAddress := testAddDeviceService
@@ -84,8 +77,6 @@ func TestAddDeviceServiceRequest_Validate(t *testing.T) {
 		{"valid AddDeviceServiceRequest, no Request Id", noReqId, false},
 		{"invalid AddDeviceServiceRequest, Request Id is not an uuid", invalidReqId, true},
 		{"invalid AddDeviceServiceRequest, no Name", noName, true},
-		{"invalid AddDeviceServiceRequest, no OperatingState", noOperatingState, true},
-		{"invalid AddDeviceServiceRequest, invalid OperatingState", invalidOperatingState, true},
 		{"invalid AddDeviceServiceRequest, no AdminState", noAdminState, true},
 		{"invalid AddDeviceServiceRequest, invalid AdminState", invalidAdminState, true},
 		{"invalid AddDeviceServiceRequest, no BaseAddress", noBaseAddress, true},
@@ -133,11 +124,10 @@ func TestAddDeviceService_UnmarshalJSON(t *testing.T) {
 func TestAddDeviceServiceReqToDeviceServiceModels(t *testing.T) {
 	requests := []AddDeviceServiceRequest{testAddDeviceService}
 	expectedDeviceServiceModel := []models.DeviceService{{
-		Name:           TestDeviceServiceName,
-		BaseAddress:    TestBaseAddress,
-		OperatingState: models.Enabled,
-		Labels:         []string{"MODBUS", "TEMP"},
-		AdminState:     models.Locked,
+		Name:        TestDeviceServiceName,
+		BaseAddress: TestBaseAddress,
+		Labels:      []string{"MODBUS", "TEMP"},
+		AdminState:  models.Locked,
 	}}
 	resultModels := AddDeviceServiceReqToDeviceServiceModels(requests)
 	assert.Equal(t, expectedDeviceServiceModel, resultModels, "AddDeviceServiceReqToDeviceServiceModels did not result in expected DeviceService model.")
@@ -205,11 +195,9 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 	invalidBaseAddress := valid
 	invalidBaseAddress.Service.BaseAddress = &invalidUrl
 
-	invalidOperatingState := valid
 	invalid := "invalid"
-	invalidOperatingState.Service.OperatingState = &invalid
 	invalidAdminState := valid
-	invalidAdminState.Service.OperatingState = &invalid
+	invalidAdminState.Service.AdminState = &invalid
 	tests := []struct {
 		name        string
 		req         UpdateDeviceServiceRequest
@@ -229,7 +217,6 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 		{"valid, nil baseAddress", validNilBaseAddress, false},
 		{"invalid, invalid baseAddress", invalidBaseAddress, true},
 
-		{"invalid, invalid OperatingState", invalidOperatingState, true},
 		{"invalid, invalid AdminState", invalidAdminState, true},
 	}
 	for _, tt := range tests {
@@ -255,7 +242,6 @@ func TestUpdateDeviceServiceRequest_UnmarshalJSON_NilField(t *testing.T) {
 	// Nil field checking is used to update with patch
 	assert.Nil(t, req.Service.BaseAddress)
 	assert.Nil(t, req.Service.AdminState)
-	assert.Nil(t, req.Service.OperatingState)
 	assert.Nil(t, req.Service.Labels)
 }
 
@@ -286,7 +272,6 @@ func TestReplaceDeviceServiceModelFieldsWithDTO(t *testing.T) {
 	ReplaceDeviceServiceModelFieldsWithDTO(&ds, patch)
 
 	assert.Equal(t, TestBaseAddress, ds.BaseAddress)
-	assert.Equal(t, models.Enabled, string(ds.OperatingState))
 	assert.Equal(t, models.Locked, string(ds.AdminState))
 	assert.Equal(t, testLabels, ds.Labels)
 }

--- a/v2/models/deviceservice.go
+++ b/v2/models/deviceservice.go
@@ -11,11 +11,11 @@ package models
 type DeviceService struct {
 	Timestamps
 	Id            string
-	Name          string     // time in milliseconds that the device last provided any feedback or responded to any request
-	Description   string     // Description of the device service
-	LastConnected int64      // time in milliseconds that the device last reported data to the core
-	LastReported  int64      // operational state - either enabled or disabled
-	Labels        []string   // tags or other labels applied to the device service for search or other identification needs
-	BaseAddress   string     // BaseAddress is a fully qualified URI, e.g. <protocol>:\\<hostname>:<port>/<optional path>
-	AdminState    AdminState // Device Service Admin State
+	Name          string
+	Description   string
+	LastConnected int64
+	LastReported  int64
+	Labels        []string
+	BaseAddress   string
+	AdminState    AdminState
 }

--- a/v2/models/deviceservice.go
+++ b/v2/models/deviceservice.go
@@ -10,13 +10,12 @@ package models
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type DeviceService struct {
 	Timestamps
-	Id             string
-	Name           string         // time in milliseconds that the device last provided any feedback or responded to any request
-	Description    string         // Description of the device service
-	LastConnected  int64          // time in milliseconds that the device last reported data to the core
-	LastReported   int64          // operational state - either enabled or disabled
-	OperatingState OperatingState // operational state - ether enabled or disableddc
-	Labels         []string       // tags or other labels applied to the device service for search or other identification needs
-	BaseAddress    string         // BaseAddress is a fully qualified URI, e.g. <protocol>:\\<hostname>:<port>/<optional path>
-	AdminState     AdminState     // Device Service Admin State
+	Id            string
+	Name          string     // time in milliseconds that the device last provided any feedback or responded to any request
+	Description   string     // Description of the device service
+	LastConnected int64      // time in milliseconds that the device last reported data to the core
+	LastReported  int64      // operational state - either enabled or disabled
+	Labels        []string   // tags or other labels applied to the device service for search or other identification needs
+	BaseAddress   string     // BaseAddress is a fully qualified URI, e.g. <protocol>:\\<hostname>:<port>/<optional path>
+	AdminState    AdminState // Device Service Admin State
 }

--- a/v2/models/operatingstate.go
+++ b/v2/models/operatingstate.go
@@ -9,10 +9,12 @@ package models
 type OperatingState string
 
 /*
-	Enabled  : ENABLED
-	Disabled : DISABLED
+	Up      : UP
+	Down    : DOWN
+	Unknown : UNKNOWN
 */
 const (
-	Enabled  = "ENABLED"
-	Disabled = "DISABLED"
+	Up      = "UP"
+	Down    = "DOWN"
+	Unknown = "UNKNOWN"
 )


### PR DESCRIPTION
Fix #318 
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #318 


## What is the new behavior?
V2 Device OperatingState value change the enumeration value of OperatingState from Enabled/Disabled to Up/Down/Unknown

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
This PR is based on the https://github.com/edgexfoundry/go-mod-core-contracts/pull/384