### PR TITLE
feat(v2 data): Remove pushed field from Event DTO/Model

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -13,13 +13,11 @@ const (
 	ApiEventRoute              = ApiBase + "/event"
 	ApiAllEventRoute           = ApiEventRoute + "/" + All
 	ApiEventIdRoute            = ApiEventRoute + "/" + Id + "/{" + Id + "}"
-	ApiEventPushRoute          = ApiEventRoute + "/" + Pushed
 	ApiEventCountRoute         = ApiEventRoute + "/" + Count
 	ApiEventCountByDeviceRoute = ApiEventCountRoute + "/" + Device + "/{" + DeviceName + "}"
 	ApiEventByDeviceNameRoute  = ApiEventRoute + "/" + Device + "/" + Name + "/{" + Name + "}"
 	ApiEventByTimeRangeRoute   = ApiEventRoute + "/" + Start + "/{" + Start + "}/" + End + "/{" + End + "}"
 	ApiEventByAgeRoute         = ApiEventRoute + "/" + Age + "/{" + Age + "}"
-	ApiEventScrubRoute         = ApiEventRoute + "/" + Scrub
 
 	ApiReadingRoute             = ApiBase + "/reading"
 	ApiAllReadingRoute          = ApiReadingRoute + "/" + All

--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -20,7 +20,6 @@ import (
 type Event struct {
 	common.Versionable `json:",inline"`
 	Id                 string            `json:"id" validate:"required,uuid"`
-	Pushed             int64             `json:"pushed,omitempty"`
 	DeviceName         string            `json:"deviceName" validate:"required"`
 	ProfileName        string            `json:"profileName" validate:"required"`
 	Created            int64             `json:"created"`
@@ -44,7 +43,6 @@ func FromEventModelToDTO(event models.Event) Event {
 	return Event{
 		Versionable: common.Versionable{ApiVersion: v2.ApiVersion},
 		Id:          event.Id,
-		Pushed:      event.Pushed,
 		DeviceName:  event.DeviceName,
 		ProfileName: event.ProfileName,
 		Created:     event.Created,

--- a/v2/dtos/event_test.go
+++ b/v2/dtos/event_test.go
@@ -18,7 +18,6 @@ import (
 
 var valid = models.Event{
 	Id:          TestUUID,
-	Pushed:      TestTimestamp,
 	DeviceName:  TestDeviceName,
 	ProfileName: TestDeviceProfileName,
 	Created:     TestTimestamp,
@@ -33,7 +32,6 @@ var valid = models.Event{
 var expectedDTO = Event{
 	Versionable: common.Versionable{ApiVersion: v2.ApiVersion},
 	Id:          TestUUID,
-	Pushed:      TestTimestamp,
 	DeviceName:  TestDeviceName,
 	ProfileName: TestDeviceProfileName,
 	Created:     TestTimestamp,
@@ -63,7 +61,7 @@ func TestFromEventModelToDTO(t *testing.T) {
 func TestEvent_ToXML(t *testing.T) {
 	// Since the order in map is random we have to verify the individual items exists without depending on order
 	contains := []string{
-		"<Event><ApiVersion>v2</ApiVersion><Id>7a1707f0-166f-4c4b-bc9d-1d54c74e0137</Id><Pushed>1594963842</Pushed><DeviceName>TestDevice</DeviceName><ProfileName>TestDeviceProfileName</ProfileName><Created>1594963842</Created><Origin>1594963842</Origin><Tags>",
+		"<Event><ApiVersion>v2</ApiVersion><Id>7a1707f0-166f-4c4b-bc9d-1d54c74e0137</Id><DeviceName>TestDevice</DeviceName><ProfileName>TestDeviceProfileName</ProfileName><Created>1594963842</Created><Origin>1594963842</Origin><Tags>",
 		"<GatewayID>Houston-0001</GatewayID>",
 		"<Latitude>29.630771</Latitude>",
 		"<Longitude>-95.377603</Longitude>",

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -23,14 +23,6 @@ type AddEventRequest struct {
 	Event              dtos.Event `json:"event" validate:"required"`
 }
 
-// UpdateEventPushedByIdRequest defines the Request Content for PUT event as pushed DTO.
-// This object and its properties correspond to the UpdateEventPushedByIdRequest object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/UpdateEventPushedByIdRequest
-type UpdateEventPushedByIdRequest struct {
-	common.BaseRequest `json:",inline"`
-	Id                 string `json:"id" validate:"required,uuid"`
-}
-
 // Validate satisfies the Validator interface
 func (a AddEventRequest) Validate() error {
 	if err := v2.Validate(a); err != nil {

--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -26,14 +26,6 @@ type MultiEventsResponse struct {
 	Events              []dtos.Event `json:"events"`
 }
 
-// UpdateEventPushedByIdResponse defines the Response Content for PUT event as pushed DTO.
-// This object and its properties correspond to the UpdateEventPushedByIdResponse object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/UpdateEventPushedByIdResponse
-type UpdateEventPushedByIdResponse struct {
-	common.BaseResponse `json:",inline"`
-	Id                  string `json:"id"`
-}
-
 func NewEventResponse(requestId string, message string, statusCode int, event dtos.Event) EventResponse {
 	return EventResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
@@ -45,12 +37,5 @@ func NewMultiEventsResponse(requestId string, message string, statusCode int, ev
 	return MultiEventsResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
 		Events:       events,
-	}
-}
-
-func NewUpdateEventPushedByIdResponse(requestId string, message string, statusCode int, id string) UpdateEventPushedByIdResponse {
-	return UpdateEventPushedByIdResponse{
-		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
-		Id:           id,
 	}
 }

--- a/v2/dtos/responses/event_test.go
+++ b/v2/dtos/responses/event_test.go
@@ -41,16 +41,3 @@ func TestNewMultiEventsResponse(t *testing.T) {
 	assert.Equal(t, expectedMessage, actual.Message)
 	assert.Equal(t, expectedEvents, actual.Events)
 }
-
-func TestNewUpdateEventPushedByIdResponse(t *testing.T) {
-	expectedRequestId := "123456"
-	expectedStatusCode := 200
-	expectedMessage := "unit test message"
-	expectedId := "11111111-2222-3333-4444-555555555555"
-	actual := NewUpdateEventPushedByIdResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedId)
-
-	assert.Equal(t, expectedRequestId, actual.RequestId)
-	assert.Equal(t, expectedStatusCode, actual.StatusCode)
-	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedId, actual.Id)
-}

--- a/v2/models/event.go
+++ b/v2/models/event.go
@@ -10,7 +10,6 @@ package models
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type Event struct {
 	Id          string
-	Pushed      int64
 	DeviceName  string
 	ProfileName string
 	Created     int64


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #397 

## What is the new behavior?
Per edgexfoundry/edgex-go#2937, Event DTO/Model no longer needs pushed field,
so remove pushed field for code purity.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No