### PR TITLE
feat(v2): Adjust DeviceServiceCommandClient interface by moving baseURL as func param

### DIFF
--- a/v2/clients/http/deviceservicecommand.go
+++ b/v2/clients/http/deviceservicecommand.go
@@ -18,34 +18,30 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
 )
 
-type deviceServiceCommandClient struct {
-	baseUrl string
-}
+type deviceServiceCommandClient struct{}
 
 // NewDeviceServiceCommandClient creates an instance of deviceServiceCommandClient
-func NewDeviceServiceCommandClient(baseUrl string) interfaces.DeviceServiceCommandClient {
-	return &deviceServiceCommandClient{
-		baseUrl: baseUrl,
-	}
+func NewDeviceServiceCommandClient() interfaces.DeviceServiceCommandClient {
+	return &deviceServiceCommandClient{}
 }
 
-func (client *deviceServiceCommandClient) ReadCommand(ctx context.Context, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX) {
+func (client *deviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX) {
 	var response responses.EventResponse
 	requestPath := path.Join(v2.ApiDeviceRoute, v2.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
 	queryParams := url.Values{}
 	queryParams.Set(v2.PushEvent, pushEvent)
 	queryParams.Set(v2.ReturnEvent, returnEvent)
-	err := utils.GetRequest(ctx, &response, client.baseUrl, requestPath, queryParams)
+	err := utils.GetRequest(ctx, &response, baseUrl, requestPath, queryParams)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
 	return response, nil
 }
 
-func (client *deviceServiceCommandClient) WriteCommand(ctx context.Context, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
+func (client *deviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
 	requestPath := path.Join(v2.ApiDeviceRoute, v2.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
-	err := utils.PutRequest(ctx, &response, client.baseUrl+requestPath, settings)
+	err := utils.PutRequest(ctx, &response, baseUrl+requestPath, settings)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservicecommand_test.go
+++ b/v2/clients/http/deviceservicecommand_test.go
@@ -42,27 +42,27 @@ var testEventDTO = dtos.Event{
 	},
 }
 
-func TestReadCommand(t *testing.T) {
+func TestGetCommand(t *testing.T) {
 	requestId := uuid.New().String()
 	expectedResponse := responses.NewEventResponse(requestId, "", http.StatusOK, testEventDTO)
 	ts := newTestServer(http.MethodGet, v2.ApiDeviceRoute+"/"+v2.Name+"/"+TestDeviceName+"/"+TestCommandName, expectedResponse)
 	defer ts.Close()
 
-	client := NewDeviceServiceCommandClient(ts.URL)
-	res, err := client.ReadCommand(context.Background(), TestDeviceName, TestCommandName, v2.ValueNo, v2.ValueYes)
+	client := NewDeviceServiceCommandClient()
+	res, err := client.GetCommand(context.Background(), ts.URL, TestDeviceName, TestCommandName, v2.ValueNo, v2.ValueYes)
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedResponse, res)
 }
 
-func TestWriteCommand(t *testing.T) {
+func TestSetCommand(t *testing.T) {
 	requestId := uuid.New().String()
 	expectedResponse := common.NewBaseResponse(requestId, "", http.StatusOK)
 	ts := newTestServer(http.MethodPut, v2.ApiDeviceRoute+"/"+v2.Name+"/"+TestDeviceName+"/"+TestCommandName, expectedResponse)
 	defer ts.Close()
 
-	client := NewDeviceServiceCommandClient(ts.URL)
-	res, err := client.WriteCommand(context.Background(), TestDeviceName, TestCommandName, nil)
+	client := NewDeviceServiceCommandClient()
+	res, err := client.SetCommand(context.Background(), ts.URL, TestDeviceName, TestCommandName, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, requestId, res.RequestId)

--- a/v2/clients/interfaces/deviceservicecommand.go
+++ b/v2/clients/interfaces/deviceservicecommand.go
@@ -13,10 +13,10 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
 )
 
-// DeviceServiceCommandClient defines the interface for interactions with the device command endpoints on the EdgeX Foundry device service.
+// DeviceServiceCommandClient defines the interface for interactions with the device command endpoints on the EdgeX Foundry device services.
 type DeviceServiceCommandClient interface {
-	// ReadCommand invokes device service's command API for issuing read command
-	ReadCommand(ctx context.Context, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX)
-	// WriteCommand invokes device service's command API for issuing write command
-	WriteCommand(ctx context.Context, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX)
+	// GetCommand invokes device service's command API for issuing get(read) command
+	GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX)
+	// SetCommand invokes device service's command API for issuing set(write) command
+	SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX)
 }

--- a/v2/clients/interfaces/mocks/DeviceServiceCommandClient.go
+++ b/v2/clients/interfaces/mocks/DeviceServiceCommandClient.go
@@ -19,20 +19,20 @@ type DeviceServiceCommandClient struct {
 	mock.Mock
 }
 
-// ReadCommand provides a mock function with given fields: ctx, deviceName, commandName, pushEvent, returnEvent
-func (_m *DeviceServiceCommandClient) ReadCommand(ctx context.Context, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX) {
-	ret := _m.Called(ctx, deviceName, commandName, pushEvent, returnEvent)
+// GetCommand provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent
+func (_m *DeviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX) {
+	ret := _m.Called(ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent)
 
 	var r0 responses.EventResponse
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) responses.EventResponse); ok {
-		r0 = rf(ctx, deviceName, commandName, pushEvent, returnEvent)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) responses.EventResponse); ok {
+		r0 = rf(ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent)
 	} else {
 		r0 = ret.Get(0).(responses.EventResponse)
 	}
 
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) errors.EdgeX); ok {
-		r1 = rf(ctx, deviceName, commandName, pushEvent, returnEvent)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, string) errors.EdgeX); ok {
+		r1 = rf(ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)
@@ -42,20 +42,20 @@ func (_m *DeviceServiceCommandClient) ReadCommand(ctx context.Context, deviceNam
 	return r0, r1
 }
 
-// WriteCommand provides a mock function with given fields: ctx, deviceName, commandName, settings
-func (_m *DeviceServiceCommandClient) WriteCommand(ctx context.Context, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
-	ret := _m.Called(ctx, deviceName, commandName, settings)
+// SetCommand provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, settings
+func (_m *DeviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
+	ret := _m.Called(ctx, baseUrl, deviceName, commandName, settings)
 
 	var r0 common.BaseResponse
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]string) common.BaseResponse); ok {
-		r0 = rf(ctx, deviceName, commandName, settings)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, map[string]string) common.BaseResponse); ok {
+		r0 = rf(ctx, baseUrl, deviceName, commandName, settings)
 	} else {
 		r0 = ret.Get(0).(common.BaseResponse)
 	}
 
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, map[string]string) errors.EdgeX); ok {
-		r1 = rf(ctx, deviceName, commandName, settings)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, map[string]string) errors.EdgeX); ok {
+		r1 = rf(ctx, baseUrl, deviceName, commandName, settings)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #479 

## What is the new behavior?
The original DeviceServiceCommandClient interface will use baseUrl as the object field; however, as various device services will have different baseUrl, so we shall move the baseUrl from object field to the parameters of func GetCommand and SetCommand. With such change, a single DeviceServiceCommandClient could interact with various device services.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No