### PR TITLE
feat(v2): implement custom validation tag for RFC3986 unreserved characters

### DIFF
--- a/v2/dtos/command.go
+++ b/v2/dtos/command.go
@@ -10,7 +10,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // Command and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/Command
 type Command struct {
-	Name string `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string"`
+	Name string `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Get  bool   `json:"get" yaml:"get,omitempty" validate:"required_without=Put"`
 	Put  bool   `json:"put" yaml:"put,omitempty" validate:"required_without=Get"`
 }

--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -17,7 +17,7 @@ type Device struct {
 	Id                 string                        `json:"id,omitempty" validate:"omitempty,uuid"`
 	Created            int64                         `json:"created,omitempty"`
 	Modified           int64                         `json:"modified,omitempty"`
-	Name               string                        `json:"name" validate:"required,edgex-dto-none-empty-string"`
+	Name               string                        `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Description        string                        `json:"description,omitempty"`
 	AdminState         string                        `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	OperatingState     string                        `json:"operatingState" validate:"oneof='UP' 'DOWN' 'UNKNOWN'"`
@@ -25,8 +25,8 @@ type Device struct {
 	LastReported       int64                         `json:"lastReported,omitempty"`
 	Labels             []string                      `json:"labels,omitempty"`
 	Location           interface{}                   `json:"location,omitempty"`
-	ServiceName        string                        `json:"serviceName" validate:"required,edgex-dto-none-empty-string"`
-	ProfileName        string                        `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
+	ServiceName        string                        `json:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName        string                        `json:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AutoEvents         []AutoEvent                   `json:"autoEvents,omitempty" validate:"dive"`
 	Protocols          map[string]ProtocolProperties `json:"protocols,omitempty" validate:"required,gt=0"`
 }
