### PR TITLE
fix: Ensure ApiVersion is set when converting models to DTOs

### DIFF
--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -72,6 +72,7 @@ func ToDeviceModel(dto Device) models.Device {
 // FromDeviceModelToDTO transforms the Device Model to the Device DTO
 func FromDeviceModelToDTO(d models.Device) Device {
 	var dto Device
+	dto.Versionable = common.NewVersionable()
 	dto.Id = d.Id
 	dto.Name = d.Name
 	dto.Description = d.Description

--- a/v2/dtos/deviceprofile.go
+++ b/v2/dtos/deviceprofile.go
@@ -46,6 +46,7 @@ func ToDeviceProfileModel(deviceProfileDTO DeviceProfile) models.DeviceProfile {
 // FromDeviceProfileModelToDTO transforms the DeviceProfile Model to the DeviceProfile DTO
 func FromDeviceProfileModelToDTO(deviceProfile models.DeviceProfile) DeviceProfile {
 	return DeviceProfile{
+		Versionable:     common.NewVersionable(),
 		Id:              deviceProfile.Id,
 		Name:            deviceProfile.Name,
 		Description:     deviceProfile.Description,

--- a/v2/dtos/deviceprofile_test.go
+++ b/v2/dtos/deviceprofile_test.go
@@ -3,6 +3,7 @@ package dtos
 import (
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,7 @@ var testDeviceProfile = models.DeviceProfile{
 
 func profileData() DeviceProfile {
 	return DeviceProfile{
+		Versionable:  common.NewVersionable(),
 		Name:         TestDeviceProfileName,
 		Manufacturer: TestManufacturer,
 		Description:  TestDescription,

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -53,6 +53,7 @@ func ToDeviceServiceModel(dto DeviceService) models.DeviceService {
 // FromDeviceServiceModelToDTO transforms the DeviceService Model to the DeviceService DTO
 func FromDeviceServiceModelToDTO(ds models.DeviceService) DeviceService {
 	var dto DeviceService
+	dto.Versionable = common.NewVersionable()
 	dto.Id = ds.Id
 	dto.Name = ds.Name
 	dto.Description = ds.Description

--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 
@@ -55,7 +54,7 @@ func FromEventModelToDTO(event models.Event) Event {
 	}
 
 	return Event{
-		Versionable: common.Versionable{ApiVersion: v2.ApiVersion},
+		Versionable: common.NewVersionable(),
 		Id:          event.Id,
 		DeviceName:  event.DeviceName,
 		ProfileName: event.ProfileName,

--- a/v2/dtos/interval.go
+++ b/v2/dtos/interval.go
@@ -50,6 +50,7 @@ func ToIntervalModel(dto Interval) models.Interval {
 // FromIntervalModelToDTO transforms the Interval Model to the Interval DTO
 func FromIntervalModelToDTO(model models.Interval) Interval {
 	var dto Interval
+	dto.Versionable = common.NewVersionable()
 	dto.Id = model.Id
 	dto.Name = model.Name
 	dto.Start = model.Start

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -300,7 +300,7 @@ func FromReadingModelToDTO(reading models.Reading) BaseReading {
 	switch r := reading.(type) {
 	case models.BinaryReading:
 		baseReading = BaseReading{
-			Versionable:   common.Versionable{ApiVersion: v2.ApiVersion},
+			Versionable:   common.NewVersionable(),
 			Id:            r.Id,
 			Created:       r.Created,
 			Origin:        r.Origin,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
ApiVersion not being set on all ToDto helper functions.

## Issue Number: #474


## What is the new behavior?
ApiVersion now being set on all ToDto helper functions that have ApiVersion


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information