### PR TITLE
fix(v2): Add missing validation tag to Subscription DTO

### DIFF
--- a/v2/dtos/requests/subscription_test.go
+++ b/v2/dtos/requests/subscription_test.go
@@ -114,9 +114,13 @@ func TestAddSubscriptionRequest_Validate(t *testing.T) {
 		{Type: models.Rest, Url: "http127.0.0.1"},
 	}
 
+	noCategories := addSubscriptionRequestData()
+	noCategories.Subscription.Categories = nil
+	noLabels := addSubscriptionRequestData()
+	noLabels.Subscription.Labels = nil
 	noCategoriesAndLabels := addSubscriptionRequestData()
-	noCategoriesAndLabels.Subscription.Categories = []string{}
-	noCategoriesAndLabels.Subscription.Labels = []string{}
+	noCategoriesAndLabels.Subscription.Categories = nil
+	noCategoriesAndLabels.Subscription.Labels = nil
 	invalidCategory := addSubscriptionRequestData()
 	invalidCategory.Subscription.Categories = []string{unsupportedCategory}
 
@@ -135,6 +139,8 @@ func TestAddSubscriptionRequest_Validate(t *testing.T) {
 	}{
 		{"valid", valid, false},
 		{"valid, no request ID", noReqId, false},
+		{"valid, no categories specified", noCategories, false},
+		{"valid, no labels specified", noLabels, false},
 		{"invalid, request ID is not an UUID", invalidReqId, true},
 		{"invalid, no subscription name", noSubscriptionName, true},
 		{"invalid, subscription name containing reserved chars", subscriptionNameWithReservedChars, true},

--- a/v2/dtos/subscription.go
+++ b/v2/dtos/subscription.go
@@ -18,8 +18,8 @@ type Subscription struct {
 	Name               string    `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Channels           []Channel `json:"channels" validate:"required,gt=0,dive"`
 	Receiver           string    `json:"receiver" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Categories         []string  `json:"categories,omitempty" validate:"required_without=Labels,gt=0,dive,oneof='SECURITY' 'SW_HEALTH' 'HW_HEALTH'"`
-	Labels             []string  `json:"labels,omitempty" validate:"required_without=Categories,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Categories         []string  `json:"categories,omitempty" validate:"required_without=Labels,omitempty,gt=0,dive,oneof='SECURITY' 'SW_HEALTH' 'HW_HEALTH'"`
+	Labels             []string  `json:"labels,omitempty" validate:"required_without=Categories,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Created            int64     `json:"created,omitempty"`
 	Modified           int64     `json:"modified,omitempty"`
 	Description        string    `json:"description,omitempty"`


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Both `Categories` and `Labels` fields are required when adding a new Subscription.

## Issue Number: #515 


## What is the new behavior?
Added `omitempty` after `required_without` so that the validator can work as expected.

Close #515 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