@@ -35,14 +35,14 @@ type Device struct {
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/UpdateDevice
 type UpdateDevice struct {
 	Id             *string                       `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name           *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
+	Name           *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Description    *string                       `json:"description" validate:"omitempty,edgex-dto-none-empty-string"`
 	AdminState     *string                       `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	OperatingState *string                       `json:"operatingState" validate:"omitempty,oneof='UP' 'DOWN' 'UNKNOWN'"`
 	LastConnected  *int64                        `json:"lastConnected"`
 	LastReported   *int64                        `json:"lastReported"`
-	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string"`
-	ProfileName    *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string"`
+	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName    *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Labels         []string                      `json:"labels"`
 	Location       interface{}                   `json:"location"`
 	AutoEvents     []AutoEvent                   `json:"autoEvents" validate:"dive"`

--- a/v2/dtos/deviceprofile.go
+++ b/v2/dtos/deviceprofile.go
@@ -18,7 +18,7 @@ import (
 type DeviceProfile struct {
 	common.Versionable `json:",inline"`
 	Id                 string            `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name               string            `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string" `
+	Name               string            `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Manufacturer       string            `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
 	Description        string            `json:"description,omitempty" yaml:"description,omitempty"`
 	Model              string            `json:"model,omitempty" yaml:"model,omitempty"`

--- a/v2/dtos/deviceresource.go
+++ b/v2/dtos/deviceresource.go
@@ -11,7 +11,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceResource
 type DeviceResource struct {
 	Description string            `json:"description" yaml:"description,omitempty"`
-	Name        string            `json:"name" yaml:"name,omitempty" validate:"required,edgex-dto-none-empty-string"`
+	Name        string            `json:"name" yaml:"name,omitempty" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Tag         string            `json:"tag" yaml:"tag,omitempty"`
 	Properties  PropertyValue     `json:"properties" yaml:"properties"`
 	Attributes  map[string]string `json:"attributes" yaml:"attributes,omitempty"`

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -15,7 +15,7 @@ import (
 type DeviceService struct {
 	common.Versionable `json:",inline"`
 	Id                 string   `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name               string   `json:"name" validate:"required,edgex-dto-none-empty-string"`
+	Name               string   `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Created            int64    `json:"created,omitempty"`
 	Modified           int64    `json:"modified,omitempty"`
 	Description        string   `json:"description,omitempty"`
@@ -30,7 +30,7 @@ type DeviceService struct {
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/UpdateDeviceService
 type UpdateDeviceService struct {
 	Id          *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name        *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
+	Name        *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	BaseAddress *string  `json:"baseAddress" validate:"omitempty,uri"`
 	Labels      []string `json:"labels"`
 	AdminState  *string  `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`

--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -20,8 +20,8 @@ import (
 type Event struct {
 	common.Versionable `json:",inline"`
 	Id                 string            `json:"id" validate:"required,uuid"`
-	DeviceName         string            `json:"deviceName" validate:"required"`
-	ProfileName        string            `json:"profileName" validate:"required"`
+	DeviceName         string            `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName        string            `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
 	Created            int64             `json:"created"`
 	Origin             int64             `json:"origin" validate:"required"`
 	Readings           []BaseReading     `json:"readings" validate:"gt=0,dive,required"`

--- a/v2/dtos/profileresource.go
+++ b/v2/dtos/profileresource.go
@@ -10,7 +10,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 // ProfileResource and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/ProfileResource
 type ProfileResource struct {
-	Name string              `json:"name,omitempty" yaml:"name,omitempty" validate:"required,edgex-dto-none-empty-string"`
+	Name string              `json:"name,omitempty" yaml:"name,omitempty" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Get  []ResourceOperation `json:"get,omitempty" yaml:"get,omitempty" validate:"required_without=Set"`
 	Set  []ResourceOperation `json:"set,omitempty" yaml:"set,omitempty" validate:"required_without=Get"`
 }

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -18,9 +18,9 @@ type BaseReading struct {
 	Id                 string `json:"id"`
 	Created            int64  `json:"created"`
 	Origin             int64  `json:"origin" validate:"required"`
-	DeviceName         string `json:"deviceName" validate:"required"`
-	ResourceName       string `json:"resourceName" validate:"required"`
-	ProfileName        string `json:"profileName" validate:"required"`
+	DeviceName         string `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	ResourceName       string `json:"resourceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName        string `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
 	ValueType          string `json:"valueType" validate:"required,edgex-dto-value-type"`
 	BinaryReading      `json:",inline" validate:"-"`
 	SimpleReading      `json:",inline" validate:"-"`

--- a/v2/dtos/requests/const_test.go
+++ b/v2/dtos/requests/const_test.go
@@ -34,3 +34,28 @@ const (
 	testUser     = "edgexer"
 	testPassword = "password"
 )
+
+var namesWithReservedChar = []string{
+	"name!.~_001",
+	"name#.~_001",
+	"name$.~_001",
+	"name&.~_001",
+	"name`.~_001",
+	"name'.~_001",
+	"name(.~_001",
+	"name).~_001",
+	"name*.~_001",
+	"name,.~_001",
+	"name/.~_001",
+	"name:.~_001",
+	"name;.~_001",
+	"name=.~_001",
+	"name?.~_001",
+	"name@.~_001",
+	"name[.~_001",
+	"name].~_001",
+	"name%.~_001",
+	"name .~_001",
+}
+
+var nameWithUnreservedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"

--- a/v2/dtos/requests/device_test.go
+++ b/v2/dtos/requests/device_test.go
@@ -174,7 +174,7 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 			if tt.expectError {
 				assert.Error(t, err, fmt.Sprintf("expect error but not : %s", tt.name))
 			} else {
-				assert.Nil(t, err, fmt.Sprintf("unexpected error occurs : %s", tt.name))
+				assert.NoError(t, err, fmt.Sprintf("unexpected error occurs : %s", tt.name))
 			}
 		})
 	}

--- a/v2/dtos/requests/device_test.go
+++ b/v2/dtos/requests/device_test.go
@@ -131,6 +131,53 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 			assert.Equal(t, tt.expectError, err != nil, "Unexpected addDeviceRequest validation result.", err)
 		})
 	}
