### PR TITLE
feat(meta): implement ProvisionWatcherClient

### DIFF
--- a/v2/clients/http/provisionwatcher.go
+++ b/v2/clients/http/provisionwatcher.go
@@ -1,0 +1,112 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+)
+
+type ProvisionWatcherClient struct {
+	baseUrl string
+}
+
+// NewProvisionWatcherClient creates an instance of ProvisionWatcherClient
+func NewProvisionWatcherClient(baseUrl string) interfaces.ProvisionWatcherClient {
+	return &ProvisionWatcherClient{
+		baseUrl: baseUrl,
+	}
+}
+
+func (pwc ProvisionWatcherClient) Add(ctx context.Context, reqs []requests.AddProvisionWatcherRequest) (res []common.BaseWithIdResponse, err errors.EdgeX) {
+	err = utils.PostRequest(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, reqs)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return
+}
+
+func (pwc ProvisionWatcherClient) Update(ctx context.Context, reqs []requests.UpdateProvisionWatcherRequest) (res []common.BaseResponse, err errors.EdgeX) {
+	err = utils.PatchRequest(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, reqs)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return
+}
+
+func (pwc ProvisionWatcherClient) AllProvisionWatchers(ctx context.Context, labels []string, offset int, limit int) (res responses.MultiProvisionWatchersResponse, err errors.EdgeX) {
+	requestParams := url.Values{}
+	if len(labels) > 0 {
+		requestParams.Set(v2.Labels, strings.Join(labels, v2.CommaSeparator))
+	}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err = utils.GetRequest(ctx, &res, pwc.baseUrl, v2.ApiAllProvisionWatcherRoute, requestParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return
+}
+
+func (pwc ProvisionWatcherClient) ProvisionWatcherByName(ctx context.Context, name string) (res responses.ProvisionWatcherResponse, err errors.EdgeX) {
+	path := path.Join(v2.ApiProvisionWatcherRoute, v2.Name, url.QueryEscape(name))
+	err = utils.GetRequest(ctx, &res, pwc.baseUrl, path, nil)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return
+}
+
+func (pwc ProvisionWatcherClient) DeleteProvisionWatcherByName(ctx context.Context, name string) (res common.BaseResponse, err errors.EdgeX) {
+	path := path.Join(v2.ApiProvisionWatcherRoute, v2.Name, url.QueryEscape(name))
+	err = utils.DeleteRequest(ctx, &res, pwc.baseUrl, path)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return
+}
+
+func (pwc ProvisionWatcherClient) ProvisionWatchersByProfileName(ctx context.Context, name string, offset int, limit int) (res responses.MultiProvisionWatchersResponse, err errors.EdgeX) {
+	requestPath := path.Join(v2.ApiProvisionWatcherRoute, v2.Profile, v2.Name, url.QueryEscape(name))
+	requestParams := url.Values{}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err = utils.GetRequest(ctx, &res, pwc.baseUrl, requestPath, requestParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return
+}
+
+func (pwc ProvisionWatcherClient) ProvisionWatchersByServiceName(ctx context.Context, name string, offset int, limit int) (res responses.MultiProvisionWatchersResponse, err errors.EdgeX) {
+	requestPath := path.Join(v2.ApiProvisionWatcherRoute, v2.Service, v2.Name, url.QueryEscape(name))
+	requestParams := url.Values{}
+	requestParams.Set(v2.Offset, strconv.Itoa(offset))
+	requestParams.Set(v2.Limit, strconv.Itoa(limit))
+	err = utils.GetRequest(ctx, &res, pwc.baseUrl, requestPath, requestParams)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return
+}

--- a/v2/clients/http/provisionwatcher_test.go
+++ b/v2/clients/http/provisionwatcher_test.go
@@ -1,0 +1,97 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvisionWatcherClient_Add(t *testing.T) {
+	ts := newTestServer(http.MethodPost, v2.ApiProvisionWatcherRoute, []common.BaseWithIdResponse{})
+	defer ts.Close()
+
+	client := NewProvisionWatcherClient(ts.URL)
+	res, err := client.Add(context.Background(), []requests.AddProvisionWatcherRequest{})
+	require.NoError(t, err)
+	require.IsType(t, []common.BaseWithIdResponse{}, res)
+}
+
+func TestProvisionWatcherClient_Update(t *testing.T) {
+	ts := newTestServer(http.MethodPatch, v2.ApiProvisionWatcherRoute, []common.BaseResponse{})
+	defer ts.Close()
+
+	client := NewProvisionWatcherClient(ts.URL)
+	res, err := client.Update(context.Background(), []requests.UpdateProvisionWatcherRequest{})
+	require.NoError(t, err)
+	require.IsType(t, []common.BaseResponse{}, res)
+}
+
+func TestProvisionWatcherClient_AllProvisionWatchers(t *testing.T) {
+	ts := newTestServer(http.MethodGet, v2.ApiAllProvisionWatcherRoute, responses.MultiProvisionWatchersResponse{})
+	defer ts.Close()
+
+	client := NewProvisionWatcherClient(ts.URL)
+	res, err := client.AllProvisionWatchers(context.Background(), []string{"label1", "label2"}, 1, 10)
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiProvisionWatchersResponse{}, res)
+}
+
+func TestProvisionWatcherClient_ProvisionWatcherByName(t *testing.T) {
+	pwName := "watcher"
+	urlPath := path.Join(v2.ApiProvisionWatcherRoute, v2.Name, pwName)
+	ts := newTestServer(http.MethodGet, urlPath, responses.ProvisionWatcherResponse{})
+	defer ts.Close()
+
+	client := NewProvisionWatcherClient(ts.URL)
+	res, err := client.ProvisionWatcherByName(context.Background(), pwName)
+	require.NoError(t, err)
+	require.IsType(t, responses.ProvisionWatcherResponse{}, res)
+}
+
+func TestProvisionWatcherClient_DeleteProvisionWatcherByName(t *testing.T) {
+	pwName := "watcher"
+	urlPath := path.Join(v2.ApiProvisionWatcherRoute, v2.Name, pwName)
+	ts := newTestServer(http.MethodDelete, urlPath, common.BaseResponse{})
+	defer ts.Close()
+
+	client := NewProvisionWatcherClient(ts.URL)
+	res, err := client.DeleteProvisionWatcherByName(context.Background(), pwName)
+	require.NoError(t, err)
+	require.IsType(t, common.BaseResponse{}, res)
+}
+
+func TestProvisionWatcherClient_ProvisionWatchersByProfileName(t *testing.T) {
+	profileName := "profile"
+	urlPath := path.Join(v2.ApiProvisionWatcherRoute, v2.Profile, v2.Name, profileName)
+	ts := newTestServer(http.MethodGet, urlPath, responses.MultiProvisionWatchersResponse{})
+	defer ts.Close()
+
+	client := NewProvisionWatcherClient(ts.URL)
+	res, err := client.ProvisionWatchersByProfileName(context.Background(), profileName, 1, 10)
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiProvisionWatchersResponse{}, res)
+}
+
+func TestProvisionWatcherClient_ProvisionWatchersByServiceName(t *testing.T) {
+	serviceName := "service"
+	urlPath := path.Join(v2.ApiProvisionWatcherRoute, v2.Service, v2.Name, serviceName)
+	ts := newTestServer(http.MethodGet, urlPath, responses.MultiProvisionWatchersResponse{})
+	defer ts.Close()
+
+	client := NewProvisionWatcherClient(ts.URL)
+	res, err := client.ProvisionWatchersByServiceName(context.Background(), serviceName, 1, 10)
+	require.NoError(t, err)
+	require.IsType(t, responses.MultiProvisionWatchersResponse{}, res)
+}

