### PR TITLE
feat: Add factory methods for AddEventRequest, Event and Reading DTOs

### DIFF
--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -5,13 +5,21 @@
 
 package common
 
-import v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+import (
+	"github.com/google/uuid"
+
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+)
 
 // Request defines the base content for request DTOs (data transfer objects).
 // This object and its properties correspond to the BaseRequest object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BaseRequest
 type BaseRequest struct {
 	RequestId string `json:"requestId" validate:"len=0|uuid"`
+}
+
+func NewBaseRequest() BaseRequest {
+	return BaseRequest{RequestId: uuid.New().String()}
 }
 
 // BaseResponse defines the base content for response DTOs (data transfer objects).

--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -38,7 +38,7 @@ type BaseResponse struct {
 
 // Versionable shows the API version in DTOs
 type Versionable struct {
-	ApiVersion string `json:"apiVersion,omitempty"`
+	ApiVersion string `json:"apiVersion" validate:"required"`
 }
 
 // BaseWithIdResponse defines the base content for response DTOs (data transfer objects).

--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -15,11 +15,15 @@ import (
 // This object and its properties correspond to the BaseRequest object in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BaseRequest
 type BaseRequest struct {
-	RequestId string `json:"requestId" validate:"len=0|uuid"`
+	Versionable `json:",inline"`
+	RequestId   string `json:"requestId" validate:"len=0|uuid"`
 }
 
 func NewBaseRequest() BaseRequest {
-	return BaseRequest{RequestId: uuid.New().String()}
+	return BaseRequest{
+		Versionable: NewVersionable(),
+		RequestId:   uuid.NewString(),
+	}
 }
 
 // BaseResponse defines the base content for response DTOs (data transfer objects).

--- a/v2/dtos/common/base_test.go
+++ b/v2/dtos/common/base_test.go
@@ -14,6 +14,12 @@ import (
 	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 )
 
+func TestNewBaseRequest(t *testing.T) {
+	actual := NewBaseRequest()
+	assert.Equal(t, v2.ApiVersion, actual.ApiVersion)
+	assert.NotEmpty(t, actual.RequestId)
+}
+
 func TestNewBaseResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := 200

--- a/v2/dtos/common/secret_test.go
+++ b/v2/dtos/common/secret_test.go
@@ -31,8 +31,11 @@ const (
 )
 
 var validRequest = SecretRequest{
-	BaseRequest: BaseRequest{RequestId: TestUUID},
-	Path:        "something",
+	BaseRequest: BaseRequest{
+		RequestId:   TestUUID,
+		Versionable: NewVersionable(),
+	},
+	Path: "something",
 	SecretData: []SecretDataKeyValue{
 		{Key: "username", Value: "User1"},
 		{Key: "password", Value: "password"},

--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -9,10 +9,13 @@ import (
 	"encoding/xml"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+
+	"github.com/google/uuid"
 )
 
 // Event and its properties are defined in the APIv2 specification:
@@ -26,6 +29,17 @@ type Event struct {
 	Origin             int64             `json:"origin" validate:"required"`
 	Readings           []BaseReading     `json:"readings" validate:"gt=0,dive,required"`
 	Tags               map[string]string `json:"tags,omitempty" xml:"-"` // Have to ignore since map not supported for XML
+}
+
+// NewEvent creates and returns an initialized Event with no Readings
+func NewEvent(profileName string, deviceName string) Event {
+	return Event{
+		Versionable: common.NewVersionable(),
+		Id:          uuid.New().String(),
+		DeviceName:  deviceName,
+		ProfileName: profileName,
+		Origin:      time.Now().UnixNano(),
+	}
 }
 
 // FromEventModelToDTO transforms the Event Model to the Event DTO
@@ -52,8 +66,23 @@ func FromEventModelToDTO(event models.Event) Event {
 	}
 }
 
+// AddSimpleReading adds a simple reading to the Event
+func (e *Event) AddSimpleReading(resourceName string, valueType string, value interface{}) error {
+	reading, err := NewSimpleReading(e.ProfileName, e.DeviceName, resourceName, valueType, value)
+	if err != nil {
+		return err
+	}
+	e.Readings = append(e.Readings, reading)
+	return nil
+}
+
+// AddBinaryReading adds a binary reading to the Event
+func (e *Event) AddBinaryReading(resourceName string, binaryValue []byte, mediaType string) {
+	e.Readings = append(e.Readings, NewBinaryReading(e.ProfileName, e.DeviceName, resourceName, binaryValue, mediaType))
+}
+
 // ToXML provides a XML representation of the Event as a string
-func (e Event) ToXML() (string, error) {
+func (e *Event) ToXML() (string, error) {
 	eventXml, err := xml.Marshal(e)
 	if err != nil {
 		return "", err

--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -35,7 +35,7 @@ type Event struct {
 func NewEvent(profileName string, deviceName string) Event {
 	return Event{
 		Versionable: common.NewVersionable(),
-		Id:          uuid.New().String(),
+		Id:          uuid.NewString(),
 		DeviceName:  deviceName,
 		ProfileName: profileName,
 		Origin:      time.Now().UnixNano(),

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -6,6 +6,16 @@
 package dtos
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
@@ -26,6 +36,12 @@ type BaseReading struct {
 	SimpleReading      `json:",inline" validate:"-"`
 }
 
+// SimpleReading and its properties are defined in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/SimpleReading
+type SimpleReading struct {
+	Value string `json:"value" validate:"required"`
+}
+
 // BinaryReading and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BinaryReading
 type BinaryReading struct {
@@ -33,10 +49,206 @@ type BinaryReading struct {
 	MediaType   string `json:"mediaType" validate:"required"`
 }
 
-// SimpleReading and its properties are defined in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/SimpleReading
-type SimpleReading struct {
-	Value string `json:"value" validate:"required"`
+func newBaseReading(profileName string, deviceName string, resourceName string, valueType string) BaseReading {
+	return BaseReading{
+		Versionable:  common.NewVersionable(),
+		Id:           uuid.New().String(),
+		Origin:       time.Now().UnixNano(),
+		DeviceName:   deviceName,
+		ResourceName: resourceName,
+		ProfileName:  profileName,
+		ValueType:    valueType,
+	}
+}
+
+// NewSimpleReading creates and returns a new initialized BaseReading with its SimpleReading initialized
+func NewSimpleReading(profileName string, deviceName string, resourceName string, valueType string, value interface{}) (BaseReading, error) {
+	stringValue, err := convertInterfaceValue(valueType, value)
+	if err != nil {
+		return BaseReading{}, err
+	}
+
+	reading := newBaseReading(profileName, deviceName, resourceName, valueType)
+	reading.SimpleReading = SimpleReading{
+		Value: stringValue,
+	}
+	return reading, nil
+}
+
+// NewBinaryReading creates and returns a new initialized BaseReading with its BinaryReading initialized
+func NewBinaryReading(profileName string, deviceName string, resourceName string, binaryValue []byte, mediaType string) BaseReading {
+	reading := newBaseReading(profileName, deviceName, resourceName, v2.ValueTypeBinary)
+	reading.BinaryReading = BinaryReading{
+		BinaryValue: binaryValue,
+		MediaType:   mediaType,
+	}
+	return reading
+}
+
+func convertInterfaceValue(valueType string, value interface{}) (string, error) {
+	switch valueType {
+	case v2.ValueTypeBool:
+		return convertSimpleValue(valueType, reflect.Bool, value)
+	case v2.ValueTypeString:
+		return convertSimpleValue(valueType, reflect.String, value)
+
+	case v2.ValueTypeUint8:
+		return convertSimpleValue(valueType, reflect.Uint8, value)
+	case v2.ValueTypeUint16:
+		return convertSimpleValue(valueType, reflect.Uint16, value)
+	case v2.ValueTypeUint32:
+		return convertSimpleValue(valueType, reflect.Uint32, value)
+	case v2.ValueTypeUint64:
+		return convertSimpleValue(valueType, reflect.Uint64, value)
+
+	case v2.ValueTypeInt8:
+		return convertSimpleValue(valueType, reflect.Int8, value)
+	case v2.ValueTypeInt16:
+		return convertSimpleValue(valueType, reflect.Int16, value)
+	case v2.ValueTypeInt32:
+		return convertSimpleValue(valueType, reflect.Int32, value)
+	case v2.ValueTypeInt64:
+		return convertSimpleValue(valueType, reflect.Int64, value)
+
+	case v2.ValueTypeFloat32:
+		return convertFloatValue(valueType, reflect.Float32, value)
+	case v2.ValueTypeFloat64:
+		return convertFloatValue(valueType, reflect.Float64, value)
+
+	case v2.ValueTypeBoolArray:
+		return convertSimpleArrayValue(valueType, reflect.Bool, value)
+	case v2.ValueTypeStringArray:
+		return convertSimpleArrayValue(valueType, reflect.String, value)
+
+	case v2.ValueTypeUint8Array:
+		return convertSimpleArrayValue(valueType, reflect.Uint8, value)
+	case v2.ValueTypeUint16Array:
+		return convertSimpleArrayValue(valueType, reflect.Uint16, value)
+	case v2.ValueTypeUint32Array:
+		return convertSimpleArrayValue(valueType, reflect.Uint32, value)
+	case v2.ValueTypeUint64Array:
+		return convertSimpleArrayValue(valueType, reflect.Uint64, value)
+
+	case v2.ValueTypeInt8Array:
+		return convertSimpleArrayValue(valueType, reflect.Int8, value)
+	case v2.ValueTypeInt16Array:
+		return convertSimpleArrayValue(valueType, reflect.Int16, value)
+	case v2.ValueTypeInt32Array:
+		return convertSimpleArrayValue(valueType, reflect.Int32, value)
+	case v2.ValueTypeInt64Array:
+		return convertSimpleArrayValue(valueType, reflect.Int64, value)
+
+	case v2.ValueTypeFloat32Array:
+		arrayValue, ok := value.([]float32)
+		if !ok {
+			return "", fmt.Errorf("unable to cast value to []float32 for %s", valueType)
+		}
+
+		return convertFloat32ArrayValue(arrayValue)
+	case v2.ValueTypeFloat64Array:
+		arrayValue, ok := value.([]float64)
+		if !ok {
+			return "", fmt.Errorf("unable to cast value to []float64 for %s", valueType)
+		}
+
+		return convertFloat64ArrayValue(arrayValue)
+
+	default:
+		return "", fmt.Errorf("invalid simple reading type of %s", valueType)
+	}
+}
+
+func convertSimpleValue(valueType string, kind reflect.Kind, value interface{}) (string, error) {
+	if err := validateType(valueType, kind, value); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", value), nil
+}
+
+func convertFloatValue(valueType string, kind reflect.Kind, value interface{}) (string, error) {
+	if err := validateType(valueType, kind, value); err != nil {
+		return "", err
+	}
+
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.BigEndian, value); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func convertSimpleArrayValue(valueType string, kind reflect.Kind, value interface{}) (string, error) {
+	if err := validateType(valueType, kind, value); err != nil {
+		return "", err
+	}
+
+	result := fmt.Sprintf("%v", value)
+	result = strings.ReplaceAll(result, " ", ", ")
+	return result, nil
+}
+
+func convertFloat32ArrayValue(values []float32) (string, error) {
+	result := "["
+	first := true
+	for _, value := range values {
+		if first {
+			floatValue, err := convertFloatValue(v2.ValueTypeFloat32, reflect.Float32, value)
+			if err != nil {
+				return "", err
+			}
+			result += floatValue
+			first = false
+			continue
+		}
+
+		floatValue, err := convertFloatValue(v2.ValueTypeFloat32, reflect.Float32, value)
+		if err != nil {
+			return "", err
+		}
+		result += ", " + floatValue
+	}
+
+	return result, nil
+}
+
+func convertFloat64ArrayValue(values []float64) (string, error) {
+	result := "["
+	first := true
+	for _, value := range values {
+		if first {
+			floatValue, err := convertFloatValue(v2.ValueTypeFloat64, reflect.Float64, value)
+			if err != nil {
+				return "", err
+			}
+			result += floatValue
+			first = false
+			continue
+		}
+
+		floatValue, err := convertFloatValue(v2.ValueTypeFloat64, reflect.Float64, value)
+		if err != nil {
+			return "", err
+		}
+		result += ", " + floatValue
+	}
+
+	return result, nil
+}
+
+func validateType(valueType string, kind reflect.Kind, value interface{}) error {
+	if reflect.TypeOf(value).Kind() == reflect.Slice {
+		if kind != reflect.TypeOf(value).Elem().Kind() {
+			return fmt.Errorf("slice of type of value `%s` not a match for specified ValueType '%s", kind.String(), valueType)
+		}
+		return nil
+	}
+
+	if kind != reflect.TypeOf(value).Kind() {
+		return fmt.Errorf("type of value `%s` not a match for specified ValueType '%s", kind.String(), valueType)
+	}
+
+	return nil
 }
 
 // Validate satisfies the Validator interface

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -52,7 +52,7 @@ type BinaryReading struct {
 func newBaseReading(profileName string, deviceName string, resourceName string, valueType string) BaseReading {
 	return BaseReading{
 		Versionable:  common.NewVersionable(),
-		Id:           uuid.New().String(),
+		Id:           uuid.NewString(),
 		Origin:       time.Now().UnixNano(),
 		DeviceName:   deviceName,
 		ResourceName: resourceName,

--- a/v2/dtos/reading_test.go
+++ b/v2/dtos/reading_test.go
@@ -8,6 +8,8 @@ package dtos
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
@@ -91,4 +93,123 @@ func TestFromReadingModelToDTO(t *testing.T) {
 			assert.Equal(t, expectedDTO, result, "FromReadingModelToDTO did not result in expected Reading DTO.")
 		})
 	}
+}
+
+func TestNewSimpleReading(t *testing.T) {
+	expectedApiVersion := v2.ApiVersion
+	expectedDeviceName := TestDeviceName
+	expectedProfileName := TestDeviceProfileName
+	expectedResourceName := TestDeviceResourceName
+
+	tests := []struct {
+		name              string
+		expectedValueType string
+		value             interface{}
+		expectedValue     string
+	}{
+		{"Simple Boolean (true)", v2.ValueTypeBool, true, "true"},
+		{"Simple Boolean (false)", v2.ValueTypeBool, false, "false"},
+		{"Simple String", v2.ValueTypeString, "hello world", "hello world"},
+		{"Simple Uint8", v2.ValueTypeUint8, uint8(123), "123"},
+		{"Simple Uint16", v2.ValueTypeUint16, uint16(12345), "12345"},
+		{"Simple Uint32", v2.ValueTypeUint32, uint32(1234567890), "1234567890"},
+		{"Simple uint64", v2.ValueTypeUint64, uint64(1234567890987654321), "1234567890987654321"},
+		{"Simple int8", v2.ValueTypeInt8, int8(-123), "-123"},
+		{"Simple int16", v2.ValueTypeInt16, int16(-12345), "-12345"},
+		{"Simple int32", v2.ValueTypeInt32, int32(-1234567890), "-1234567890"},
+		{"Simple int64", v2.ValueTypeInt64, int64(-1234567890987654321), "-1234567890987654321"},
+		{"Simple Float32", v2.ValueTypeFloat32, float32(123.456), "QvbpeQ=="},
+		{"Simple Float64", v2.ValueTypeFloat64, float64(123456789.0987654321), "QZ1vNFRlIsQ="},
+		{"Simple Boolean Array", v2.ValueTypeBoolArray, []bool{true, false}, "[true, false]"},
+		{"Simple String Array", v2.ValueTypeStringArray, []string{"hello", "world"}, "[hello, world]"},
+		{"Simple Uint8 Array", v2.ValueTypeUint8Array, []uint8{123, 21}, "[123, 21]"},
+		{"Simple Uint16 Array", v2.ValueTypeUint16Array, []uint16{12345, 4321}, "[12345, 4321]"},
+		{"Simple Uint32 Array", v2.ValueTypeUint32Array, []uint32{1234567890, 87654321}, "[1234567890, 87654321]"},
+		{"Simple Uint64 Array", v2.ValueTypeUint64Array, []uint64{1234567890987654321, 10987654321}, "[1234567890987654321, 10987654321]"},
+		{"Simple Int8 Array", v2.ValueTypeInt8Array, []int8{-123, 123}, "[-123, 123]"},
+		{"Simple Int16 Array", v2.ValueTypeInt16Array, []int16{-12345, 12345}, "[-12345, 12345]"},
+		{"Simple Int32 Array", v2.ValueTypeInt32Array, []int32{-1234567890, 1234567890}, "[-1234567890, 1234567890]"},
+		{"Simple Int64 Array", v2.ValueTypeInt64Array, []int64{-1234567890987654321, 1234567890987654321}, "[-1234567890987654321, 1234567890987654321]"},
+		{"Simple Float32 Array", v2.ValueTypeFloat32Array, []float32{123.456, -654.321}, "[QvbpeQ==, xCOUiw=="},
+		{"Simple Float64 Array", v2.ValueTypeFloat64Array, []float64{123456789.0987654321, -987654321.123456789}, "[QZ1vNFRlIsQ=, wc1vNFiPzW8="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := NewSimpleReading(expectedProfileName, expectedDeviceName, expectedResourceName, tt.expectedValueType, tt.value)
+			require.NoError(t, err)
+			assert.Equal(t, expectedApiVersion, actual.ApiVersion)
+			assert.NotEmpty(t, actual.Id)
+			assert.Equal(t, expectedProfileName, actual.ProfileName)
+			assert.Equal(t, expectedDeviceName, actual.DeviceName)
+			assert.Equal(t, expectedResourceName, actual.ResourceName)
+			assert.Equal(t, tt.expectedValueType, actual.ValueType)
+			assert.Equal(t, tt.expectedValue, actual.Value)
+			assert.Zero(t, actual.Created)
+			assert.NotZero(t, actual.Origin)
+		})
+	}
+}
+
+func TestNewSimpleReadingError(t *testing.T) {
+	tests := []struct {
+		name              string
+		expectedValueType string
+		value             interface{}
+	}{
+		{"Invalid Simple Boolean", v2.ValueTypeBool, 123},
+		{"Invalid Simple String", v2.ValueTypeString, 234},
+		{"Invalid Simple Uint8", v2.ValueTypeUint8, uint32(1234567890)},
+		{"Invalid Simple Uint16", v2.ValueTypeUint16, uint32(1234567890)},
+		{"Invalid Simple Uint32", v2.ValueTypeUint32, uint64(1234567890987654321)},
+		{"Invalid Simple uint64", v2.ValueTypeUint64, int64(1234567890987654321)},
+		{"Invalid Simple int8", v2.ValueTypeInt8, uint8(123)},
+		{"Invalid Simple int16", v2.ValueTypeInt16, uint16(12345)},
+		{"Invalid Simple int32", v2.ValueTypeInt32, uint32(1234567890)},
+		{"Invalid Simple int64", v2.ValueTypeInt64, uint64(1234567890987654321)},
+		{"Invalid Simple Float32", v2.ValueTypeFloat32, float64(123.456)},
+		{"Invalid Simple Float64", v2.ValueTypeFloat64, float32(123456789.0987654321)},
+		{"Invalid Simple Boolean Array", v2.ValueTypeBoolArray, []string{"true", "false"}},
+		{"Invalid Simple String Array", v2.ValueTypeStringArray, []bool{false, true}},
+		{"Invalid Simple Uint8 Array", v2.ValueTypeUint8Array, []int8{123, 21}},
+		{"Invalid Simple Uint16 Array", v2.ValueTypeUint16Array, []int16{12345, 4321}},
+		{"Invalid Simple Uint32 Array", v2.ValueTypeUint32Array, []int32{1234567890, 87654321}},
+		{"Invalid Simple Uint64 Array", v2.ValueTypeUint64Array, []int64{1234567890987654321, 10987654321}},
+		{"Invalid Simple Int8 Array", v2.ValueTypeInt8Array, []uint8{123, 123}},
+		{"Invalid Simple Int16 Array", v2.ValueTypeInt16Array, []uint16{12345, 12345}},
+		{"Invalid Simple Int32 Array", v2.ValueTypeInt32Array, []uint32{1234567890, 1234567890}},
+		{"Invalid Simple Int64 Array", v2.ValueTypeInt64Array, []uint64{1234567890987654321, 1234567890987654321}},
+		{"Invalid Simple Float32 Array", v2.ValueTypeFloat32Array, []float64{123.456, -654.321}},
+		{"Invalid Simple Float64 Array", v2.ValueTypeFloat64Array, []float32{123456789.0987654321, -987654321.123456789}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewSimpleReading(TestDeviceProfileName, TestDeviceName, TestDeviceResourceName, tt.expectedValueType, tt.value)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNewBinaryReading(t *testing.T) {
+	expectedApiVersion := v2.ApiVersion
+	expectedDeviceName := TestDeviceName
+	expectedProfileName := TestDeviceProfileName
+	expectedResourceName := TestDeviceResourceName
+
+	expectedValueType := v2.ValueTypeBinary
+	expectedBinaryValue := []byte("hello word, any one out there?")
+	expectedMediaType := "application/text"
+
+	actual := NewBinaryReading(expectedProfileName, expectedDeviceName, expectedResourceName, expectedBinaryValue, expectedMediaType)
+
+	assert.Equal(t, expectedApiVersion, actual.ApiVersion)
+	assert.NotEmpty(t, actual.Id)
+	assert.Equal(t, expectedProfileName, actual.ProfileName)
+	assert.Equal(t, expectedDeviceName, actual.DeviceName)
+	assert.Equal(t, expectedResourceName, actual.ResourceName)
+	assert.Equal(t, expectedValueType, actual.ValueType)
+	assert.Equal(t, expectedBinaryValue, actual.BinaryValue)
+	assert.Zero(t, actual.Created)
+	assert.NotZero(t, actual.Origin)
 }

--- a/v2/dtos/requests/device_test.go
+++ b/v2/dtos/requests/device_test.go
@@ -36,9 +36,11 @@ var testProtocols = map[string]dtos.ProtocolProperties{
 }
 var testAddDevice = AddDeviceRequest{
 	BaseRequest: common.BaseRequest{
-		RequestId: ExampleUUID,
+		RequestId:   ExampleUUID,
+		Versionable: common.NewVersionable(),
 	},
 	Device: dtos.Device{
+		Versionable:    common.NewVersionable(),
 		Name:           TestDeviceName,
 		ServiceName:    TestDeviceServiceName,
 		ProfileName:    TestDeviceProfileName,
@@ -54,7 +56,8 @@ var testAddDevice = AddDeviceRequest{
 var testNowTime = time.Now().Unix()
 var testUpdateDevice = UpdateDeviceRequest{
 	BaseRequest: common.BaseRequest{
-		RequestId: ExampleUUID,
+		RequestId:   ExampleUUID,
+		Versionable: common.NewVersionable(),
 	},
 	Device: mockUpdateDevice(),
 }
@@ -360,6 +363,7 @@ func TestUpdateDeviceRequest_Validate(t *testing.T) {
 
 func TestUpdateDeviceRequest_UnmarshalJSON_NilField(t *testing.T) {
 	reqJson := `{
+		"apiVersion" : "v2",
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
 		"device":{"name":"TestDevice"}
 	}`
@@ -385,6 +389,7 @@ func TestUpdateDeviceRequest_UnmarshalJSON_NilField(t *testing.T) {
 
 func TestUpdateDeviceRequest_UnmarshalJSON_EmptySlice(t *testing.T) {
 	reqJson := `{
+		"apiVersion" : "v2",
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
 		"device":{
 			"name":"TestDevice",

--- a/v2/dtos/requests/deviceprofile_test.go
+++ b/v2/dtos/requests/deviceprofile_test.go
@@ -52,9 +52,11 @@ func profileData() DeviceProfileRequest {
 	}}
 	return DeviceProfileRequest{
 		BaseRequest: common.BaseRequest{
-			RequestId: ExampleUUID,
+			RequestId:   ExampleUUID,
+			Versionable: common.NewVersionable(),
 		},
 		Profile: dtos.DeviceProfile{
+			Versionable:     common.NewVersionable(),
 			Name:            TestDeviceProfileName,
 			Manufacturer:    TestManufacturer,
 			Description:     TestDescription,

--- a/v2/dtos/requests/deviceservice_test.go
+++ b/v2/dtos/requests/deviceservice_test.go
@@ -20,9 +20,11 @@ import (
 
 var testAddDeviceService = AddDeviceServiceRequest{
 	BaseRequest: common.BaseRequest{
-		RequestId: ExampleUUID,
+		RequestId:   ExampleUUID,
+		Versionable: common.NewVersionable(),
 	},
 	Service: dtos.DeviceService{
+		Versionable: common.NewVersionable(),
 		Name:        TestDeviceServiceName,
 		BaseAddress: TestBaseAddress,
 		Labels:      []string{"MODBUS", "TEMP"},
@@ -32,7 +34,8 @@ var testAddDeviceService = AddDeviceServiceRequest{
 
 var testUpdateDeviceService = UpdateDeviceServiceRequest{
 	BaseRequest: common.BaseRequest{
-		RequestId: ExampleUUID,
+		RequestId:   ExampleUUID,
+		Versionable: common.NewVersionable(),
 	},
 	Service: mockDeviceServiceDTO(),
 }
@@ -277,6 +280,7 @@ func TestUpdateDeviceServiceRequest_UnmarshalJSON_NilField(t *testing.T) {
 
 func TestUpdateDeviceServiceRequest_UnmarshalJSON_EmptySlice(t *testing.T) {
 	reqJson := `{
+		"apiVersion" : "v2",
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
 		"service":{
 			"name":"TestDevice",

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -23,6 +23,17 @@ type AddEventRequest struct {
 	Event              dtos.Event `json:"event" validate:"required"`
 }
 
+// NewAddRequest creates, initializes and returns an AddEventRequest which has no readings
+// Sample usage:
+//    request := NewAddRequest("myProfile", "myDevice")
+//    request.Event.AddSimpleReading("myInt32Resource", v2.ValueTypeInt32, int32(1234))
+func NewAddRequest(profileName string, deviceName string) AddEventRequest {
+	return AddEventRequest{
+		BaseRequest: common.NewBaseRequest(),
+		Event:       dtos.NewEvent(profileName, deviceName),
+	}
+}
+
 // Validate satisfies the Validator interface
 func (a AddEventRequest) Validate() error {
 	if err := v2.Validate(a); err != nil {

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -271,6 +271,7 @@ func TestNewAddRequest(t *testing.T) {
 
 	actual := NewAddRequest(expectedProfileName, expectedDeviceName)
 
+	assert.Equal(t, expectedApiVersion, actual.ApiVersion)
 	assert.NotEmpty(t, actual.RequestId)
 	assert.Equal(t, expectedApiVersion, actual.Event.ApiVersion)
 	assert.NotEmpty(t, actual.Event.Id)

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -8,11 +8,10 @@ package requests
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 
 	"github.com/stretchr/testify/assert"
@@ -20,30 +19,20 @@ import (
 )
 
 func eventRequestData() AddEventRequest {
-	return AddEventRequest{
-		BaseRequest: common.BaseRequest{
-			RequestId: ExampleUUID,
-		},
-		Event: dtos.Event{
-			Id:          ExampleUUID,
-			DeviceName:  TestDeviceName,
-			ProfileName: TestDeviceProfileName,
-			Origin:      TestOriginTime,
-			Readings: []dtos.BaseReading{{
-				DeviceName:   TestDeviceName,
-				ResourceName: TestDeviceResourceName,
-				ProfileName:  TestDeviceProfileName,
-				Origin:       TestOriginTime,
-				ValueType:    v2.ValueTypeUint8,
-				SimpleReading: dtos.SimpleReading{
-					Value: TestReadingValue,
-				},
-			}},
-			Tags: map[string]string{
-				"GatewayId": "Houston-0001",
-			},
-		},
+	request := NewAddRequest(TestDeviceProfileName, TestDeviceName)
+	request.RequestId = ExampleUUID
+	request.Event.Id = ExampleUUID
+	request.Event.Origin = TestOriginTime
+	request.Event.Tags = map[string]string{
+		"GatewayId": "Houston-0001",
 	}
+
+	value, _ := strconv.ParseUint(TestReadingValue, 10, 8)
+	_ = request.Event.AddSimpleReading(TestDeviceResourceName, v2.ValueTypeUint8, uint8(value))
+	request.Event.Readings[0].Id = ExampleUUID
+	request.Event.Readings[0].Origin = TestOriginTime
+
+	return request
 }
 
 func TestAddEventRequest_Validate(t *testing.T) {

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -263,3 +263,20 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 		})
 	}
 }
+
+func TestNewAddRequest(t *testing.T) {
+	expectedProfileName := TestDeviceProfileName
+	expectedDeviceName := TestDeviceName
+	expectedApiVersion := v2.ApiVersion
+
+	actual := NewAddRequest(expectedProfileName, expectedDeviceName)
+
+	assert.NotEmpty(t, actual.RequestId)
+	assert.Equal(t, expectedApiVersion, actual.Event.ApiVersion)
+	assert.NotEmpty(t, actual.Event.Id)
+	assert.Equal(t, expectedProfileName, actual.Event.ProfileName)
+	assert.Equal(t, expectedDeviceName, actual.Event.DeviceName)
+	assert.Zero(t, len(actual.Event.Readings))
+	assert.Zero(t, actual.Event.Created)
+	assert.NotZero(t, actual.Event.Origin)
+}

--- a/v2/dtos/requests/interval_test.go
+++ b/v2/dtos/requests/interval_test.go
@@ -20,14 +20,16 @@ import (
 func addIntervalRequestData() AddIntervalRequest {
 	return AddIntervalRequest{
 		BaseRequest: common.BaseRequest{
-			RequestId: ExampleUUID,
+			RequestId:   ExampleUUID,
+			Versionable: common.NewVersionable(),
 		},
 		Interval: dtos.Interval{
-			Name:      TestIntervalName,
-			Start:     TestIntervalStart,
-			End:       TestIntervalEnd,
-			Frequency: TestIntervalFrequency,
-			RunOnce:   TestIntervalRunOnce,
+			Versionable: common.NewVersionable(),
+			Name:        TestIntervalName,
+			Start:       TestIntervalStart,
+			End:         TestIntervalEnd,
+			Frequency:   TestIntervalFrequency,
+			RunOnce:     TestIntervalRunOnce,
 		},
 	}
 }
@@ -35,7 +37,8 @@ func addIntervalRequestData() AddIntervalRequest {
 func updateIntervalRequestData() UpdateIntervalRequest {
 	return UpdateIntervalRequest{
 		BaseRequest: common.BaseRequest{
-			RequestId: ExampleUUID,
+			RequestId:   ExampleUUID,
+			Versionable: common.NewVersionable(),
 		},
 		Interval: updateIntervalData(),
 	}
@@ -229,6 +232,7 @@ func TestUpdateIntervalRequest_Validate(t *testing.T) {
 
 func TestUpdateIntervalRequest_UnmarshalJSON_NilField(t *testing.T) {
 	reqJson := `{
+		"apiVersion" : "v2",
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
 		"interval":{"name":"TestInterval"}
 	}`

--- a/v2/dtos/requests/provisionwatcher_test.go
+++ b/v2/dtos/requests/provisionwatcher_test.go
@@ -28,9 +28,11 @@ var testBlockingIdentifiers = map[string][]string{
 }
 var testAddProvisionWatcher = AddProvisionWatcherRequest{
 	BaseRequest: common.BaseRequest{
-		RequestId: ExampleUUID,
+		RequestId:   ExampleUUID,
+		Versionable: common.NewVersionable(),
 	},
 	ProvisionWatcher: dtos.ProvisionWatcher{
+		Versionable:         common.NewVersionable(),
 		Name:                testProvisionWatcherName,
 		Labels:              testProvisionWatcherLabels,
 		Identifiers:         testIdentifiers,
@@ -44,7 +46,8 @@ var testAddProvisionWatcher = AddProvisionWatcherRequest{
 
 var testUpdateProvisionWatcher = UpdateProvisionWatcherRequest{
 	BaseRequest: common.BaseRequest{
-		RequestId: ExampleUUID,
+		RequestId:   ExampleUUID,
+		Versionable: common.NewVersionable(),
 	},
 	ProvisionWatcher: mockUpdateProvisionWatcher(),
 }
@@ -56,6 +59,7 @@ func mockUpdateProvisionWatcher() dtos.UpdateProvisionWatcher {
 	testDeviceServiceName := TestDeviceServiceName
 	testProfileName := TestDeviceProfileName
 	d := dtos.UpdateProvisionWatcher{}
+	d.Versionable = common.NewVersionable()
 	d.Id = &testId
 	d.Name = &testName
 	d.Labels = testProvisionWatcherLabels
@@ -278,8 +282,9 @@ func TestUpdateProvisionWatcherRequest_Validate(t *testing.T) {
 
 func TestUpdateProvisionWatcherRequest_UnmarshalJSON_NilField(t *testing.T) {
 	reqJson := `{
+		"apiVersion" : "v2",
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
-		"provisionWatcher":{"name":"test-watcher"}
+		"provisionWatcher":{"apiVersion" : "v2","name":"test-watcher"}
 	}`
 	var req UpdateProvisionWatcherRequest
 
@@ -298,8 +303,10 @@ func TestUpdateProvisionWatcherRequest_UnmarshalJSON_NilField(t *testing.T) {
 
 func TestUpdateProvisionWatcherRequest_UnmarshalJSON_EmptySlice(t *testing.T) {
 	reqJson := `{
+		"apiVersion" : "v2",
         "requestId":"7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
 		"provisionWatcher":{
+			"apiVersion" : "v2",
 			"name":"test-watcher",
 			"labels":[],
 			"autoEvents":[]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
AddEventRequest, Event and Reading DTOs do not have factory methods

## Issue Number: #467


## What is the new behavior?
AddEventRequest, Event and Reading DTOs now have factory methods


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information