### PR TITLE
feat(v2): refactor CoreCommand DTO to DeviceCoreCommand

### DIFF
--- a/v2/dtos/corecommand.go
+++ b/v2/dtos/corecommand.go
@@ -5,13 +5,20 @@
 
 package dtos
 
+// DeviceCoreCommand and its properties are defined in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/DeviceCoreCommand
+type DeviceCoreCommand struct {
+	DeviceName   string        `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName  string        `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	CoreCommands []CoreCommand `json:"coreCommands,omitempty" validate:"dive"`
+}
+
 // CoreCommand and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/CoreCommand
 type CoreCommand struct {
-	Name       string `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	DeviceName string `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	Get        bool   `json:"get,omitempty" validate:"required_without=Set"`
-	Set        bool   `json:"set,omitempty" validate:"required_without=Get"`
-	Path       string `json:"path,omitempty"`
-	Url        string `json:"url,omitempty"`
+	Name string `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Get  bool   `json:"get,omitempty" validate:"required_without=Set"`
+	Set  bool   `json:"set,omitempty" validate:"required_without=Get"`
+	Path string `json:"path,omitempty"`
+	Url  string `json:"url,omitempty"`
 }

--- a/v2/dtos/responses/corecommand.go
+++ b/v2/dtos/responses/corecommand.go
@@ -10,17 +10,32 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 )
 
-// MultiCoreCommandsResponse defines the Response Content for GET multiple CoreCommand DTOs.
-// This object and its properties correspond to the MultiCoreCommandsResponse object in the APIv2 specification:
-// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/MultiCoreCommandsResponse
-type MultiCoreCommandsResponse struct {
+// DeviceCoreCommandResponse defines the Response Content for GET DeviceCoreCommand DTO.
+// This object and its properties correspond to the DeviceCoreCommandResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/DeviceCoreCommandResponse
+type DeviceCoreCommandResponse struct {
 	common.BaseResponse `json:",inline"`
-	CoreCommands        []dtos.CoreCommand `json:"coreCommands"`
+	DeviceCoreCommand   dtos.DeviceCoreCommand `json:"deviceCoreCommand"`
 }
 
-func NewMultiCoreCommandsResponse(requestId string, message string, statusCode int, commands []dtos.CoreCommand) MultiCoreCommandsResponse {
-	return MultiCoreCommandsResponse{
-		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
-		CoreCommands: commands,
+func NewDeviceCoreCommandResponse(requestId string, message string, statusCode int, deviceCoreCommand dtos.DeviceCoreCommand) DeviceCoreCommandResponse {
+	return DeviceCoreCommandResponse{
+		BaseResponse:      common.NewBaseResponse(requestId, message, statusCode),
+		DeviceCoreCommand: deviceCoreCommand,
+	}
+}
+
+// MultiDeviceCoreCommandsResponse defines the Response Content for GET multiple DeviceCoreCommand DTOs.
+// This object and its properties correspond to the MultiDeviceCoreCommandsResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/MultiDeviceCoreCommandsResponse
+type MultiDeviceCoreCommandsResponse struct {
+	common.BaseResponse `json:",inline"`
+	DeviceCoreCommands  []dtos.DeviceCoreCommand `json:"deviceCoreCommands"`
+}
+
+func NewMultiDeviceCoreCommandsResponse(requestId string, message string, statusCode int, commands []dtos.DeviceCoreCommand) MultiDeviceCoreCommandsResponse {
+	return MultiDeviceCoreCommandsResponse{
+		BaseResponse:       common.NewBaseResponse(requestId, message, statusCode),
+		DeviceCoreCommands: commands,
 	}
 }

--- a/v2/dtos/responses/corecommand_test.go
+++ b/v2/dtos/responses/corecommand_test.go
@@ -13,18 +13,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewMultiCoreCommandsResponse(t *testing.T) {
+func TestNewDeviceCoreCommandResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := http.StatusOK
 	expectedMessage := "unit test message"
-	expectedCommands := []dtos.CoreCommand{
-		{Name: "testCommand1", DeviceName: "testDevice1", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
-		{Name: "testCommand2", DeviceName: "testDevice1", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+	expectedDeviceCoreCommand := dtos.DeviceCoreCommand{
+		DeviceName:  "testDevice1",
+		ProfileName: "testProfile",
+		CoreCommands: []dtos.CoreCommand{
+			{Name: "testCommand1", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
+			{Name: "testCommand2", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+		},
 	}
-	actual := NewMultiCoreCommandsResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedCommands)
+	actual := NewDeviceCoreCommandResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedDeviceCoreCommand)
 
 	assert.Equal(t, expectedRequestId, actual.RequestId)
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
-	assert.Equal(t, expectedCommands, actual.CoreCommands)
+	assert.Equal(t, expectedDeviceCoreCommand, actual.DeviceCoreCommand)
+}
+
+func TestNewMultiDeviceCoreCommandsResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := http.StatusOK
+	expectedMessage := "unit test message"
+	expectedDeviceCoreCommands := []dtos.DeviceCoreCommand{
+		dtos.DeviceCoreCommand{
+			DeviceName:  "testDevice1",
+			ProfileName: "testProfile",
+			CoreCommands: []dtos.CoreCommand{
+				{Name: "testCommand1", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
+				{Name: "testCommand2", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+			},
+		},
+		dtos.DeviceCoreCommand{
+			DeviceName:  "testDevice2",
+			ProfileName: "testProfile",
+			CoreCommands: []dtos.CoreCommand{
+				{Name: "testCommand3", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
+				{Name: "testCommand4", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+			},
+		},
+	}
+	actual := NewMultiDeviceCoreCommandsResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedDeviceCoreCommands)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedDeviceCoreCommands, actual.DeviceCoreCommands)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #506 

## What is the new behavior?
The original CoreCommand DTO has field "DeviceName" to indicate which
device the command belongs to; however, the "DeviceName" becomes
redundant when query commands by deviceName, as each CoreCommand DTO
returned includes the same value of DeviceName.  As a result, this
commit refactor the CoreCommand DTO by extracting DeviceName up to a
level, so a single new DeviceCoreCommand DTO will have DeviceName and
ProfileName on the top level, and multiple CoreCommands in the bottom
level.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No