### PR TITLE
feat(command): Revise CommandResponse DTO to MultiCoreCommandsResponse

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -42,16 +42,17 @@ const (
 	ApiDeviceServiceByNameRoute = ApiDeviceServiceRoute + "/" + Name + "/{" + Name + "}"
 	ApiDeviceServiceByIdRoute   = ApiDeviceServiceRoute + "/" + Id + "/{" + Id + "}"
 
-	ApiDeviceRoute              = ApiBase + "/device"
-	ApiAllDeviceRoute           = ApiDeviceRoute + "/" + All
-	ApiDeviceIdExistsRoute      = ApiDeviceRoute + "/" + Check + "/" + Id + "/{" + Id + "}"
-	ApiDeviceNameExistsRoute    = ApiDeviceRoute + "/" + Check + "/" + Name + "/{" + Name + "}"
-	ApiDeviceByIdRoute          = ApiDeviceRoute + "/" + Id + "/{" + Id + "}"
-	ApiDeviceByNameRoute        = ApiDeviceRoute + "/" + Name + "/{" + Name + "}"
-	ApiDeviceByProfileIdRoute   = ApiDeviceRoute + "/" + Profile + "/" + Id + "/{" + Id + "}"
-	ApiDeviceByProfileNameRoute = ApiDeviceRoute + "/" + Profile + "/" + Name + "/{" + Name + "}"
-	ApiDeviceByServiceIdRoute   = ApiDeviceRoute + "/" + Service + "/" + Id + "/{" + Id + "}"
-	ApiDeviceByServiceNameRoute = ApiDeviceRoute + "/" + Service + "/" + Name + "/{" + Name + "}"
+	ApiDeviceRoute                = ApiBase + "/device"
+	ApiAllDeviceRoute             = ApiDeviceRoute + "/" + All
+	ApiDeviceIdExistsRoute        = ApiDeviceRoute + "/" + Check + "/" + Id + "/{" + Id + "}"
+	ApiDeviceNameExistsRoute      = ApiDeviceRoute + "/" + Check + "/" + Name + "/{" + Name + "}"
+	ApiDeviceByIdRoute            = ApiDeviceRoute + "/" + Id + "/{" + Id + "}"
+	ApiDeviceByNameRoute          = ApiDeviceRoute + "/" + Name + "/{" + Name + "}"
+	ApiDeviceByProfileIdRoute     = ApiDeviceRoute + "/" + Profile + "/" + Id + "/{" + Id + "}"
+	ApiDeviceByProfileNameRoute   = ApiDeviceRoute + "/" + Profile + "/" + Name + "/{" + Name + "}"
+	ApiDeviceByServiceIdRoute     = ApiDeviceRoute + "/" + Service + "/" + Id + "/{" + Id + "}"
+	ApiDeviceByServiceNameRoute   = ApiDeviceRoute + "/" + Service + "/" + Name + "/{" + Name + "}"
+	ApiDeviceNameCommandNameRoute = ApiDeviceRoute + "/" + Name + "/{" + DeviceName + "}" + "/" + Command + "/{" + CommandName + "}"
 
 	ApiProvisionWatcherRoute              = ApiBase + "/provisionwatcher"
 	ApiAllProvisionWatcherRoute           = ApiProvisionWatcherRoute + "/" + All
@@ -72,7 +73,6 @@ const (
 	ApiWatcherCallbackRoute     = ApiBase + "/callback/watcher"
 	ApiWatcherCallbackNameRoute = ApiBase + "/callback/watcher/name/{name}"
 	ApiDiscoveryRoute           = ApiBase + "/discovery"
-	ApiNameCommandRoute         = ApiBase + "/device/name/{name}/{command}"
 )
 
 // Constants related to defined url path names and parameters in the v2 service APIs
@@ -89,9 +89,11 @@ const (
 	Check        = "check"
 	Profile      = "profile"
 	Service      = "service"
+	Command      = "command"
 	ProfileName  = "profileName"
 	ServiceName  = "serviceName"
 	ResourceName = "resourceName"
+	CommandName  = "commandName"
 	Start        = "start"
 	End          = "end"
 	Age          = "age"

--- a/v2/dtos/command.go
+++ b/v2/dtos/command.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/v2/dtos/corecommand.go
+++ b/v2/dtos/corecommand.go
@@ -10,8 +10,8 @@ package dtos
 type CoreCommand struct {
 	Name       string `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	DeviceName string `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	Get        bool   `json:"get,omitempty" validate:"required_without=Put"`
-	Put        bool   `json:"put,omitempty" validate:"required_without=Get"`
+	Get        bool   `json:"get" validate:"required_without=Put"`
+	Put        bool   `json:"put" validate:"required_without=Get"`
 	Path       string `json:"path,omitempty"`
 	Url        string `json:"url,omitempty"`
 }

--- a/v2/dtos/corecommand.go
+++ b/v2/dtos/corecommand.go
@@ -1,0 +1,17 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dtos
+
+// CoreCommand and its properties are defined in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/CoreCommand
+type CoreCommand struct {
+	Name       string `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	DeviceName string `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	Get        bool   `json:"get,omitempty" validate:"required_without=Put"`
+	Put        bool   `json:"put,omitempty" validate:"required_without=Get"`
+	Path       string `json:"path,omitempty"`
+	Url        string `json:"url,omitempty"`
+}

--- a/v2/dtos/responses/corecommand.go
+++ b/v2/dtos/responses/corecommand.go
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package responses
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+)
+
+// MultiCoreCommandsResponse defines the Response Content for GET multiple CoreCommand DTOs.
+// This object and its properties correspond to the MultiCoreCommandsResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/MultiCoreCommandsResponse
+type MultiCoreCommandsResponse struct {
+	common.BaseResponse `json:",inline"`
+	CoreCommands        []dtos.CoreCommand `json:"coreCommands"`
+}
+
+func NewMultiCoreCommandsResponse(requestId string, message string, statusCode int, commands []dtos.CoreCommand) MultiCoreCommandsResponse {
+	return MultiCoreCommandsResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		CoreCommands: commands,
+	}
+}

