### PR TITLE
fix: Fix float reading encoding to be simple E-Notation

### DIFF
--- a/v2/dtos/event_test.go
+++ b/v2/dtos/event_test.go
@@ -102,7 +102,7 @@ func TestEvent_AddSimpleReading(t *testing.T) {
 		value        string
 	}{
 		{int32(12345), "myInt32", v2.ValueTypeInt32, "12345"},
-		{float32(12345.4567), "myFloat32", v2.ValueTypeFloat32, "RkDl1A=="},
+		{float32(12345.4567), "myFloat32", v2.ValueTypeFloat32, "1.234546e+04"},
 		{[]bool{false, true, false}, "myBoolArray", v2.ValueTypeBoolArray, "[false, true, false]"},
 	}
 	expectedReadingsCount := len(expectedReadingDetails)

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -6,9 +6,6 @@
 package dtos
 
 import (
-	"bytes"
-	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	"reflect"
 	"strings"
@@ -171,11 +168,7 @@ func convertFloatValue(valueType string, kind reflect.Kind, value interface{}) (
 		return "", err
 	}
 
-	buf := new(bytes.Buffer)
-	if err := binary.Write(buf, binary.BigEndian, value); err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+	return fmt.Sprintf("%e", value), nil
 }
 
 func convertSimpleArrayValue(valueType string, kind reflect.Kind, value interface{}) (string, error) {

--- a/v2/dtos/reading_test.go
+++ b/v2/dtos/reading_test.go
@@ -118,8 +118,8 @@ func TestNewSimpleReading(t *testing.T) {
 		{"Simple int16", v2.ValueTypeInt16, int16(-12345), "-12345"},
 		{"Simple int32", v2.ValueTypeInt32, int32(-1234567890), "-1234567890"},
 		{"Simple int64", v2.ValueTypeInt64, int64(-1234567890987654321), "-1234567890987654321"},
-		{"Simple Float32", v2.ValueTypeFloat32, float32(123.456), "QvbpeQ=="},
-		{"Simple Float64", v2.ValueTypeFloat64, float64(123456789.0987654321), "QZ1vNFRlIsQ="},
+		{"Simple Float32", v2.ValueTypeFloat32, float32(123.456), "1.234560e+02"},
+		{"Simple Float64", v2.ValueTypeFloat64, float64(123456789.0987654321), "1.234568e+08"},
 		{"Simple Boolean Array", v2.ValueTypeBoolArray, []bool{true, false}, "[true, false]"},
 		{"Simple String Array", v2.ValueTypeStringArray, []string{"hello", "world"}, "[hello, world]"},
 		{"Simple Uint8 Array", v2.ValueTypeUint8Array, []uint8{123, 21}, "[123, 21]"},
@@ -130,8 +130,8 @@ func TestNewSimpleReading(t *testing.T) {
 		{"Simple Int16 Array", v2.ValueTypeInt16Array, []int16{-12345, 12345}, "[-12345, 12345]"},
 		{"Simple Int32 Array", v2.ValueTypeInt32Array, []int32{-1234567890, 1234567890}, "[-1234567890, 1234567890]"},
 		{"Simple Int64 Array", v2.ValueTypeInt64Array, []int64{-1234567890987654321, 1234567890987654321}, "[-1234567890987654321, 1234567890987654321]"},
-		{"Simple Float32 Array", v2.ValueTypeFloat32Array, []float32{123.456, -654.321}, "[QvbpeQ==, xCOUiw=="},
-		{"Simple Float64 Array", v2.ValueTypeFloat64Array, []float64{123456789.0987654321, -987654321.123456789}, "[QZ1vNFRlIsQ=, wc1vNFiPzW8="},
+		{"Simple Float32 Array", v2.ValueTypeFloat32Array, []float32{123.456, -654.321}, "[1.234560e+02, -6.543210e+02"},
+		{"Simple Float64 Array", v2.ValueTypeFloat64Array, []float64{123456789.0987654321, -987654321.123456789}, "[1.234568e+08, -9.876543e+08"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
Floats are being Base64 encoded

## Issue Number: #508

## What is the new behavior?
Floats are now E-Notation encoded

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information