### PR TITLE
fix(meta): Add yml tag for device profile API

### DIFF
--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -38,7 +38,7 @@ type BaseResponse struct {
 
 // Versionable shows the API version in DTOs
 type Versionable struct {
-	ApiVersion string `json:"apiVersion" validate:"required"`
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion" validate:"required"`
 }
 
 // BaseWithIdResponse defines the base content for response DTOs (data transfer objects).

--- a/v2/dtos/deviceprofile.go
+++ b/v2/dtos/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ import (
 // DeviceProfile and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceProfile
 type DeviceProfile struct {
-	common.Versionable `json:",inline"`
+	common.Versionable `json:",inline" yaml:",inline"`
 	Id                 string           `json:"id,omitempty" validate:"omitempty,uuid"`
 	Name               string           `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Manufacturer       string           `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`


### PR DESCRIPTION
Fix #483

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Miss the apiVersion after unmarshaling by yaml lib.

## Issue Number: #483 


## What is the new behavior?
To fix the device profile YAML file post fail, add apiVersion yml tag for unmarshaling.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information