--- a/v2/dtos/responses/corecommand.go
+++ b/v2/dtos/responses/corecommand.go
@@ -6,8 +6,8 @@
 package responses
 
 import (
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 )
 
 // MultiCoreCommandsResponse defines the Response Content for GET multiple CoreCommand DTOs.

--- a/v2/dtos/responses/corecommand_test.go
+++ b/v2/dtos/responses/corecommand_test.go
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package responses
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMultiCoreCommandsResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := http.StatusOK
+	expectedMessage := "unit test message"
+	expectedCommands := []dtos.CoreCommand{
+		{Name: "testCommand1", DeviceName: "testDevice1", Get: true, Put: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
+		{Name: "testCommand2", DeviceName: "testDevice1", Get: false, Put: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+	}
+	actual := NewMultiCoreCommandsResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedCommands)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedCommands, actual.CoreCommands)
+}

--- a/v2/dtos/responses/corecommand_test.go
+++ b/v2/dtos/responses/corecommand_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION


Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/CommandResponse defines array of CommandResponse DTO as the response for GET /device/all and single CommnadResponse DTO as response for GET /device/name/{name}. After discussion with Cloud, this structure could be simplified by moving device field into CoreCommand DTO, and then both GET /device/all and GET /device/name/{name} could have single CommandResponse with multiple CoreCommand DTOs. Moreover, with such change, the CommandResponse DTO is suggested to renamed to MultiCoreCommandsResponse.

## Issue Number:
fix #441 

## What is the new behavior?
1. Create and rename CommandResposne DTO to MultiCoreCommandsResponse
2. Create CoreCommand DTO

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No