### PR TITLE
feat: Refactor HTTP sendRequest function

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -213,3 +213,35 @@ func codeMapping(kind ErrKind) int {
 		return http.StatusInternalServerError
 	}
 }
+
+// KindMapping determines the correct EdgeX error kind for the given HTTP response code.
+func KindMapping(code int) ErrKind {
+	switch code {
+	case http.StatusInternalServerError:
+		return KindServerError
+	case http.StatusBadGateway:
+		return KindCommunicationError
+	case http.StatusNotFound:
+		return KindEntityDoesNotExist
+	case http.StatusBadRequest:
+		return KindContractInvalid
+	case http.StatusConflict:
+		return KindDuplicateName
+	case http.StatusRequestEntityTooLarge:
+		return KindLimitExceeded
+	case http.StatusServiceUnavailable:
+		return KindServiceUnavailable
+	case http.StatusLocked:
+		return KindServiceLocked
+	case http.StatusNotImplemented:
+		return KindNotImplemented
+	case http.StatusMethodNotAllowed:
+		return KindNotAllowed
+	case http.StatusRequestedRangeNotSatisfiable:
+		return KindRangeNotSatisfiable
+	case ClientErrorCode:
+		return KindClientError
+	default:
+		return KindUnknown
+	}
+}

--- a/v2/clients/http/utils/common.go
+++ b/v2/clients/http/utils/common.go
@@ -155,9 +155,6 @@ func sendRequest(ctx context.Context, req *http.Request) ([]byte, errors.EdgeX) 
 		return nil, errors.NewCommonEdgeXWrapper(err)
 	}
 	msg := fmt.Sprintf("request failed, status code: %d, err: %s", res.StatusCode, res.Message)
-	if resp.StatusCode == http.StatusBadRequest {
-		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, msg, nil)
-	} else {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, msg, nil)
-	}
+	errKind := errors.KindMapping(res.StatusCode)
+	return nil, errors.NewCommonEdgeX(errKind, msg, nil)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The sendRequest function doesn't return a proper EdgeX ErrKind when request fails.

## Issue Number: #444 


## What is the new behavior?
Added a `KindMapping` function for determining the correct EdgeX ErrKind for the given HTTP status code.
Updated V2 HTTP sendRequest function to return the correct EdgeX ErrKind when request fails.

Close #444

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Other information
Refer to [codeMapping](https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/errors/types.go#L187-L214) function, there is a many-to-one relationship between some EdgeX ErrKinds and HTTP status codes. Reverse mapping seems impossible, hence the `KindMapping` function only performs one-to-one mapping.