--- a/v2/clients/interfaces/provisionwatcher.go
+++ b/v2/clients/interfaces/provisionwatcher.go
@@ -1,0 +1,42 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+)
+
+// ProvisionWatcherClient defines the interface for interactions with the ProvisionWatcher endpoint on the EdgeX Foundry core-metadata service.
+type ProvisionWatcherClient interface {
+	// Add adds a new provision watcher.
+	Add(ctx context.Context, reqs []requests.AddProvisionWatcherRequest) ([]common.BaseWithIdResponse, errors.EdgeX)
+	// Update updates provision watchers.
+	Update(ctx context.Context, reqs []requests.UpdateProvisionWatcherRequest) ([]common.BaseResponse, errors.EdgeX)
+	// AllProvisionWatchers returns all provision watchers. ProvisionWatchers can also be filtered by labels.
+	// The result can be limited in a certain range by specifying the offset and limit parameters.
+	// offset: The number of items to skip before starting to collect the result set. Default is 0.
+	// limit: The number of items to return. Specify -1 will return all remaining items after offset. The maximum will be the MaxResultCount as defined in the configuration of service. Default is 20.
+	AllProvisionWatchers(ctx context.Context, labels []string, offset int, limit int) (responses.MultiProvisionWatchersResponse, errors.EdgeX)
+	// ProvisionWatcherByName returns a provision watcher by name.
+	ProvisionWatcherByName(ctx context.Context, name string) (responses.ProvisionWatcherResponse, errors.EdgeX)
+	// DeleteProvisionWatcherByName deletes a provision watcher by name.
+	DeleteProvisionWatcherByName(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX)
+	// ProvisionWatchersByProfileName returns provision watchers associated with the specified device profile name.
+	// The result can be limited in a certain range by specifying the offset and limit parameters.
+	// offset: The number of items to skip before starting to collect the result set. Default is 0.
+	// limit: The number of items to return. Specify -1 will return all remaining items after offset. The maximum will be the MaxResultCount as defined in the configuration of service. Default is 20.
+	ProvisionWatchersByProfileName(ctx context.Context, name string, offset int, limit int) (responses.MultiProvisionWatchersResponse, errors.EdgeX)
+	// ProvisionWatchersByServiceName returns provision watchers associated with the specified device service name.
+	// The result can be limited in a certain range by specifying the offset and limit parameters.
+	// offset: The number of items to skip before starting to collect the result set. Default is 0.
+	// limit: The number of items to return. Specify -1 will return all remaining items after offset. The maximum will be the MaxResultCount as defined in the configuration of service. Default is 20.
+	ProvisionWatchersByServiceName(ctx context.Context, name string, offset int, limit int) (responses.MultiProvisionWatchersResponse, errors.EdgeX)
+}


### PR DESCRIPTION
add v2 ProvisionWatcherClient to interact with v2 ProvisionWatcher
endpoint on the core-metadata service.

- (POST)   /provisionwatcher
- (PATCH)  /provisionwatcher
- (GET)    /provisionwatcher/all
- (GET)    /provisionwatcher/name/{name}
- (GET)    /provisionwatcher/service/name/{name}
- (GET)    /provisionwatcher/profile/name/{name}
- (DELETE) /provisionwatcher/name/{name}

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #428 


## What is the new behavior?
add v2 ProvisionWatcherClient

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information