### PR TITLE
feat: Enhance V2 validation error message

### DIFF
--- a/v2/validator.go
+++ b/v2/validator.go
@@ -64,7 +64,8 @@ func Validate(a interface{}) error {
 // Internal: generate representative validation error messages
 func getErrorMessage(e validator.FieldError) string {
 	tag := e.Tag()
-	fieldName := e.Field()
+	// StructNamespace returns the namespace for the field error, with the field's actual name.
+	fieldName := e.StructNamespace()
 	fieldValue := e.Param()
 	var msg string
 	switch tag {


### PR DESCRIPTION
Enhance V2 validation error message to contain the parent struct name.
Fix #437

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior? #437
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently the error message defined for V2 DTO validation only contains the struct field name and field value, so it would be out of track in which struct name the field failed the validation, Ex. The error message `Type field is required` does not indicate in which struct has the field `Type`.

## Issue Number:
#437


## What is the new behavior?
The error message contains the (parent) struct name as well as the field name, ex. `DeviceProfile.DeviceResources[0].Properties.Type field is required` after applying the change.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information