### PR TITLE
feat: enhance v2 DeviceServiceCallbackClient

### DIFF
--- a/v2/clients/http/deviceservicecallback.go
+++ b/v2/clients/http/deviceservicecallback.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@ import (
 	"path"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
-	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
@@ -46,10 +46,56 @@ func (client *deviceServiceCallbackClient) UpdateDeviceCallback(ctx context.Cont
 	return response, nil
 }
 
-func (client *deviceServiceCallbackClient) DeleteDeviceCallback(ctx context.Context, id string) (common.BaseResponse, errors.EdgeX) {
+func (client *deviceServiceCallbackClient) DeleteDeviceCallback(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	requestPath := path.Join(v2.ApiDeviceCallbackRoute, v2.Id, id)
+	requestPath := path.Join(v2.ApiDeviceCallbackRoute, v2.Name, name)
 	err := utils.DeleteRequest(ctx, &response, client.baseUrl, requestPath)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	return response, nil
+}
+
+func (client *deviceServiceCallbackClient) UpdateDeviceProfileCallback(ctx context.Context, request requests.DeviceProfileRequest) (common.BaseResponse, errors.EdgeX) {
+	var response common.BaseResponse
+	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiProfileCallbackRoute, request)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	return response, nil
+}
+
+func (client *deviceServiceCallbackClient) AddProvisionWatcherCallback(ctx context.Context, request requests.AddProvisionWatcherRequest) (common.BaseResponse, errors.EdgeX) {
+	var response common.BaseResponse
+	err := utils.PostRequest(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, request)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	return response, nil
+}
+
+func (client *deviceServiceCallbackClient) UpdateProvisionWatcherCallback(ctx context.Context, request requests.UpdateProvisionWatcherRequest) (common.BaseResponse, errors.EdgeX) {
+	var response common.BaseResponse
+	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, request)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	return response, nil
+}
+
+func (client *deviceServiceCallbackClient) DeleteProvisionWatcherCallback(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX) {
+	var response common.BaseResponse
+	requestPath := path.Join(v2.ApiWatcherCallbackRoute, v2.Name, name)
+	err := utils.DeleteRequest(ctx, &response, client.baseUrl, requestPath)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	return response, nil
+}
+
+func (client *deviceServiceCallbackClient) UpdateDeviceServiceCallback(ctx context.Context, request requests.UpdateDeviceServiceRequest) (common.BaseResponse, errors.EdgeX) {
+	var response common.BaseResponse
+	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiServiceCallbackRoute, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservicecallback_test.go
+++ b/v2/clients/http/deviceservicecallback_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -47,15 +47,82 @@ func TestUpdateDeviceCallback(t *testing.T) {
 }
 
 func TestDeleteDeviceCallback(t *testing.T) {
-	testDeviceId := "testId"
+	testDeviceName := "testName"
 	requestId := uuid.New().String()
-	urlPath := path.Join(v2.ApiDeviceCallbackRoute, v2.Id, "testId")
+	urlPath := path.Join(v2.ApiDeviceCallbackRoute, v2.Name, testDeviceName)
 	expectedResponse := common.NewBaseResponse(requestId, "", http.StatusOK)
 	ts := newTestServer(http.MethodDelete, urlPath, expectedResponse)
 	defer ts.Close()
 
 	client := NewDeviceServiceCallbackClient(ts.URL)
-	res, err := client.DeleteDeviceCallback(context.Background(), testDeviceId)
+	res, err := client.DeleteDeviceCallback(context.Background(), testDeviceName)
+
+	require.NoError(t, err)
+	assert.Equal(t, requestId, res.RequestId)
+}
+
+func TestUpdateDeviceProfileCallback(t *testing.T) {
+	requestId := uuid.New().String()
+	expectedResponse := common.NewBaseResponse(requestId, "", http.StatusOK)
+	ts := newTestServer(http.MethodPut, v2.ApiProfileCallbackRoute, expectedResponse)
+	defer ts.Close()
+
+	client := NewDeviceServiceCallbackClient(ts.URL)
+	res, err := client.UpdateDeviceProfileCallback(context.Background(), requests.DeviceProfileRequest{})
+
+	require.NoError(t, err)
+	assert.Equal(t, requestId, res.RequestId)
+}
+
+func TestAddProvisionWatcherCallback(t *testing.T) {
+	requestId := uuid.New().String()
+	expectedResponse := common.NewBaseResponse(requestId, "", http.StatusOK)
+	ts := newTestServer(http.MethodPost, v2.ApiWatcherCallbackRoute, expectedResponse)
+	defer ts.Close()
+
+	client := NewDeviceServiceCallbackClient(ts.URL)
+	res, err := client.AddProvisionWatcherCallback(context.Background(), requests.AddProvisionWatcherRequest{})
+
+	require.NoError(t, err)
+	assert.Equal(t, requestId, res.RequestId)
+}
+
+func TestUpdateProvisionWatcherCallback(t *testing.T) {
+	requestId := uuid.New().String()
+	expectedResponse := common.NewBaseResponse(requestId, "", http.StatusOK)
+	ts := newTestServer(http.MethodPut, v2.ApiWatcherCallbackRoute, expectedResponse)
+	defer ts.Close()
+
+	client := NewDeviceServiceCallbackClient(ts.URL)
+	res, err := client.UpdateProvisionWatcherCallback(context.Background(), requests.UpdateProvisionWatcherRequest{})
+
+	require.NoError(t, err)
+	assert.Equal(t, requestId, res.RequestId)
+}
+
+func TestDeleteProvisionWatcherCallback(t *testing.T) {
+	testWatcherName := "testName"
+	requestId := uuid.New().String()
+	urlPath := path.Join(v2.ApiWatcherCallbackRoute, v2.Name, testWatcherName)
+	expectedResponse := common.NewBaseResponse(requestId, "", http.StatusOK)
+	ts := newTestServer(http.MethodDelete, urlPath, expectedResponse)
+	defer ts.Close()
+
+	client := NewDeviceServiceCallbackClient(ts.URL)
+	res, err := client.DeleteProvisionWatcherCallback(context.Background(), testWatcherName)
+
+	require.NoError(t, err)
+	assert.Equal(t, requestId, res.RequestId)
+}
+
+func TestUpdateDeviceServiceCallback(t *testing.T) {
+	requestId := uuid.New().String()
+	expectedResponse := common.NewBaseResponse(requestId, "", http.StatusOK)
+	ts := newTestServer(http.MethodPut, v2.ApiServiceCallbackRoute, expectedResponse)
+	defer ts.Close()
+
+	client := NewDeviceServiceCallbackClient(ts.URL)
+	res, err := client.UpdateDeviceServiceCallback(context.Background(), requests.UpdateDeviceServiceRequest{})
 
 	require.NoError(t, err)
 	assert.Equal(t, requestId, res.RequestId)

--- a/v2/clients/interfaces/deviceservicecallback.go
+++ b/v2/clients/interfaces/deviceservicecallback.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,10 +15,20 @@ import (
 
 // DeviceServiceCallbackClient defines the interface for interactions with the callback endpoint on the EdgeX Foundry device service.
 type DeviceServiceCallbackClient interface {
-	// AddDeviceCallback invoke device service's callback API for adding device
+	// AddDeviceCallback invokes device service's callback API for adding device
 	AddDeviceCallback(ctx context.Context, request requests.AddDeviceRequest) (common.BaseResponse, errors.EdgeX)
-	// UpdateDeviceCallback invoke device service's callback API for updating device
+	// UpdateDeviceCallback invokes device service's callback API for updating device
 	UpdateDeviceCallback(ctx context.Context, request requests.UpdateDeviceRequest) (common.BaseResponse, errors.EdgeX)
-	// DeleteDeviceCallback invoke device service's callback API for deleting device
-	DeleteDeviceCallback(ctx context.Context, id string) (common.BaseResponse, errors.EdgeX)
+	// DeleteDeviceCallback invokes device service's callback API for deleting device
+	DeleteDeviceCallback(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX)
+	// UpdateDeviceProfileCallback invokes device service's callback API for updating device profile
+	UpdateDeviceProfileCallback(ctx context.Context, request requests.DeviceProfileRequest) (common.BaseResponse, errors.EdgeX)
+	// AddProvisionWatcherCallback invokes device service's callback API for adding provision watcher
+	AddProvisionWatcherCallback(ctx context.Context, request requests.AddProvisionWatcherRequest) (common.BaseResponse, errors.EdgeX)
+	// UpdateProvisionWatcherCallback invokes device service's callback API for updating provision watcher
+	UpdateProvisionWatcherCallback(ctx context.Context, request requests.UpdateProvisionWatcherRequest) (common.BaseResponse, errors.EdgeX)
+	// DeleteProvisionWatcherCallback invokes device service's callback API for deleting provision watcher
+	DeleteProvisionWatcherCallback(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX)
+	// UpdateDeviceServiceCallback invokes device service's callback API for updating device service
+	UpdateDeviceServiceCallback(ctx context.Context, request requests.UpdateDeviceServiceRequest) (common.BaseResponse, errors.EdgeX)
 }

--- a/v2/constants.go
+++ b/v2/constants.go
@@ -72,6 +72,7 @@ const (
 	ApiProfileCallbackNameRoute = ApiBase + "/callback/profile/name/{name}"
 	ApiWatcherCallbackRoute     = ApiBase + "/callback/watcher"
 	ApiWatcherCallbackNameRoute = ApiBase + "/callback/watcher/name/{name}"
+	ApiServiceCallbackRoute     = ApiBase + "/callback/service"
 	ApiDiscoveryRoute           = ApiBase + "/discovery"
 )
 


### PR DESCRIPTION
- update DELETE callback to be done by name
- add ProvisionWatcher callback support
- add DeviceProfile callback support

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #447 


## What is the new behavior?
DeviceServiceCallbackClient is now able to fully utilize device service v2 callback API

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information