### PR TITLE
refactor(meta): Profile add UnmarshalYAML func and rename Type field

### DIFF
--- a/v2/dtos/deviceprofile_test.go
+++ b/v2/dtos/deviceprofile_test.go
@@ -34,7 +34,7 @@ var testDeviceProfile = models.DeviceProfile{
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: models.PropertyValue{
-			Type:      "INT16",
+			ValueType: v2.ValueTypeInt16,
 			ReadWrite: "RW",
 		},
 	}},
@@ -68,7 +68,7 @@ func profileData() DeviceProfile {
 			Tag:         TestTag,
 			Attributes:  testAttributes,
 			Properties: PropertyValue{
-				Type:      "INT16",
+				ValueType: v2.ValueTypeInt16,
 				ReadWrite: "RW",
 			},
 		}},
@@ -149,7 +149,7 @@ deviceResources:
   -  
     name: "DeviceValue_Boolean_RW"
     properties:
-      { type: "BOOL"}
+      { valueType: "Bool"}
 deviceCommands:
   -  
     name: "GenerateDeviceValue_Boolean_RW"
@@ -162,7 +162,7 @@ deviceResources:
   -  
     name: "DeviceValue_Boolean_RW"
     properties:
-      { type: "BOOL"}
+      { valueType: "Bool"}
 deviceCommands:
   -  
     name: "GenerateDeviceValue_Boolean_RW"
@@ -183,12 +183,39 @@ deviceCommands:
 		t.Run(tt.name, func(t *testing.T) {
 			var dp DeviceProfile
 			err := yaml.Unmarshal(tt.data, &dp)
-			require.NoError(t, err)
-			err = v2.Validate(dp)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAddDeviceProfile_UnmarshalYAML(t *testing.T) {
+	valid := profileData()
+	resultTestBytes, _ := yaml.Marshal(profileData())
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name     string
+		expected DeviceProfile
+		args     args
+		wantErr  bool
+	}{
+		{"valid", valid, args{resultTestBytes}, false},
+		{"invalid", DeviceProfile{}, args{[]byte("Invalid DeviceProfile")}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dp DeviceProfile
+			err := yaml.Unmarshal(tt.args.data, &dp)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, dp, "Unmarshal did not result in expected DeviceProfileRequest.")
 			}
 		})
 	}

