### PR TITLE
feat(v2): Update DeviceServiceCommandClient interface to have queryParams

### DIFF
--- a/v2/clients/http/deviceservicecommand.go
+++ b/v2/clients/http/deviceservicecommand.go
@@ -25,13 +25,14 @@ func NewDeviceServiceCommandClient() interfaces.DeviceServiceCommandClient {
 	return &deviceServiceCommandClient{}
 }
 
-func (client *deviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX) {
+func (client *deviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string) (responses.EventResponse, errors.EdgeX) {
 	var response responses.EventResponse
 	requestPath := path.Join(v2.ApiDeviceRoute, v2.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
-	queryParams := url.Values{}
-	queryParams.Set(v2.PushEvent, pushEvent)
-	queryParams.Set(v2.ReturnEvent, returnEvent)
-	err := utils.GetRequest(ctx, &response, baseUrl, requestPath, queryParams)
+	params, err := url.ParseQuery(queryParams)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	err = utils.GetRequest(ctx, &response, baseUrl, requestPath, params)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservicecommand.go
+++ b/v2/clients/http/deviceservicecommand.go
@@ -39,10 +39,10 @@ func (client *deviceServiceCommandClient) GetCommand(ctx context.Context, baseUr
 	return response, nil
 }
 
-func (client *deviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
+func (client *deviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
 	requestPath := path.Join(v2.ApiDeviceRoute, v2.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
-	err := utils.PutRequest(ctx, &response, baseUrl+requestPath, settings)
+	err := utils.PutRequest(ctx, &response, baseUrl+requestPath+"?"+queryParams, settings)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservicecommand_test.go
+++ b/v2/clients/http/deviceservicecommand_test.go
@@ -49,7 +49,7 @@ func TestGetCommand(t *testing.T) {
 	defer ts.Close()
 
 	client := NewDeviceServiceCommandClient()
-	res, err := client.GetCommand(context.Background(), ts.URL, TestDeviceName, TestCommandName, v2.ValueNo, v2.ValueYes)
+	res, err := client.GetCommand(context.Background(), ts.URL, TestDeviceName, TestCommandName, "")
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedResponse, res)

--- a/v2/clients/http/deviceservicecommand_test.go
+++ b/v2/clients/http/deviceservicecommand_test.go
@@ -62,7 +62,7 @@ func TestSetCommand(t *testing.T) {
 	defer ts.Close()
 
 	client := NewDeviceServiceCommandClient()
-	res, err := client.SetCommand(context.Background(), ts.URL, TestDeviceName, TestCommandName, nil)
+	res, err := client.SetCommand(context.Background(), ts.URL, TestDeviceName, TestCommandName, "", nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, requestId, res.RequestId)

--- a/v2/clients/interfaces/deviceservicecommand.go
+++ b/v2/clients/interfaces/deviceservicecommand.go
@@ -18,5 +18,5 @@ type DeviceServiceCommandClient interface {
 	// GetCommand invokes device service's command API for issuing get(read) command
 	GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string) (responses.EventResponse, errors.EdgeX)
 	// SetCommand invokes device service's command API for issuing set(write) command
-	SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX)
+	SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]string) (common.BaseResponse, errors.EdgeX)
 }

--- a/v2/clients/interfaces/deviceservicecommand.go
+++ b/v2/clients/interfaces/deviceservicecommand.go
@@ -16,7 +16,7 @@ import (
 // DeviceServiceCommandClient defines the interface for interactions with the device command endpoints on the EdgeX Foundry device services.
 type DeviceServiceCommandClient interface {
 	// GetCommand invokes device service's command API for issuing get(read) command
-	GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX)
+	GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string) (responses.EventResponse, errors.EdgeX)
 	// SetCommand invokes device service's command API for issuing set(write) command
 	SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX)
 }

--- a/v2/clients/interfaces/mocks/DeviceServiceCommandClient.go
+++ b/v2/clients/interfaces/mocks/DeviceServiceCommandClient.go
@@ -42,20 +42,20 @@ func (_m *DeviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl st
 	return r0, r1
 }
 
-// SetCommand provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, settings
-func (_m *DeviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
-	ret := _m.Called(ctx, baseUrl, deviceName, commandName, settings)
+// SetCommand provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, queryParams, settings
+func (_m *DeviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
+	ret := _m.Called(ctx, baseUrl, deviceName, commandName, queryParams, settings)
 
 	var r0 common.BaseResponse
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, map[string]string) common.BaseResponse); ok {
-		r0 = rf(ctx, baseUrl, deviceName, commandName, settings)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, map[string]string) common.BaseResponse); ok {
+		r0 = rf(ctx, baseUrl, deviceName, commandName, queryParams, settings)
 	} else {
 		r0 = ret.Get(0).(common.BaseResponse)
 	}
 
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, map[string]string) errors.EdgeX); ok {
-		r1 = rf(ctx, baseUrl, deviceName, commandName, settings)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, map[string]string) errors.EdgeX); ok {
+		r1 = rf(ctx, baseUrl, deviceName, commandName, queryParams, settings)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)

--- a/v2/clients/interfaces/mocks/DeviceServiceCommandClient.go
+++ b/v2/clients/interfaces/mocks/DeviceServiceCommandClient.go
@@ -19,20 +19,20 @@ type DeviceServiceCommandClient struct {
 	mock.Mock
 }
 
-// GetCommand provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent
-func (_m *DeviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, pushEvent string, returnEvent string) (responses.EventResponse, errors.EdgeX) {
-	ret := _m.Called(ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent)
+// GetCommand provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, queryParams
+func (_m *DeviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string) (responses.EventResponse, errors.EdgeX) {
+	ret := _m.Called(ctx, baseUrl, deviceName, commandName, queryParams)
 
 	var r0 responses.EventResponse
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) responses.EventResponse); ok {
-		r0 = rf(ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) responses.EventResponse); ok {
+		r0 = rf(ctx, baseUrl, deviceName, commandName, queryParams)
 	} else {
 		r0 = ret.Get(0).(responses.EventResponse)
 	}
 
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, string) errors.EdgeX); ok {
-		r1 = rf(ctx, baseUrl, deviceName, commandName, pushEvent, returnEvent)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) errors.EdgeX); ok {
+		r1 = rf(ctx, baseUrl, deviceName, commandName, queryParams)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #485 

## What is the new behavior?
The current DeviceServicCommandClient interface only specify pushEvent and returnEvent as part of func GetCommand signature, which is not properly handling user specified query parameters. The DeviceServicCommandClient interface shall update its GetCommand signature to have queryParams so that all query params could be passed to device service for further processing.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No