### PR TITLE
feat(meta): Add V2 client for querying device profile

### DIFF
--- a/v2/clients/http/common.go
+++ b/v2/clients/http/common.go
@@ -28,7 +28,7 @@ func NewCommonClient(baseUrl string) interfaces.CommonClient {
 
 func (cc *commonClient) Configuration(ctx context.Context) (common.ConfigResponse, errors.EdgeX) {
 	cr := common.ConfigResponse{}
-	err := utils.GetRequest(ctx, &cr, cc.baseUrl+v2.ApiConfigRoute)
+	err := utils.GetRequest(ctx, &cr, cc.baseUrl, v2.ApiConfigRoute, nil)
 	if err != nil {
 		return cr, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -37,7 +37,7 @@ func (cc *commonClient) Configuration(ctx context.Context) (common.ConfigRespons
 
 func (cc *commonClient) Metrics(ctx context.Context) (common.MetricsResponse, errors.EdgeX) {
 	mr := common.MetricsResponse{}
-	err := utils.GetRequest(ctx, &mr, cc.baseUrl+v2.ApiMetricsRoute)
+	err := utils.GetRequest(ctx, &mr, cc.baseUrl, v2.ApiMetricsRoute, nil)
 	if err != nil {
 		return mr, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -46,7 +46,7 @@ func (cc *commonClient) Metrics(ctx context.Context) (common.MetricsResponse, er
 
 func (cc *commonClient) Ping(ctx context.Context) (common.PingResponse, errors.EdgeX) {
 	pr := common.PingResponse{}
-	err := utils.GetRequest(ctx, &pr, cc.baseUrl+v2.ApiPingRoute)
+	err := utils.GetRequest(ctx, &pr, cc.baseUrl, v2.ApiPingRoute, nil)
 	if err != nil {
 		return pr, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -55,7 +55,7 @@ func (cc *commonClient) Ping(ctx context.Context) (common.PingResponse, errors.E
 
 func (cc *commonClient) Version(ctx context.Context) (common.VersionResponse, errors.EdgeX) {
 	vr := common.VersionResponse{}
-	err := utils.GetRequest(ctx, &vr, cc.baseUrl+v2.ApiVersionRoute)
+	err := utils.GetRequest(ctx, &vr, cc.baseUrl, v2.ApiVersionRoute, nil)
 	if err != nil {
 		return vr, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceprofile.go
+++ b/v2/clients/http/deviceprofile.go
@@ -9,6 +9,10 @@ import (
 	"context"
 	"net/url"
 	"path"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2"
@@ -16,6 +20,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
 )
 
 type DeviceProfileClient struct {
@@ -77,4 +82,88 @@ func (client *DeviceProfileClient) DeleteByName(ctx context.Context, name string
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
 	return response, nil
+}
+
+func (client *DeviceProfileClient) DeviceProfileByName(ctx context.Context, name string) (res responses.DeviceProfileResponse, edgexError errors.EdgeX) {
+	u, err := url.Parse(client.baseUrl)
+	if err != nil {
+		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
+	}
+	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Name, url.QueryEscape(name))
+	err = utils.GetRequest(ctx, &res, u.String())
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (client *DeviceProfileClient) AllDeviceProfiles(ctx context.Context, labels []string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
+	u, err := url.Parse(client.baseUrl)
+	if err != nil {
+		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
+	}
+	u.Path = path.Join(u.Path, v2.ApiAllDeviceProfileRoute)
+	q := u.Query()
+	if len(labels) > 0 {
+		q.Set(v2.Labels, strings.Join(labels, v2.CommaSeparator))
+	}
+	q.Set(v2.Offset, strconv.Itoa(offset))
+	q.Set(v2.Limit, strconv.Itoa(limit))
+	u.RawQuery = q.Encode()
+	err = utils.GetRequest(ctx, &res, u.String())
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (client *DeviceProfileClient) DeviceProfilesByModel(ctx context.Context, model string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
+	u, err := url.Parse(client.baseUrl)
+	if err != nil {
+		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
+	}
+	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Model, url.QueryEscape(model))
+	q := u.Query()
+	q.Set(v2.Offset, strconv.Itoa(offset))
+	q.Set(v2.Limit, strconv.Itoa(limit))
+	u.RawQuery = q.Encode()
+	err = utils.GetRequest(ctx, &res, u.String())
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (client *DeviceProfileClient) DeviceProfilesByManufacturer(ctx context.Context, manufacturer string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
+	u, err := url.Parse(client.baseUrl)
+	if err != nil {
+		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
+	}
+	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Manufacturer, url.QueryEscape(manufacturer))
+	q := u.Query()
+	q.Set(v2.Offset, strconv.Itoa(offset))
+	q.Set(v2.Limit, strconv.Itoa(limit))
+	u.RawQuery = q.Encode()
+	err = utils.GetRequest(ctx, &res, u.String())
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (client *DeviceProfileClient) DeviceProfilesByManufacturerAndModel(ctx context.Context, manufacturer string, model string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
+	u, err := url.Parse(client.baseUrl)
+	if err != nil {
+		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
+	}
+	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Manufacturer, url.QueryEscape(manufacturer), v2.Model, url.QueryEscape(model))
+	q := u.Query()
+	q.Set(v2.Offset, strconv.Itoa(offset))
+	q.Set(v2.Limit, strconv.Itoa(limit))
+	u.RawQuery = q.Encode()
+	err = utils.GetRequest(ctx, &res, u.String())
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
 }

--- a/v2/clients/http/deviceprofile.go
+++ b/v2/clients/http/deviceprofile.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"net/url"
 	"path"
-	"net/url"
-	"path"
 	"strconv"
 	"strings"
 
@@ -85,12 +83,8 @@ func (client *DeviceProfileClient) DeleteByName(ctx context.Context, name string
 }
 
 func (client *DeviceProfileClient) DeviceProfileByName(ctx context.Context, name string) (res responses.DeviceProfileResponse, edgexError errors.EdgeX) {
-	u, err := url.Parse(client.baseUrl)
-	if err != nil {
-		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
-	}
-	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Name, url.QueryEscape(name))
-	err = utils.GetRequest(ctx, &res, u.String())
+	requestPath := path.Join(v2.ApiDeviceProfileRoute, v2.Name, url.QueryEscape(name))
+	err := utils.GetRequest(ctx, &res, client.baseUrl, requestPath, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -98,19 +92,13 @@ func (client *DeviceProfileClient) DeviceProfileByName(ctx context.Context, name
 }
 
 func (client *DeviceProfileClient) AllDeviceProfiles(ctx context.Context, labels []string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
-	u, err := url.Parse(client.baseUrl)
-	if err != nil {
-		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
-	}
-	u.Path = path.Join(u.Path, v2.ApiAllDeviceProfileRoute)
-	q := u.Query()
+	requestParams := url.Values{}
 	if len(labels) > 0 {
-		q.Set(v2.Labels, strings.Join(labels, v2.CommaSeparator))
+		requestParams.Set(v2.Labels, strings.Join(labels, v2.CommaSeparator))
 	}
-	q.Set(v2.Offset, strconv.Itoa(offset))
-	q.Set(v2.Limit, strconv.Itoa(limit))
-	u.RawQuery = q.Encode()
-	err = utils.GetRequest(ctx, &res, u.String())
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err := utils.GetRequest(ctx, &res, client.baseUrl, v2.ApiAllDeviceProfileRoute, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -118,16 +106,11 @@ func (client *DeviceProfileClient) AllDeviceProfiles(ctx context.Context, labels
 }
 
 func (client *DeviceProfileClient) DeviceProfilesByModel(ctx context.Context, model string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
-	u, err := url.Parse(client.baseUrl)
-	if err != nil {
-		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
-	}
-	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Model, url.QueryEscape(model))
-	q := u.Query()
-	q.Set(v2.Offset, strconv.Itoa(offset))
-	q.Set(v2.Limit, strconv.Itoa(limit))
-	u.RawQuery = q.Encode()
-	err = utils.GetRequest(ctx, &res, u.String())
+	requestPath := path.Join(v2.ApiDeviceProfileRoute, v2.Model, url.QueryEscape(model))
+	requestParams := url.Values{}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err := utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -135,16 +118,11 @@ func (client *DeviceProfileClient) DeviceProfilesByModel(ctx context.Context, mo
 }
 
 func (client *DeviceProfileClient) DeviceProfilesByManufacturer(ctx context.Context, manufacturer string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
-	u, err := url.Parse(client.baseUrl)
-	if err != nil {
-		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
-	}
-	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Manufacturer, url.QueryEscape(manufacturer))
-	q := u.Query()
-	q.Set(v2.Offset, strconv.Itoa(offset))
-	q.Set(v2.Limit, strconv.Itoa(limit))
-	u.RawQuery = q.Encode()
-	err = utils.GetRequest(ctx, &res, u.String())
+	requestPath := path.Join(v2.ApiDeviceProfileRoute, v2.Manufacturer, url.QueryEscape(manufacturer))
+	requestParams := url.Values{}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err := utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -152,16 +130,11 @@ func (client *DeviceProfileClient) DeviceProfilesByManufacturer(ctx context.Cont
 }
 
 func (client *DeviceProfileClient) DeviceProfilesByManufacturerAndModel(ctx context.Context, manufacturer string, model string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
-	u, err := url.Parse(client.baseUrl)
-	if err != nil {
-		return res, errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
-	}
-	u.Path = path.Join(u.Path, v2.ApiDeviceProfileRoute, v2.Manufacturer, url.QueryEscape(manufacturer), v2.Model, url.QueryEscape(model))
-	q := u.Query()
-	q.Set(v2.Offset, strconv.Itoa(offset))
-	q.Set(v2.Limit, strconv.Itoa(limit))
-	u.RawQuery = q.Encode()
-	err = utils.GetRequest(ctx, &res, u.String())
+	requestPath := path.Join(v2.ApiDeviceProfileRoute, v2.Manufacturer, url.QueryEscape(manufacturer), v2.Model, url.QueryEscape(model))
+	requestParams := url.Values{}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err := utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceprofile_test.go
+++ b/v2/clients/http/deviceprofile_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"path"
 	"os"
 	"path"
 	"path/filepath"
@@ -185,7 +184,7 @@ func TestDeleteDeviceProfileByName(t *testing.T) {
 func TestQueryDeviceProfileByName(t *testing.T) {
 	testName := "testName"
 	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Name, testName)
-	ts := newTestServer(urlPath, responses.DeviceProfileResponse{})
+	ts := newTestServer(http.MethodGet, urlPath, responses.DeviceProfileResponse{})
 	defer ts.Close()
 	client := NewDeviceProfileClient(ts.URL)
 	_, err := client.DeviceProfileByName(context.Background(), testName)
@@ -193,7 +192,7 @@ func TestQueryDeviceProfileByName(t *testing.T) {
 }
 
 func TestQueryAllDeviceProfiles(t *testing.T) {
-	ts := newTestServer(v2.ApiAllDeviceProfileRoute, responses.MultiDeviceProfilesResponse{})
+	ts := newTestServer(http.MethodGet, v2.ApiAllDeviceProfileRoute, responses.MultiDeviceProfilesResponse{})
 	defer ts.Close()
 	client := NewDeviceProfileClient(ts.URL)
 	_, err := client.AllDeviceProfiles(context.Background(), []string{"testLabel1", "testLabel2"}, 1, 10)
@@ -203,7 +202,7 @@ func TestQueryAllDeviceProfiles(t *testing.T) {
 func TestQueryDeviceProfilesByModel(t *testing.T) {
 	testModel := "testModel"
 	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Model, testModel)
-	ts := newTestServer(urlPath, responses.MultiDeviceProfilesResponse{})
+	ts := newTestServer(http.MethodGet, urlPath, responses.MultiDeviceProfilesResponse{})
 	defer ts.Close()
 	client := NewDeviceProfileClient(ts.URL)
 	_, err := client.DeviceProfilesByModel(context.Background(), testModel, 1, 10)
@@ -213,7 +212,7 @@ func TestQueryDeviceProfilesByModel(t *testing.T) {
 func TestQueryDeviceProfilesByManufacturer(t *testing.T) {
 	testManufacturer := "testManufacturer"
 	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Manufacturer, testManufacturer)
-	ts := newTestServer(urlPath, responses.MultiDeviceProfilesResponse{})
+	ts := newTestServer(http.MethodGet, urlPath, responses.MultiDeviceProfilesResponse{})
 	defer ts.Close()
 	client := NewDeviceProfileClient(ts.URL)
 	_, err := client.DeviceProfilesByManufacturer(context.Background(), testManufacturer, 1, 10)
@@ -224,7 +223,7 @@ func TestQueryDeviceProfilesByManufacturerAndModel(t *testing.T) {
 	testManufacturer := "testManufacturer"
 	testModel := "testModel"
 	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Manufacturer, testManufacturer, v2.Model, testModel)
-	ts := newTestServer(urlPath, responses.MultiDeviceProfilesResponse{})
+	ts := newTestServer(http.MethodGet, urlPath, responses.MultiDeviceProfilesResponse{})
 	defer ts.Close()
 	client := NewDeviceProfileClient(ts.URL)
 	_, err := client.DeviceProfilesByManufacturerAndModel(context.Background(), testManufacturer, testModel, 1, 10)

--- a/v2/clients/http/deviceprofile_test.go
+++ b/v2/clients/http/deviceprofile_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"os"
 	"path"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -178,4 +180,53 @@ func TestDeleteDeviceProfileByName(t *testing.T) {
 	res, err := client.DeleteByName(context.Background(), testName)
 	require.NoError(t, err)
 	require.NotNil(t, res)
+}
+
+func TestQueryDeviceProfileByName(t *testing.T) {
+	testName := "testName"
+	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Name, testName)
+	ts := newTestServer(urlPath, responses.DeviceProfileResponse{})
+	defer ts.Close()
+	client := NewDeviceProfileClient(ts.URL)
+	_, err := client.DeviceProfileByName(context.Background(), testName)
+	require.NoError(t, err)
+}
+
+func TestQueryAllDeviceProfiles(t *testing.T) {
+	ts := newTestServer(v2.ApiAllDeviceProfileRoute, responses.MultiDeviceProfilesResponse{})
+	defer ts.Close()
+	client := NewDeviceProfileClient(ts.URL)
+	_, err := client.AllDeviceProfiles(context.Background(), []string{"testLabel1", "testLabel2"}, 1, 10)
+	require.NoError(t, err)
+}
+
+func TestQueryDeviceProfilesByModel(t *testing.T) {
+	testModel := "testModel"
+	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Model, testModel)
+	ts := newTestServer(urlPath, responses.MultiDeviceProfilesResponse{})
+	defer ts.Close()
+	client := NewDeviceProfileClient(ts.URL)
+	_, err := client.DeviceProfilesByModel(context.Background(), testModel, 1, 10)
+	require.NoError(t, err)
+}
+
+func TestQueryDeviceProfilesByManufacturer(t *testing.T) {
+	testManufacturer := "testManufacturer"
+	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Manufacturer, testManufacturer)
+	ts := newTestServer(urlPath, responses.MultiDeviceProfilesResponse{})
+	defer ts.Close()
+	client := NewDeviceProfileClient(ts.URL)
+	_, err := client.DeviceProfilesByManufacturer(context.Background(), testManufacturer, 1, 10)
+	require.NoError(t, err)
+}
+
+func TestQueryDeviceProfilesByManufacturerAndModel(t *testing.T) {
+	testManufacturer := "testManufacturer"
+	testModel := "testModel"
+	urlPath := path.Join(v2.ApiDeviceProfileRoute, v2.Manufacturer, testManufacturer, v2.Model, testModel)
+	ts := newTestServer(urlPath, responses.MultiDeviceProfilesResponse{})
+	defer ts.Close()
+	client := NewDeviceProfileClient(ts.URL)
+	_, err := client.DeviceProfilesByManufacturerAndModel(context.Background(), testManufacturer, testModel, 1, 10)
+	require.NoError(t, err)
 }

--- a/v2/clients/http/utils/request.go
+++ b/v2/clients/http/utils/request.go
@@ -8,14 +8,22 @@ package utils
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"net/http"
+	"net/url"
 )
 
 // Helper method to make the get request and return the body
-func GetRequest(ctx context.Context, returnValuePointer interface{}, url string) errors.EdgeX {
-	req, err := createRequest(ctx, http.MethodGet, url)
+func GetRequest(ctx context.Context, returnValuePointer interface{}, baseUrl string, requestPath string, requestParams url.Values) errors.EdgeX {
+	u, err := url.Parse(baseUrl)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindClientError, "fail to parse baseUrl", err)
+	}
+	u.Path = requestPath
+	if requestParams != nil {
+		u.RawQuery = requestParams.Encode()
+	}
+	req, err := createRequest(ctx, http.MethodGet, u.String())
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/interfaces/deviceprofile.go
+++ b/v2/clients/interfaces/deviceprofile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
 )
 
 // DeviceProfileClient defines the interface for interactions with the DeviceProfile endpoint on the EdgeX Foundry core-metadata service.
@@ -25,4 +26,14 @@ type DeviceProfileClient interface {
 	UpdateByYaml(ctx context.Context, yamlFilePath string) (common.BaseResponse, errors.EdgeX)
 	// DeleteByName deletes profile by name
 	DeleteByName(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX)
+	// Query profile by name
+	DeviceProfileByName(ctx context.Context, name string) (responses.DeviceProfileResponse, errors.EdgeX)
+	// Query all profiles
+	AllDeviceProfiles(ctx context.Context, labels []string, offset int, limit int) (responses.MultiDeviceProfilesResponse, errors.EdgeX)
+	// Query profiles by model
+	DeviceProfilesByModel(ctx context.Context, model string, offset int, limit int) (responses.MultiDeviceProfilesResponse, errors.EdgeX)
+	// Query profiles by manufacturer
+	DeviceProfilesByManufacturer(ctx context.Context, manufacturer string, offset int, limit int) (responses.MultiDeviceProfilesResponse, errors.EdgeX)
+	// Query profiles by manufacturer and model
+	DeviceProfilesByManufacturerAndModel(ctx context.Context, manufacturer string, model string, offset int, limit int) (responses.MultiDeviceProfilesResponse, errors.EdgeX)
 }


### PR DESCRIPTION
Fix #392

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #392


## What is the new behavior?
Add V2 client for querying the device profile
- query by name
- query all
- query all by model
- query all by manufacturer
- query all by manufacturer and model

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information