### PR TITLE
fix: Check empty value when converting Model to UpdateDTO

### DIFF
--- a/v2/clients/http/utils/common.go
+++ b/v2/clients/http/utils/common.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 
 	"github.com/google/uuid"
 )
@@ -150,15 +149,7 @@ func sendRequest(ctx context.Context, req *http.Request) ([]byte, errors.EdgeX) 
 	}
 
 	// Handle error response
-	if resp.StatusCode == http.StatusNotFound {
-		msg := fmt.Sprintf("request failed, status code: %d, err: %s", resp.StatusCode, string(bodyBytes))
-		return nil, errors.NewCommonEdgeX(errors.KindMapping(resp.StatusCode), msg, nil)
-	}
-	var res common.BaseResponse
-	if err := json.Unmarshal(bodyBytes, &res); err != nil {
-		return nil, errors.NewCommonEdgeXWrapper(err)
-	}
-	msg := fmt.Sprintf("request failed, status code: %d, err: %s", res.StatusCode, res.Message)
-	errKind := errors.KindMapping(res.StatusCode)
+	msg := fmt.Sprintf("request failed, status code: %d, err: %s", resp.StatusCode, string(bodyBytes))
+	errKind := errors.KindMapping(resp.StatusCode)
 	return nil, errors.NewCommonEdgeX(errKind, msg, nil)
 }

--- a/v2/clients/http/utils/common.go
+++ b/v2/clients/http/utils/common.go
@@ -150,6 +150,10 @@ func sendRequest(ctx context.Context, req *http.Request) ([]byte, errors.EdgeX) 
 	}
 
 	// Handle error response
