### PR TITLE
feat(data): Update AddEvent to use single AddEventRequest DTO

### DIFF
--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -68,27 +68,24 @@ func (a *AddEventRequest) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// AddEventReqToEventModels transforms the AddEventRequest DTO array to the Event model array
-func AddEventReqToEventModels(addRequests []AddEventRequest) (events []models.Event) {
-	for _, a := range addRequests {
-		var e models.Event
-		readings := make([]models.Reading, len(a.Event.Readings))
-		for i, r := range a.Event.Readings {
-			readings[i] = dtos.ToReadingModel(r)
-		}
-
-		tags := make(map[string]string)
-		for tag, value := range a.Event.Tags {
-			tags[tag] = value
-		}
-
-		e.Id = a.Event.Id
-		e.DeviceName = a.Event.DeviceName
-		e.ProfileName = a.Event.ProfileName
-		e.Origin = a.Event.Origin
-		e.Readings = readings
-		e.Tags = tags
-		events = append(events, e)
+// AddEventReqToEventModel transforms the AddEventRequest DTO to the Event model
+func AddEventReqToEventModel(addEventReq AddEventRequest) (event models.Event) {
+	readings := make([]models.Reading, len(addEventReq.Event.Readings))
+	for i, r := range addEventReq.Event.Readings {
+		readings[i] = dtos.ToReadingModel(r)
 	}
-	return events
+
+	tags := make(map[string]string)
+	for tag, value := range addEventReq.Event.Tags {
+		tags[tag] = value
+	}
+
+	return models.Event{
+		Id:          addEventReq.Event.Id,
+		DeviceName:  addEventReq.Event.DeviceName,
+		ProfileName: addEventReq.Event.ProfileName,
+		Origin:      addEventReq.Event.Origin,
+		Readings:    readings,
+		Tags:        tags,
+	}
 }

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -228,7 +228,7 @@ func TestAddEvent_UnmarshalJSON(t *testing.T) {
 }
 
 func Test_AddEventReqToEventModels(t *testing.T) {
-	valid := []AddEventRequest{eventRequestData()}
+	valid := eventRequestData()
 	s := models.SimpleReading{
 		BaseReading: models.BaseReading{
 			DeviceName:   TestDeviceName,
@@ -239,7 +239,7 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 		},
 		Value: TestReadingValue,
 	}
-	expectedEventModel := []models.Event{{
+	expectedEventModel := models.Event{
 		Id:          ExampleUUID,
 		DeviceName:  TestDeviceName,
 		ProfileName: TestDeviceProfileName,
@@ -248,18 +248,18 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 		Tags: map[string]string{
 			"GatewayId": "Houston-0001",
 		},
-	}}
+	}
 
 	tests := []struct {
-		name      string
-		addEvents []AddEventRequest
+		name        string
+		addEventReq AddEventRequest
 	}{
 		{"valid AddEventRequest", valid},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eventModel := AddEventReqToEventModels(tt.addEvents)
-			assert.Equal(t, expectedEventModel, eventModel, "AddEventReqToEventModels did not result in expected Event model.")
+			eventModel := AddEventReqToEventModel(tt.addEventReq)
+			assert.Equal(t, expectedEventModel, eventModel, "AddEventReqToEventModel did not result in expected Event model.")
 		})
 	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #429

## What is the new behavior?
Per discussion over edgexfoundry/edgex-go#3002 (comment), AddEvent V2 API shall be updated to deal with single AddEventRequest DTO instead of AddEventRequest DTO array. As a result, func `AddEventReqToEventModels` shall be updated accordingly.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No