### PR TITLE
fix(v2): Refine the ReplaceSubscriptionModelFieldsWithDTO func

### DIFF
--- a/v2/dtos/requests/subscription.go
+++ b/v2/dtos/requests/subscription.go
@@ -107,6 +107,12 @@ func ReplaceSubscriptionModelFieldsWithDTO(s *models.Subscription, patch dtos.Up
 	if patch.Receiver != nil {
 		s.Receiver = *patch.Receiver
 	}
+	if patch.ResendLimit != nil {
+		s.ResendLimit = *patch.ResendLimit
+	}
+	if patch.ResendInterval != nil {
+		s.ResendInterval = *patch.ResendInterval
+	}
 }
 
 func NewAddSubscriptionRequest(dto dtos.Subscription) AddSubscriptionRequest {

--- a/v2/dtos/requests/subscription_test.go
+++ b/v2/dtos/requests/subscription_test.go
@@ -300,3 +300,21 @@ func TestUpdateSubscriptionRequest_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceSubscriptionModelFieldsWithDTO(t *testing.T) {
+	subscription := models.Subscription{
+		Id:   "7a1707f0-166f-4c4b-bc9d-1d54c74e0137",
+		Name: "name",
+	}
+	patch := updateSubscriptionData()
+
+	ReplaceSubscriptionModelFieldsWithDTO(&subscription, patch)
+
+	assert.Equal(t, dtos.ToCategoryModels(testSubscriptionCategories), subscription.Categories)
+	assert.Equal(t, testSubscriptionLabels, subscription.Labels)
+	assert.Equal(t, dtos.ToChannelModels(testSubscriptionChannels), subscription.Channels)
+	assert.Equal(t, testSubscriptionDescription, subscription.Description)
+	assert.Equal(t, testSubscriptionReceiver, subscription.Receiver)
+	assert.Equal(t, testSubscriptionResendLimit, subscription.ResendLimit)
+	assert.Equal(t, testSubscriptionResendInterval, subscription.ResendInterval)
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
ReplaceSubscriptionModelFieldsWithDTO function is missing the process of replacing the ResendLimit and ResendInterval fields.

## Issue Number: #500 


## What is the new behavior?
Added replacements of the ResendLimit and ResendInterval fields.

Close #500

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
