### PR TITLE
feat: update device service v2 api route

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -65,15 +65,14 @@ const (
 	ApiPingRoute    = ApiBase + "/ping"
 	ApiVersionRoute = ApiBase + "/version"
 
-	ApiDeviceCallbackRoute    = ApiBase + "/callback/device"
-	ApiDeviceCallbackIdRoute  = ApiBase + "/callback/device/id/{id}"
-	ApiProfileCallbackRoute   = ApiBase + "/callback/profile"
-	ApiProfileCallbackIdRoute = ApiBase + "/callback/profile/id/{id}"
-	ApiWatcherCallbackRoute   = ApiBase + "/callback/watcher"
-	ApiWatcherCallbackIdRoute = ApiBase + "/callback/watcher/id/{id}"
-	ApiDiscoveryRoute         = ApiBase + "/discovery"
-	ApiIdCommandRoute         = ApiBase + "/device/{id}/{command}"
-	ApiNameCommandRoute       = ApiBase + "/device/name/{name}/{command}"
+	ApiDeviceCallbackRoute      = ApiBase + "/callback/device"
+	ApiDeviceCallbackNameRoute  = ApiBase + "/callback/device/name/{name}"
+	ApiProfileCallbackRoute     = ApiBase + "/callback/profile"
+	ApiProfileCallbackNameRoute = ApiBase + "/callback/profile/name/{name}"
+	ApiWatcherCallbackRoute     = ApiBase + "/callback/watcher"
+	ApiWatcherCallbackNameRoute = ApiBase + "/callback/watcher/name/{name}"
+	ApiDiscoveryRoute           = ApiBase + "/discovery"
+	ApiNameCommandRoute         = ApiBase + "/device/name/{name}/{command}"
 )
 
 // Constants related to defined url path names and parameters in the v2 service APIs


### PR DESCRIPTION
- remove command by id route
- update callback by id route to callback by name

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The device service v2 api route are outdated.

## Issue Number: fix #440 


## What is the new behavior?
update the device service v2 api route per latest device WG's discussion

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information