+	if resp.StatusCode == http.StatusNotFound {
+		msg := fmt.Sprintf("request failed, status code: %d, err: %s", resp.StatusCode, string(bodyBytes))
+		return nil, errors.NewCommonEdgeX(errors.KindMapping(resp.StatusCode), msg, nil)
+	}
 	var res common.BaseResponse
 	if err := json.Unmarshal(bodyBytes, &res); err != nil {
 		return nil, errors.NewCommonEdgeXWrapper(err)

--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -92,23 +92,48 @@ func FromDeviceModelToDTO(d models.Device) Device {
 
 // FromDeviceModelToUpdateDTO transforms the Device Model to the UpdateDevice DTO
 func FromDeviceModelToUpdateDTO(d models.Device) UpdateDevice {
-	adminState := string(d.AdminState)
-	operatingState := string(d.OperatingState)
-	return UpdateDevice{
-		Versionable:    common.NewVersionable(),
-		Id:             &d.Id,
-		Name:           &d.Name,
-		Description:    &d.Description,
-		AdminState:     &adminState,
-		OperatingState: &operatingState,
-		LastConnected:  &d.LastConnected,
-		LastReported:   &d.LastReported,
-		ServiceName:    &d.ServiceName,
-		ProfileName:    &d.ProfileName,
-		Labels:         d.Labels,
-		Location:       d.Location,
-		AutoEvents:     FromAutoEventModelsToDTOs(d.AutoEvents),
-		Protocols:      FromProtocolModelsToDTOs(d.Protocols),
-		Notify:         &d.Notify,
+	dto := UpdateDevice{
+		Versionable: common.NewVersionable(),
+		Labels:      d.Labels,
+		Notify:      &d.Notify,
 	}
+	if d.Id != "" {
+		dto.Id = &d.Id
+	}
+	if d.Name != "" {
+		dto.Name = &d.Name
+	}
+	if d.Description != "" {
+		dto.Description = &d.Description
+	}
+	if d.AdminState != "" {
+		adminState := string(d.AdminState)
+		dto.AdminState = &adminState
+	}
+	if d.OperatingState != "" {
+		operatingState := string(d.OperatingState)
+		dto.OperatingState = &operatingState
+	}
+	if d.LastConnected != 0 {
+		dto.LastConnected = &d.LastConnected
+	}
+	if d.LastReported != 0 {
+		dto.LastReported = &d.LastReported
+	}
+	if d.ServiceName != "" {
+		dto.ServiceName = &d.ServiceName
+	}
+	if d.ProfileName != "" {
+		dto.ProfileName = &d.ProfileName
+	}
+	if d.Location != nil {
+		dto.Location = d.Location
+	}
+	if d.AutoEvents != nil {
+		dto.AutoEvents = FromAutoEventModelsToDTOs(d.AutoEvents)
+	}
+	if d.Protocols != nil {
+		dto.Protocols = FromProtocolModelsToDTOs(d.Protocols)
+	}
+	return dto
 }

--- a/v2/dtos/device_test.go
+++ b/v2/dtos/device_test.go
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dtos
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromDeviceModelToUpdateDTO(t *testing.T) {
+	model := models.Device{}
+	dto := FromDeviceModelToUpdateDTO(model)
+	assert.Equal(t, v2.ApiVersion, dto.ApiVersion)
+	assert.Nil(t, dto.Id)
+	assert.Nil(t, dto.Name)
+	assert.Nil(t, dto.Description)
+	assert.Nil(t, dto.AdminState)
+	assert.Nil(t, dto.OperatingState)
+	assert.Nil(t, dto.LastConnected)
+	assert.Nil(t, dto.LastReported)
+	assert.Nil(t, dto.ServiceName)
+	assert.Nil(t, dto.ProfileName)
+	assert.Nil(t, dto.Location)
+	assert.Nil(t, dto.AutoEvents)
+	assert.Nil(t, dto.Protocols)
+}

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -68,13 +68,22 @@ func FromDeviceServiceModelToDTO(ds models.DeviceService) DeviceService {
 
 // FromDeviceServiceModelToUpdateDTO transforms the DeviceService Model to the UpdateDeviceService DTO
 func FromDeviceServiceModelToUpdateDTO(ds models.DeviceService) UpdateDeviceService {
-	adminState := string(ds.AdminState)
-	return UpdateDeviceService{
+	dto := UpdateDeviceService{
 		Versionable: common.NewVersionable(),
-		Id:          &ds.Id,
-		Name:        &ds.Name,
-		BaseAddress: &ds.BaseAddress,
 		Labels:      ds.Labels,
-		AdminState:  &adminState,
 	}
+	if ds.Id != "" {
+		dto.Id = &ds.Id
+	}
+	if ds.Name != "" {
+		dto.Name = &ds.Name
+	}
+	if ds.BaseAddress != "" {
+		dto.BaseAddress = &ds.BaseAddress
+	}
+	if ds.AdminState != "" {
+		adminState := string(ds.AdminState)
+		dto.AdminState = &adminState
+	}
+	return dto
 }

--- a/v2/dtos/deviceservice_test.go
+++ b/v2/dtos/deviceservice_test.go
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dtos
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromDeviceServiceModelToUpdateDTO(t *testing.T) {
+	model := models.DeviceService{}
+	dto := FromDeviceServiceModelToUpdateDTO(model)
+	assert.Equal(t, v2.ApiVersion, dto.ApiVersion)
+	assert.Nil(t, dto.Id)
+	assert.Nil(t, dto.Name)
+	assert.Nil(t, dto.Labels)
+	assert.Nil(t, dto.BaseAddress)
+	assert.Nil(t, dto.AdminState)
+}

--- a/v2/dtos/provisionwatcher.go
+++ b/v2/dtos/provisionwatcher.go
@@ -74,17 +74,30 @@ func FromProvisionWatcherModelToDTO(pw models.ProvisionWatcher) ProvisionWatcher
 
 // FromProvisionWatcherModelToUpdateDTO transforms the ProvisionWatcher Model to the UpdateProvisionWatcher DTO
 func FromProvisionWatcherModelToUpdateDTO(pw models.ProvisionWatcher) UpdateProvisionWatcher {
-	adminState := string(pw.AdminState)
-	return UpdateProvisionWatcher{
+	dto := UpdateProvisionWatcher{
 		Versionable:         common.NewVersionable(),
-		Id:                  &pw.Id,
-		Name:                &pw.Name,
 		Labels:              pw.Labels,
 		Identifiers:         pw.Identifiers,
 		BlockingIdentifiers: pw.BlockingIdentifiers,
-		ProfileName:         &pw.ProfileName,
-		ServiceName:         &pw.ServiceName,
-		AdminState:          &adminState,
-		AutoEvents:          FromAutoEventModelsToDTOs(pw.AutoEvents),
 	}
+	if pw.Id != "" {
+		dto.Id = &pw.Id
+	}
+	if pw.Name != "" {
+		dto.Name = &pw.Name
+	}
+	if pw.ProfileName != "" {
+		dto.ProfileName = &pw.ProfileName
+	}
+	if pw.ServiceName != "" {
+		dto.ServiceName = &pw.ServiceName
+	}
+	if pw.AdminState != "" {
+		adminState := string(pw.AdminState)
+		dto.AdminState = &adminState
+	}
+	if pw.AutoEvents != nil {
+		dto.AutoEvents = FromAutoEventModelsToDTOs(pw.AutoEvents)
+	}
+	return dto
 }

--- a/v2/dtos/provisionwatcher_test.go
+++ b/v2/dtos/provisionwatcher_test.go
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dtos
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromProvisionWatcherModelToUpdateDTO(t *testing.T) {
+	model := models.ProvisionWatcher{}
+	dto := FromProvisionWatcherModelToUpdateDTO(model)
+	assert.Equal(t, v2.ApiVersion, dto.ApiVersion)
+	assert.Nil(t, dto.Id)
+	assert.Nil(t, dto.Name)
+	assert.Nil(t, dto.Labels)
+	assert.Nil(t, dto.Identifiers)
+	assert.Nil(t, dto.BlockingIdentifiers)
+	assert.Nil(t, dto.ProfileName)
+	assert.Nil(t, dto.ServiceName)
+	assert.Nil(t, dto.AdminState)
+	assert.Nil(t, dto.AutoEvents)
+}

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -42,7 +42,7 @@ type SimpleReading struct {
 // BinaryReading and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BinaryReading
 type BinaryReading struct {
-	BinaryValue []byte `json:"binaryValue" validate:"gt=0,dive,required"`
+	BinaryValue []byte `json:"binaryValue" validate:"gt=0,required"`
 	MediaType   string `json:"mediaType" validate:"required"`
 }
 


### PR DESCRIPTION
Fix #528

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #528


## What is the new behavior?
1. Check the empty value when convert Model to UpdateDTO
      - FromProvisionWatcherModelToUpdateDTO
      - FromDeviceModelToUpdateDTO
      - FromDeviceServiceModelToUpdateDTO

2. API client lib handle the 404 StatusNotFound response
3. Modify BinaryReading validate annotation

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information