+
+	type testForNameField struct {
+		name        string
+		Device      AddDeviceRequest
+		expectError bool
+	}
+
+	deviceNameWithUnreservedChars := testAddDevice
+	deviceNameWithUnreservedChars.Device.Name = nameWithUnreservedChars
+	profileNameWithUnreservedChars := testAddDevice
+	profileNameWithUnreservedChars.Device.ProfileName = nameWithUnreservedChars
+	serviceNameWithUnreservedChars := testAddDevice
+	serviceNameWithUnreservedChars.Device.ServiceName = nameWithUnreservedChars
+
+	// Following tests verify if name fields containing unreserved characters should pass edgex-dto-rfc3986-unreserved-chars check
+	testsForNameFields := []testForNameField{
+		{"Valid AddDeviceRequest with device name containing unreserved chars", deviceNameWithUnreservedChars, false},
+		{"Valid AddDeviceRequest with profile name containing unreserved chars", profileNameWithUnreservedChars, false},
+		{"Valid AddDeviceRequest with service name containing unreserved chars", serviceNameWithUnreservedChars, false},
+	}
+
+	// Following tests verify if name fields containing reserved characters should be detected with an error
+	for _, n := range namesWithReservedChar {
+		deviceNameWithReservedChar := testAddDevice
+		deviceNameWithReservedChar.Device.Name = n
+		profileNameWithReservedChar := testAddDevice
+		profileNameWithReservedChar.Device.ProfileName = n
+		serviceNameWithReservedChar := testAddDevice
+		serviceNameWithReservedChar.Device.ServiceName = n
+
+		testsForNameFields = append(testsForNameFields,
+			testForNameField{"Invalid AddDeviceRequest with device name containing reserved char", deviceNameWithReservedChar, true},
+			testForNameField{"Invalid AddDeviceRequest with device name containing reserved char", profileNameWithReservedChar, true},
+			testForNameField{"Invalid AddDeviceRequest with device name containing reserved char", serviceNameWithReservedChar, true},
+		)
+	}
+
+	for _, tt := range testsForNameFields {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.Device.Validate()
+			if tt.expectError {
+				assert.Error(t, err, fmt.Sprintf("expect error but not : %s", tt.name))
+			} else {
+				assert.Nil(t, err, fmt.Sprintf("unexpected error occurs : %s", tt.name))
+			}
+		})
+	}
 }
 
 func TestAddDevice_UnmarshalJSON(t *testing.T) {
@@ -314,7 +361,7 @@ func TestUpdateDeviceRequest_Validate(t *testing.T) {
 func TestUpdateDeviceRequest_UnmarshalJSON_NilField(t *testing.T) {
 	reqJson := `{
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
-		"device":{"name":"test device"}
+		"device":{"name":"TestDevice"}
 	}`
 	var req UpdateDeviceRequest
 
@@ -340,7 +387,7 @@ func TestUpdateDeviceRequest_UnmarshalJSON_EmptySlice(t *testing.T) {
 	reqJson := `{
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
 		"device":{
-			"name":"test device",
+			"name":"TestDevice",
 			"labels":[],
 			"autoEvents":[]
 		}

--- a/v2/dtos/requests/deviceprofile_test.go
+++ b/v2/dtos/requests/deviceprofile_test.go
@@ -147,7 +147,7 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 	profileNameWithUnreservedChars.Profile.Name = nameWithUnreservedChars
 
 	err := profileNameWithUnreservedChars.Validate()
-	assert.Nil(t, err, fmt.Sprintf("DeviceProfileRequest with profile name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
+	assert.NoError(t, err, fmt.Sprintf("DeviceProfileRequest with profile name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
 
 	// Following tests verify if profile name containing reserved characters should be detected with an error
 	for _, n := range namesWithReservedChar {

--- a/v2/dtos/requests/deviceprofile_test.go
+++ b/v2/dtos/requests/deviceprofile_test.go
@@ -142,6 +142,21 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+
+	profileNameWithUnreservedChars := profileData()
+	profileNameWithUnreservedChars.Profile.Name = nameWithUnreservedChars
+
+	err := profileNameWithUnreservedChars.Validate()
+	assert.Nil(t, err, fmt.Sprintf("DeviceProfileRequest with profile name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
+
+	// Following tests verify if profile name containing reserved characters should be detected with an error
+	for _, n := range namesWithReservedChar {
+		profileNameWithReservedChar := profileData()
+		profileNameWithReservedChar.Profile.Name = n
+
+		err := profileNameWithReservedChar.Validate()
+		assert.Error(t, err, fmt.Sprintf("DeviceProfileRequest with profile name containing reserved char %s should return error during validation", n))
+	}
 }
 
 func TestAddDeviceProfile_UnmarshalJSON(t *testing.T) {

--- a/v2/dtos/requests/deviceservice_test.go
+++ b/v2/dtos/requests/deviceservice_test.go
@@ -89,13 +89,19 @@ func TestAddDeviceServiceRequest_Validate(t *testing.T) {
 		})
 	}
 
-	// Following tests varify if service name containing reserved characters should be detected with an error
+	serviceNameWithUnreservedChars := testAddDeviceService
+	serviceNameWithUnreservedChars.Service.Name = nameWithUnreservedChars
+
+	err := serviceNameWithUnreservedChars.Validate()
+	assert.NoError(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
+
+	// Following tests verify if service name containing reserved characters should be detected with an error
 	for _, n := range namesWithReservedChar {
 		serviceNameWithReservedChar := testAddDeviceService
 		serviceNameWithReservedChar.Service.Name = n
 
 		err := serviceNameWithReservedChar.Validate()
-		assert.NotNil(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
+		assert.Error(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
 	}
 }
 
@@ -239,7 +245,7 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 	serviceNameWithUnreservedChars.Service.Name = &nameWithUnreservedChars
 
 	err := serviceNameWithUnreservedChars.Validate()
-	assert.Nil(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
+	assert.NoError(t, err, fmt.Sprintf("UpdateDeviceServiceRequest with service name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
 
 	// Following tests verify if service name containing reserved characters should be detected with an error
 	for _, n := range namesWithReservedChar {
@@ -247,7 +253,7 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 		serviceNameWithReservedChar.Service.Name = &n
 
 		err := serviceNameWithReservedChar.Validate()
-		assert.Error(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
+		assert.Error(t, err, fmt.Sprintf("UpdateDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
 	}
 }
 

--- a/v2/dtos/requests/deviceservice_test.go
+++ b/v2/dtos/requests/deviceservice_test.go
@@ -88,6 +88,15 @@ func TestAddDeviceServiceRequest_Validate(t *testing.T) {
 			assert.Equal(t, tt.expectError, err != nil, "Unexpected addDeviceServiceRequest validation result.", err)
 		})
 	}
+
+	// Following tests varify if service name containing reserved characters should be detected with an error
+	for _, n := range namesWithReservedChar {
+		serviceNameWithReservedChar := testAddDeviceService
+		serviceNameWithReservedChar.Service.Name = n
+
+		err := serviceNameWithReservedChar.Validate()
+		assert.NotNil(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
+	}
 }
 
 func TestAddDeviceService_UnmarshalJSON(t *testing.T) {
@@ -225,6 +234,21 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 			assert.Equal(t, tt.expectError, err != nil, "Unexpected updateDeviceServiceRequest validation result.", err)
 		})
 	}
+
+	serviceNameWithUnreservedChars := testUpdateDeviceService
+	serviceNameWithUnreservedChars.Service.Name = &nameWithUnreservedChars
+
+	err := serviceNameWithUnreservedChars.Validate()
+	assert.Nil(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
+
+	// Following tests verify if service name containing reserved characters should be detected with an error
+	for _, n := range namesWithReservedChar {
+		serviceNameWithReservedChar := testUpdateDeviceService
+		serviceNameWithReservedChar.Service.Name = &n
+
+		err := serviceNameWithReservedChar.Validate()
+		assert.Error(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
+	}
 }
 
 func TestUpdateDeviceServiceRequest_UnmarshalJSON_NilField(t *testing.T) {
@@ -249,7 +273,7 @@ func TestUpdateDeviceServiceRequest_UnmarshalJSON_EmptySlice(t *testing.T) {
 	reqJson := `{
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
 		"service":{
-			"name":"test device",
+			"name":"TestDevice",
 			"labels":[]
 		}
 	}`

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -182,7 +182,7 @@ func TestAddEventRequest_Validate(t *testing.T) {
 			if tt.expectError {
 				assert.Error(t, err, fmt.Sprintf("expect error but not : %s", tt.name))
 			} else {
-				assert.Nil(t, err, fmt.Sprintf("unexpected error occurs : %s", tt.name))
+				assert.NoError(t, err, fmt.Sprintf("unexpected error occurs : %s", tt.name))
 			}
 		})
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #343 

## What is the new behavior?
Implement a new custom validation tag "edgex-dto-rfc3986-unreserved-chars" to ensure name fields only allows RFC3986 unreserved characters.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Other information
There is no suitable existing validation tag to satisfy our needs, so I have to implement a custom tag `edgex-dto-rfc3986-unreserved-chars` to verify that all V2 DTOs' name fields could only contain unreserved characters as defined in https://tools.ietf.org/html/rfc3986#section-2.3.  Please note that unreserved characters= ALPHA / DIGIT / "-" / "." / "_" / "~"