### PR TITLE
feat(meta): Add V2 DeviceClient

### DIFF
--- a/v2/clients/http/device.go
+++ b/v2/clients/http/device.go
@@ -1,0 +1,109 @@
+package http
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http/utils"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+)
+
+type DeviceClient struct {
+	baseUrl string
+}
+
+// NewDeviceClient creates an instance of DeviceClient
+func NewDeviceClient(baseUrl string) interfaces.DeviceClient {
+	return &DeviceClient{
+		baseUrl: baseUrl,
+	}
+}
+
+func (dc DeviceClient) Add(ctx context.Context, reqs []requests.AddDeviceRequest) (res []common.BaseWithIdResponse, err errors.EdgeX) {
+	err = utils.PostRequest(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, reqs)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (dc DeviceClient) Update(ctx context.Context, reqs []requests.UpdateDeviceRequest) (res []common.BaseResponse, err errors.EdgeX) {
+	err = utils.PatchRequest(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, reqs)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (dc DeviceClient) AllDevices(ctx context.Context, labels []string, offset int, limit int) (res responses.MultiDevicesResponse, err errors.EdgeX) {
+	requestParams := url.Values{}
+	if len(labels) > 0 {
+		requestParams.Set(v2.Labels, strings.Join(labels, v2.CommaSeparator))
+	}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err = utils.GetRequest(ctx, &res, dc.baseUrl, v2.ApiAllDeviceRoute, requestParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (dc DeviceClient) DeviceNameExists(ctx context.Context, name string) (res common.BaseResponse, err errors.EdgeX) {
+	path := path.Join(v2.ApiDeviceRoute, v2.Check, v2.Name, url.QueryEscape(name))
+	err = utils.GetRequest(ctx, &res, dc.baseUrl, path, nil)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (dc DeviceClient) DeviceByName(ctx context.Context, name string) (res responses.DeviceResponse, err errors.EdgeX) {
+	path := path.Join(v2.ApiDeviceRoute, v2.Name, url.QueryEscape(name))
+	err = utils.GetRequest(ctx, &res, dc.baseUrl, path, nil)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (dc DeviceClient) DeleteDeviceByName(ctx context.Context, name string) (res common.BaseResponse, err errors.EdgeX) {
+	path := path.Join(v2.ApiDeviceRoute, v2.Name, url.QueryEscape(name))
+	err = utils.DeleteRequest(ctx, &res, dc.baseUrl+path)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (dc DeviceClient) DevicesByProfileName(ctx context.Context, name string, offset int, limit int) (res responses.MultiDevicesResponse, err errors.EdgeX) {
+	requestPath := path.Join(v2.ApiDeviceRoute, v2.Profile, v2.Name, url.QueryEscape(name))
+	requestParams := url.Values{}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err = utils.GetRequest(ctx, &res, dc.baseUrl, requestPath, requestParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
+func (dc DeviceClient) DevicesByServiceName(ctx context.Context, name string, offset int, limit int) (res responses.MultiDevicesResponse, err errors.EdgeX) {
+	requestPath := path.Join(v2.ApiDeviceRoute, v2.Service, v2.Name, url.QueryEscape(name))
+	requestParams := url.Values{}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err = utils.GetRequest(ctx, &res, dc.baseUrl, requestPath, requestParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}

--- a/v2/clients/http/device_test.go
+++ b/v2/clients/http/device_test.go
@@ -1,0 +1,97 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddDevices(t *testing.T) {
+	ts := newTestServer(http.MethodPost, v2.ApiDeviceRoute, []common.BaseWithIdResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.Add(context.Background(), []requests.AddDeviceRequest{})
+	require.NoError(t, err)
+	require.IsType(t, []common.BaseWithIdResponse{}, res)
+}
+
+func TestPatchDevices(t *testing.T) {
+	ts := newTestServer(http.MethodPatch, v2.ApiDeviceRoute, []common.BaseResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.Update(context.Background(), []requests.UpdateDeviceRequest{})
+	require.NoError(t, err)
+	require.IsType(t, []common.BaseResponse{}, res)
+}
+
+func TestQueryAllDevices(t *testing.T) {
+	ts := newTestServer(http.MethodGet, v2.ApiAllDeviceRoute, responses.MultiDevicesResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.AllDevices(context.Background(), []string{"label1", "label2"}, 1, 10)
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiDevicesResponse{}, res)
+}
+
+func TestDeviceNameExists(t *testing.T) {
+	deviceName := "device"
+	path := path.Join(v2.ApiDeviceRoute, v2.Check, v2.Name, deviceName)
+	ts := newTestServer(http.MethodGet, path, common.BaseResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.DeviceNameExists(context.Background(), deviceName)
+	require.NoError(t, err)
+	require.IsType(t, common.BaseResponse{}, res)
+}
+
+func TestQueryDeviceByName(t *testing.T) {
+	deviceName := "device"
+	path := path.Join(v2.ApiDeviceRoute, v2.Name, deviceName)
+	ts := newTestServer(http.MethodGet, path, responses.DeviceResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.DeviceByName(context.Background(), deviceName)
+	require.NoError(t, err)
+	require.IsType(t, responses.DeviceResponse{}, res)
+}
+
+func TestDeleteDeviceByName(t *testing.T) {
+	deviceName := "device"
+	path := path.Join(v2.ApiDeviceRoute, v2.Name, deviceName)
+	ts := newTestServer(http.MethodDelete, path, common.BaseResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.DeleteDeviceByName(context.Background(), deviceName)
+	require.NoError(t, err)
+	require.IsType(t, common.BaseResponse{}, res)
+}
+
+func TestQueryDevicesByProfileName(t *testing.T) {
+	profileName := "profile"
+	urlPath := path.Join(v2.ApiDeviceRoute, v2.Profile, v2.Name, profileName)
+	ts := newTestServer(http.MethodGet, urlPath, responses.MultiDevicesResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.DevicesByProfileName(context.Background(), profileName, 1, 10)
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiDevicesResponse{}, res)
+}
+
+func TestQueryDevicesByServiceName(t *testing.T) {
+	serviceName := "service"
+	urlPath := path.Join(v2.ApiDeviceRoute, v2.Service, v2.Name, serviceName)
+	ts := newTestServer(http.MethodGet, urlPath, responses.MultiDevicesResponse{})
+	defer ts.Close()
+	client := NewDeviceClient(ts.URL)
+	res, err := client.DevicesByServiceName(context.Background(), serviceName, 1, 10)
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiDevicesResponse{}, res)
+}

--- a/v2/clients/http/utils/request.go
+++ b/v2/clients/http/utils/request.go
@@ -82,6 +82,28 @@ func PutRequest(
 	return nil
 }
 
+// PatchRequest makes a PATCH request and unmarshals the response to the returnValuePointer
+func PatchRequest(
+	ctx context.Context,
+	returnValuePointer interface{},
+	url string,
+	data interface{}) errors.EdgeX {
+
+	req, err := createRequestWithRawData(ctx, http.MethodPatch, url, data)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	res, err := sendRequest(ctx, req)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if err := json.Unmarshal(res, returnValuePointer); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
+	}
+	return nil
+}
+
 // Helper method to make the post file request and return the body
 func PostByFileRequest(
 	ctx context.Context,

--- a/v2/clients/interfaces/device.go
+++ b/v2/clients/interfaces/device.go
@@ -1,0 +1,44 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+)
+
+// DeviceClient defines the interface for interactions with the Device endpoint on the EdgeX Foundry core-metadata service.
+type DeviceClient interface {
+	// Add adds new devices.
+	Add(ctx context.Context, reqs []requests.AddDeviceRequest) ([]common.BaseWithIdResponse, errors.EdgeX)
+	// Update updates devices.
+	Update(ctx context.Context, reqs []requests.UpdateDeviceRequest) ([]common.BaseResponse, errors.EdgeX)
+	// AllDevices returns all devices. Devices can also be filtered by labels.
+	// The result can be limited in a certain range by specifying the offset and limit parameters.
+	// offset: The number of items to skip before starting to collect the result set. Default is 0.
+	// limit: The number of items to return. Specify -1 will return all remaining items after offset. The maximum will be the MaxResultCount as defined in the configuration of service. Default is 20.
+	AllDevices(ctx context.Context, labels []string, offset int, limit int) (responses.MultiDevicesResponse, errors.EdgeX)
+	// DeviceNameExists checks whether the device exists.
+	DeviceNameExists(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX)
+	// DeviceByName returns a device by device name.
+	DeviceByName(ctx context.Context, name string) (responses.DeviceResponse, errors.EdgeX)
+	// DeleteByName deletes a device by device name.
+	DeleteDeviceByName(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX)
+	// DevicesByProfileName returns devices associated with the specified device profile.
+	// The result can be limited in a certain range by specifying the offset and limit parameters.
+	// offset: The number of items to skip before starting to collect the result set. Default is 0.
+	// limit: The number of items to return. Specify -1 will return all remaining items after offset. The maximum will be the MaxResultCount as defined in the configuration of service. Default is 20.
+	DevicesByProfileName(ctx context.Context, name string, offset int, limit int) (responses.MultiDevicesResponse, errors.EdgeX)
+	// DevicesByServiceName returns devices associated with the specified device service.
+	// The result can be limited in a certain range by specifying the offset and limit parameters.
+	// offset: The number of items to skip before starting to collect the result set. Default is 0.
+	// limit: The number of items to return. Specify -1 will return all remaining items after offset. The maximum will be the MaxResultCount as defined in the configuration of service. Default is 20.
+	DevicesByServiceName(ctx context.Context, name string, offset int, limit int) (responses.MultiDevicesResponse, errors.EdgeX)
+}


### PR DESCRIPTION
fix #403 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.

## Issue Number: #403

## What is the new behavior?
Add V2 DeviceClient for interactions with V2 Device endpoint on the core-metadata service.
- (POST) /device
- (PATCH) /device
- (GET) /device/all
- (GET) /device/check/name/{name}
- (GET) /device/name/{name}
- (DELETE) /device/name/{name}
- (GET) /device/profile/name/{name}
- (GET) /device/service/name/{name}

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information