### PR TITLE
feat(v2): Http client lib set API version to request body

### DIFF
--- a/v2/clients/http/device.go
+++ b/v2/clients/http/device.go
@@ -1,3 +1,8 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package http
 
 import (
@@ -28,7 +33,7 @@ func NewDeviceClient(baseUrl string) interfaces.DeviceClient {
 }
 
 func (dc DeviceClient) Add(ctx context.Context, reqs []requests.AddDeviceRequest) (res []common.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequest(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, reqs)
+	err = utils.PostRequest(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, &reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -36,7 +41,7 @@ func (dc DeviceClient) Add(ctx context.Context, reqs []requests.AddDeviceRequest
 }
 
 func (dc DeviceClient) Update(ctx context.Context, reqs []requests.UpdateDeviceRequest) (res []common.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, &reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceprofile.go
+++ b/v2/clients/http/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,7 +34,7 @@ func NewDeviceProfileClient(baseUrl string) interfaces.DeviceProfileClient {
 
 func (client *DeviceProfileClient) Add(ctx context.Context, reqs []requests.DeviceProfileRequest) ([]common.BaseWithIdResponse, errors.EdgeX) {
 	var responses []common.BaseWithIdResponse
-	err := utils.PostRequest(ctx, &responses, client.baseUrl+v2.ApiDeviceProfileRoute, reqs)
+	err := utils.PostRequest(ctx, &responses, client.baseUrl+v2.ApiDeviceProfileRoute, &reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -43,7 +43,7 @@ func (client *DeviceProfileClient) Add(ctx context.Context, reqs []requests.Devi
 
 func (client *DeviceProfileClient) Update(ctx context.Context, reqs []requests.DeviceProfileRequest) ([]common.BaseResponse, errors.EdgeX) {
 	var responses []common.BaseResponse
-	err := utils.PutRequest(ctx, &responses, client.baseUrl+v2.ApiDeviceProfileRoute, reqs)
+	err := utils.PutRequest(ctx, &responses, client.baseUrl+v2.ApiDeviceProfileRoute, &reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservice.go
+++ b/v2/clients/http/deviceservice.go
@@ -1,3 +1,8 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package http
 
 import (
@@ -29,7 +34,7 @@ func NewDeviceServiceClient(baseUrl string) interfaces.DeviceServiceClient {
 
 func (dsc DeviceServiceClient) Add(ctx context.Context, reqs []requests.AddDeviceServiceRequest) (
 	res []common.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequest(ctx, &res, dsc.baseUrl+v2.ApiDeviceServiceRoute, reqs)
+	err = utils.PostRequest(ctx, &res, dsc.baseUrl+v2.ApiDeviceServiceRoute, &reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -38,7 +43,7 @@ func (dsc DeviceServiceClient) Add(ctx context.Context, reqs []requests.AddDevic
 
 func (dsc DeviceServiceClient) Update(ctx context.Context, reqs []requests.UpdateDeviceServiceRequest) (
 	res []common.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, dsc.baseUrl+v2.ApiDeviceServiceRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, dsc.baseUrl+v2.ApiDeviceServiceRoute, &reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservicecallback.go
+++ b/v2/clients/http/deviceservicecallback.go
@@ -30,7 +30,7 @@ func NewDeviceServiceCallbackClient(baseUrl string) interfaces.DeviceServiceCall
 
 func (client *deviceServiceCallbackClient) AddDeviceCallback(ctx context.Context, request requests.AddDeviceRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PostRequest(ctx, &response, client.baseUrl+v2.ApiDeviceCallbackRoute, request)
+	err := utils.PostRequest(ctx, &response, client.baseUrl+v2.ApiDeviceCallbackRoute, &request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -39,7 +39,7 @@ func (client *deviceServiceCallbackClient) AddDeviceCallback(ctx context.Context
 
 func (client *deviceServiceCallbackClient) UpdateDeviceCallback(ctx context.Context, request requests.UpdateDeviceRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiDeviceCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiDeviceCallbackRoute, &request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -58,7 +58,7 @@ func (client *deviceServiceCallbackClient) DeleteDeviceCallback(ctx context.Cont
 
 func (client *deviceServiceCallbackClient) UpdateDeviceProfileCallback(ctx context.Context, request requests.DeviceProfileRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiProfileCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiProfileCallbackRoute, &request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -67,7 +67,7 @@ func (client *deviceServiceCallbackClient) UpdateDeviceProfileCallback(ctx conte
 
 func (client *deviceServiceCallbackClient) AddProvisionWatcherCallback(ctx context.Context, request requests.AddProvisionWatcherRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PostRequest(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, request)
+	err := utils.PostRequest(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, &request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -76,7 +76,7 @@ func (client *deviceServiceCallbackClient) AddProvisionWatcherCallback(ctx conte
 
 func (client *deviceServiceCallbackClient) UpdateProvisionWatcherCallback(ctx context.Context, request requests.UpdateProvisionWatcherRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, &request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -95,7 +95,7 @@ func (client *deviceServiceCallbackClient) DeleteProvisionWatcherCallback(ctx co
 
 func (client *deviceServiceCallbackClient) UpdateDeviceServiceCallback(ctx context.Context, request requests.UpdateDeviceServiceRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiServiceCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl+v2.ApiServiceCallbackRoute, &request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/event.go
+++ b/v2/clients/http/event.go
@@ -35,7 +35,7 @@ func (ec *eventClient) Add(ctx context.Context, req requests.AddEventRequest) (
 	common.BaseWithIdResponse, errors.EdgeX) {
 	path := path.Join(v2.ApiEventRoute, url.QueryEscape(req.Event.ProfileName), url.QueryEscape(req.Event.DeviceName))
 	var br common.BaseWithIdResponse
-	err := utils.PostRequest(ctx, &br, ec.baseUrl+path, req)
+	err := utils.PostRequest(ctx, &br, ec.baseUrl+path, &req)
 	if err != nil {
 		return br, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/provisionwatcher.go
+++ b/v2/clients/http/provisionwatcher.go
@@ -33,7 +33,7 @@ func NewProvisionWatcherClient(baseUrl string) interfaces.ProvisionWatcherClient
 }
 
 func (pwc ProvisionWatcherClient) Add(ctx context.Context, reqs []requests.AddProvisionWatcherRequest) (res []common.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequest(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, reqs)
+	err = utils.PostRequest(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, &reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -42,7 +42,7 @@ func (pwc ProvisionWatcherClient) Add(ctx context.Context, reqs []requests.AddPr
 }
 
 func (pwc ProvisionWatcherClient) Update(ctx context.Context, reqs []requests.UpdateProvisionWatcherRequest) (res []common.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, &reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/utils/request_test.go
+++ b/v2/clients/http/utils/request_test.go
@@ -1,0 +1,135 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ExampleUUID            = "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc"
+	TestOriginTime         = 1587540776
+	TestDeviceName         = "TestDevice"
+	TestDeviceServiceName  = "TestDeviceServiceName"
+	TestBaseAddress        = "http://0.0.0.0:49991/api/v1/callback"
+	TestDeviceProfileName  = "TestDeviceProfileName"
+	TestDeviceResourceName = "TestDeviceResourceName"
+	TestReadingValue       = "45"
+)
+
+func addEventRequestData() requests.AddEventRequest {
+	return requests.AddEventRequest{
+		BaseRequest: common.BaseRequest{
+			RequestId: ExampleUUID,
+		},
+		Event: dtos.Event{
+			Id:          ExampleUUID,
+			DeviceName:  TestDeviceName,
+			ProfileName: TestDeviceProfileName,
+			Origin:      TestOriginTime,
+			Readings: []dtos.BaseReading{{
+				DeviceName:   TestDeviceName,
+				ResourceName: TestDeviceResourceName,
+				ProfileName:  TestDeviceProfileName,
+				Origin:       TestOriginTime,
+				ValueType:    v2.ValueTypeUint8,
+				SimpleReading: dtos.SimpleReading{
+					Value: TestReadingValue,
+				},
+			}},
+			Tags: map[string]string{
+				"GatewayId": "Houston-0001",
+			},
+		},
+	}
+}
+
+func addDeviceServiceRequestData() requests.AddDeviceServiceRequest {
+	return requests.AddDeviceServiceRequest{
+		BaseRequest: common.BaseRequest{
+			RequestId: ExampleUUID,
+		},
+		Service: dtos.DeviceService{
+			Name:        TestDeviceServiceName,
+			BaseAddress: TestBaseAddress,
+			Labels:      []string{"MODBUS", "TEMP"},
+			AdminState:  models.Locked,
+		},
+	}
+}
+
+func updateDeviceServiceRequestData() requests.UpdateDeviceServiceRequest {
+	testName := TestDeviceServiceName
+	testBaseAddress := TestBaseAddress
+	testAdminState := models.Locked
+	ds := dtos.UpdateDeviceService{}
+	ds.Name = &testName
+	ds.BaseAddress = &testBaseAddress
+	ds.AdminState = &testAdminState
+	ds.Labels = []string{"MODBUS", "TEMP"}
+	return requests.UpdateDeviceServiceRequest{
+		BaseRequest: common.BaseRequest{
+			RequestId: ExampleUUID,
+		},
+		Service: ds,
+	}
+}
+
+func TestSetApiVersion_Versionable(t *testing.T) {
+	var data interface{} = &common.Versionable{}
+
+	setApiVersion(data)
+
+	assert.Equal(t, v2.ApiVersion, data.(*common.Versionable).ApiVersion)
+}
+
+func TestSetApiVersion_AddEventRequest(t *testing.T) {
+	evt := addEventRequestData()
+	var data interface{} = &evt
+
+	setApiVersion(data)
+	result := data.(*requests.AddEventRequest)
+
+	assert.Equal(t, v2.ApiVersion, result.ApiVersion)
+	assert.Equal(t, v2.ApiVersion, result.Event.ApiVersion)
+	for _, r := range result.Event.Readings {
+		assert.Equal(t, v2.ApiVersion, r.ApiVersion)
+	}
+}
+
+func TestSetApiVersion_AddDeviceServiceRequest(t *testing.T) {
+	ds := addDeviceServiceRequestData()
+	var data interface{} = &[]requests.AddDeviceServiceRequest{ds}
+
+	setApiVersion(data)
+	result := data.(*[]requests.AddDeviceServiceRequest)
+
+	for _, ds := range *result {
+		assert.Equal(t, v2.ApiVersion, ds.ApiVersion)
+		assert.Equal(t, v2.ApiVersion, ds.Service.ApiVersion)
+	}
+}
+
+func TestSetApiVersion_UpdateDeviceServiceRequest(t *testing.T) {
+	ds := updateDeviceServiceRequestData()
+	var data interface{} = &[]requests.UpdateDeviceServiceRequest{ds}
+
+	setApiVersion(data)
+	result := data.(*[]requests.UpdateDeviceServiceRequest)
+
+	for _, ds := range *result {
+		assert.Equal(t, v2.ApiVersion, ds.ApiVersion)
+		assert.Equal(t, v2.ApiVersion, ds.Service.ApiVersion)
+	}
+}

--- a/v2/constants.go
+++ b/v2/constants.go
@@ -7,8 +7,9 @@ package v2
 
 // Constants related to defined routes in the v2 service APIs
 const (
-	ApiVersion = "v2"
-	ApiBase    = "/api/v2"
+	ApiVersion      = "v2"
+	ApiVersionField = "ApiVersion"
+	ApiBase         = "/api/v2"
 
 	ApiEventRoute                      = ApiBase + "/event"
 	ApiEventProfileNameDeviceNameRoute = ApiEventRoute + "/{" + ProfileName + "}" + "/{" + DeviceName + "}"

--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -11,7 +11,15 @@ import v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 // This object and its properties correspond to the BaseRequest object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BaseRequest
 type BaseRequest struct {
-	RequestId string `json:"requestId" validate:"len=0|uuid"`
+	Versionable `json:",inline"`
+	RequestId   string `json:"requestId" validate:"len=0|uuid"`
+}
+
+func NewBaseRequest(requestId string) BaseRequest {
+	return BaseRequest{
+		Versionable: NewVersionable(),
+		RequestId:   requestId,
+	}
 }
 
 // BaseResponse defines the base content for response DTOs (data transfer objects).

--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,20 +34,21 @@ type Device struct {
 // UpdateDevice and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/UpdateDevice
 type UpdateDevice struct {
-	Id             *string                       `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name           *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Description    *string                       `json:"description" validate:"omitempty,edgex-dto-none-empty-string"`
-	AdminState     *string                       `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
-	OperatingState *string                       `json:"operatingState" validate:"omitempty,oneof='UP' 'DOWN' 'UNKNOWN'"`
-	LastConnected  *int64                        `json:"lastConnected"`
-	LastReported   *int64                        `json:"lastReported"`
-	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ProfileName    *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Labels         []string                      `json:"labels"`
-	Location       interface{}                   `json:"location"`
-	AutoEvents     []AutoEvent                   `json:"autoEvents" validate:"dive"`
-	Protocols      map[string]ProtocolProperties `json:"protocols" validate:"omitempty,gt=0"`
-	Notify         *bool                         `json:"notify"`
+	common.Versionable `json:",inline"`
+	Id                 *string                       `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
+	Name               *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Description        *string                       `json:"description" validate:"omitempty,edgex-dto-none-empty-string"`
+	AdminState         *string                       `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
+	OperatingState     *string                       `json:"operatingState" validate:"omitempty,oneof='UP' 'DOWN' 'UNKNOWN'"`
+	LastConnected      *int64                        `json:"lastConnected"`
+	LastReported       *int64                        `json:"lastReported"`
+	ServiceName        *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName        *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Labels             []string                      `json:"labels"`
+	Location           interface{}                   `json:"location"`
+	AutoEvents         []AutoEvent                   `json:"autoEvents" validate:"dive"`
+	Protocols          map[string]ProtocolProperties `json:"protocols" validate:"omitempty,gt=0"`
+	Notify             *bool                         `json:"notify"`
 }
 
 // ToDeviceModel transforms the Device DTO to the Device Model

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,11 +29,12 @@ type DeviceService struct {
 // UpdateDeviceService and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/UpdateDeviceService
 type UpdateDeviceService struct {
-	Id          *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name        *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	BaseAddress *string  `json:"baseAddress" validate:"omitempty,uri"`
-	Labels      []string `json:"labels"`
-	AdminState  *string  `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
+	common.Versionable `json:",inline"`
+	Id                 *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
+	Name               *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	BaseAddress        *string  `json:"baseAddress" validate:"omitempty,uri"`
+	Labels             []string `json:"labels"`
+	AdminState         *string  `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 }
 
 // ToDeviceServiceModel transforms the DeviceService DTO to the DeviceService Model

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -92,8 +92,8 @@ func AddEventReqToEventModel(addEventReq AddEventRequest) (event models.Event) {
 
 func NewAddEventRequest(requestId string, event dtos.Event) AddEventRequest {
 	event.Versionable = common.NewVersionable()
-	for _, reading := range event.Readings {
-		reading.Versionable = common.NewVersionable()
+	for i, _ := range event.Readings {
+		event.Readings[i].Versionable = common.NewVersionable()
 	}
 	return AddEventRequest{
 		common.NewBaseRequest(requestId),

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -87,5 +87,16 @@ func AddEventReqToEventModel(addEventReq AddEventRequest) (event models.Event) {
 		Origin:      addEventReq.Event.Origin,
 		Readings:    readings,
 		Tags:        tags,
+	}
+}
+
+func NewAddEventRequest(requestId string, event dtos.Event) AddEventRequest {
+	event.Versionable = common.NewVersionable()
+	for _, reading := range event.Readings {
+		reading.Versionable = common.NewVersionable()
+	}
+	return AddEventRequest{
+		common.NewBaseRequest(requestId),
+		event,
 	}
 }


### PR DESCRIPTION
Close #450

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #450 


## What is the new behavior?
Http client set API version to request body for POST, PUT, PATCH operation

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

Use golang reflect to set the API version instead of creating factory methods.

## Other information