--- a/v2/dtos/propertyvalue.go
+++ b/v2/dtos/propertyvalue.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 // PropertyValue and its properties care defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/PropertyValue
 type PropertyValue struct {
-	Type         string `json:"type" yaml:"type" validate:"required,edgex-dto-value-type"`
+	ValueType    string `json:"valueType" yaml:"valueType" validate:"required,edgex-dto-value-type"`
 	ReadWrite    string `json:"readWrite,omitempty" yaml:"readWrite,omitempty"`
 	Units        string `json:"units,omitempty" yaml:"units,omitempty"`
 	Minimum      string `json:"minimum,omitempty" yaml:"minimum,omitempty"`
@@ -28,7 +28,7 @@ type PropertyValue struct {
 // ToPropertyValueModel transforms the PropertyValue DTO to the PropertyValue model
 func ToPropertyValueModel(p PropertyValue) models.PropertyValue {
 	return models.PropertyValue{
-		Type:         p.Type,
+		ValueType:    p.ValueType,
 		ReadWrite:    p.ReadWrite,
 		Units:        p.Units,
 		Minimum:      p.Minimum,
@@ -47,7 +47,7 @@ func ToPropertyValueModel(p PropertyValue) models.PropertyValue {
 // FromPropertyValueModelToDTO transforms the PropertyValue Model to the PropertyValue DTO
 func FromPropertyValueModelToDTO(p models.PropertyValue) PropertyValue {
 	return PropertyValue{
-		Type:         p.Type,
+		ValueType:    p.ValueType,
 		ReadWrite:    p.ReadWrite,
 		Units:        p.Units,
 		Minimum:      p.Minimum,

--- a/v2/dtos/requests/deviceprofile.go
+++ b/v2/dtos/requests/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,7 +7,6 @@ package requests
 
 import (
 	"encoding/json"
-	"gopkg.in/yaml.v2"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
@@ -52,39 +51,11 @@ func (dp *DeviceProfileRequest) UnmarshalJSON(b []byte) error {
 
 	// Normalize resource's value type
 	for i, resource := range dp.Profile.DeviceResources {
-		valueType, err := v2.NormalizeValueType(resource.Properties.Type)
+		valueType, err := v2.NormalizeValueType(resource.Properties.ValueType)
 		if err != nil {
 			return errors.NewCommonEdgeXWrapper(err)
 		}
-		dp.Profile.DeviceResources[i].Properties.Type = valueType
-	}
-	return nil
-}
-
-// UnmarshalYAML implements the Unmarshaler interface for the DeviceProfileRequest type
-func (dp *DeviceProfileRequest) UnmarshalYAML(b []byte) error {
-	var alias struct {
-		common.BaseRequest
-		Profile dtos.DeviceProfile
-	}
-	if err := yaml.Unmarshal(b, &alias); err != nil {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal request body as YAML.", err)
-	}
-
-	*dp = DeviceProfileRequest(alias)
-
-	// validate DeviceProfileRequest DTO
-	if err := dp.Validate(); err != nil {
-		return err
-	}
-
-	// Normalize resource's value type
-	for i, resource := range dp.Profile.DeviceResources {
-		valueType, err := v2.NormalizeValueType(resource.Properties.Type)
-		if err != nil {
-			return errors.NewCommonEdgeXWrapper(err)
-		}
-		dp.Profile.DeviceResources[i].Properties.Type = valueType
+		dp.Profile.DeviceResources[i].Properties.ValueType = valueType
 	}
 	return nil
 }

--- a/v2/dtos/requests/deviceprofile_test.go
+++ b/v2/dtos/requests/deviceprofile_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +8,6 @@ package requests
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
@@ -32,7 +31,7 @@ func profileData() DeviceProfileRequest {
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: dtos.PropertyValue{
-			Type:      v2.ValueTypeInt16,
+			ValueType: v2.ValueTypeInt16,
 			ReadWrite: "RW",
 		},
 	}}
@@ -81,7 +80,7 @@ var expectedDeviceProfile = models.DeviceProfile{
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: models.PropertyValue{
-			Type:      v2.ValueTypeInt16,
+			ValueType: v2.ValueTypeInt16,
 			ReadWrite: "RW",
 		},
 	}},
@@ -111,9 +110,9 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 	noDeviceResourceName := profileData()
 	noDeviceResourceName.Profile.DeviceResources[0].Name = emptyString
 	noDeviceResourcePropertyType := profileData()
-	noDeviceResourcePropertyType.Profile.DeviceResources[0].Properties.Type = emptyString
+	noDeviceResourcePropertyType.Profile.DeviceResources[0].Properties.ValueType = emptyString
 	invalidDeviceResourcePropertyType := profileData()
-	invalidDeviceResourcePropertyType.Profile.DeviceResources[0].Properties.Type = "BadType"
+	invalidDeviceResourcePropertyType.Profile.DeviceResources[0].Properties.ValueType = "BadType"
 	noCommandName := profileData()
 	noCommandName.Profile.CoreCommands[0].Name = emptyString
 	noEnabledCommand := profileData()
@@ -166,11 +165,11 @@ func TestAddDeviceProfile_UnmarshalJSON(t *testing.T) {
 	validData, err := json.Marshal(profileData())
 	require.NoError(t, err)
 	validValueTypeLowerCase := profileData()
-	validValueTypeLowerCase.Profile.DeviceResources[0].Properties.Type = "int16"
+	validValueTypeLowerCase.Profile.DeviceResources[0].Properties.ValueType = "int16"
 	validValueTypeLowerCaseData, err := json.Marshal(validValueTypeLowerCase)
 	require.NoError(t, err)
 	validValueTypeUpperCase := profileData()
-	validValueTypeUpperCase.Profile.DeviceResources[0].Properties.Type = "INT16"
+	validValueTypeUpperCase.Profile.DeviceResources[0].Properties.ValueType = "INT16"
 	validValueTypeUpperCaseData, err := json.Marshal(validValueTypeUpperCase)
 	require.NoError(t, err)
 
@@ -194,37 +193,6 @@ func TestAddDeviceProfile_UnmarshalJSON(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, expected, dp, "Unmarshal did not result in expected DeviceProfileRequest.")
-			}
-		})
-	}
-}
-
-func TestAddDeviceProfile_UnmarshalYAML(t *testing.T) {
-	valid := profileData()
-	resultTestBytes, _ := yaml.Marshal(profileData())
-	type args struct {
-		data []byte
-	}
-	tests := []struct {
-		name     string
-		expected DeviceProfileRequest
-		args     args
-		wantErr  bool
-	}{
-		{"unmarshal DeviceProfileRequest with success", valid, args{resultTestBytes}, false},
-		{"unmarshal invalid DeviceProfileRequest, empty data", DeviceProfileRequest{}, args{[]byte{}}, true},
-		{"unmarshal invalid DeviceProfileRequest, string data", DeviceProfileRequest{}, args{[]byte("Invalid DeviceProfileRequest")}, true},
-	}
-	fmt.Println(string(resultTestBytes))
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var dp DeviceProfileRequest
-			err := dp.UnmarshalYAML(tt.args.data)
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, dp, "Unmarshal did not result in expected DeviceProfileRequest.")
 			}
 		})
 	}

--- a/v2/models/propertyvalue.go
+++ b/v2/models/propertyvalue.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ const (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/PropertyValue
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type PropertyValue struct {
-	Type         string
+	ValueType    string
 	ReadWrite    string
 	Units        string
 	Minimum      string


### PR DESCRIPTION
Close #289

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #289


## What is the new behavior?
- Profile DTO add UnmarshalYAML func for POST /deviceprofile/uploadfile API
- Rename PropertyValue's Type field to ValueType.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information