### PR TITLE
refactor: Remove ApiVersion from normal DTOs except EventDTO

### DIFF
--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -13,22 +13,21 @@ import (
 // Device and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/Device
 type Device struct {
-	common.Versionable `json:",inline"`
-	Id                 string                        `json:"id,omitempty" validate:"omitempty,uuid"`
-	Created            int64                         `json:"created,omitempty"`
-	Modified           int64                         `json:"modified,omitempty"`
-	Name               string                        `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Description        string                        `json:"description,omitempty"`
-	AdminState         string                        `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
-	OperatingState     string                        `json:"operatingState" validate:"oneof='UP' 'DOWN' 'UNKNOWN'"`
-	LastConnected      int64                         `json:"lastConnected,omitempty"`
-	LastReported       int64                         `json:"lastReported,omitempty"`
-	Labels             []string                      `json:"labels,omitempty"`
-	Location           interface{}                   `json:"location,omitempty"`
-	ServiceName        string                        `json:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ProfileName        string                        `json:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	AutoEvents         []AutoEvent                   `json:"autoEvents,omitempty" validate:"dive"`
-	Protocols          map[string]ProtocolProperties `json:"protocols" validate:"required,gt=0"`
+	Id             string                        `json:"id,omitempty" validate:"omitempty,uuid"`
+	Created        int64                         `json:"created,omitempty"`
+	Modified       int64                         `json:"modified,omitempty"`
+	Name           string                        `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Description    string                        `json:"description,omitempty"`
+	AdminState     string                        `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
+	OperatingState string                        `json:"operatingState" validate:"oneof='UP' 'DOWN' 'UNKNOWN'"`
+	LastConnected  int64                         `json:"lastConnected,omitempty"`
+	LastReported   int64                         `json:"lastReported,omitempty"`
+	Labels         []string                      `json:"labels,omitempty"`
+	Location       interface{}                   `json:"location,omitempty"`
+	ServiceName    string                        `json:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName    string                        `json:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	AutoEvents     []AutoEvent                   `json:"autoEvents,omitempty" validate:"dive"`
+	Protocols      map[string]ProtocolProperties `json:"protocols" validate:"required,gt=0"`
 }
 
 // UpdateDevice and its properties are defined in the APIv2 specification:
@@ -73,7 +72,6 @@ func ToDeviceModel(dto Device) models.Device {
 // FromDeviceModelToDTO transforms the Device Model to the Device DTO
 func FromDeviceModelToDTO(d models.Device) Device {
 	var dto Device
-	dto.Versionable = common.NewVersionable()
 	dto.Id = d.Id
 	dto.Name = d.Name
 	dto.Description = d.Description

--- a/v2/dtos/deviceprofile.go
+++ b/v2/dtos/deviceprofile.go
@@ -10,22 +10,20 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 )
 
 // DeviceProfile and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceProfile
 type DeviceProfile struct {
-	common.Versionable `json:",inline" yaml:",inline"`
-	Id                 string           `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name               string           `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Manufacturer       string           `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
-	Description        string           `json:"description,omitempty" yaml:"description,omitempty"`
-	Model              string           `json:"model,omitempty" yaml:"model,omitempty"`
-	Labels             []string         `json:"labels,omitempty" yaml:"labels,flow,omitempty"`
-	DeviceResources    []DeviceResource `json:"deviceResources" yaml:"deviceResources" validate:"required,gt=0,dive"`
-	DeviceCommands     []DeviceCommand  `json:"deviceCommands,omitempty" yaml:"deviceCommands,omitempty" validate:"dive"`
+	Id              string           `json:"id,omitempty" validate:"omitempty,uuid"`
+	Name            string           `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Manufacturer    string           `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
+	Description     string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Model           string           `json:"model,omitempty" yaml:"model,omitempty"`
+	Labels          []string         `json:"labels,omitempty" yaml:"labels,flow,omitempty"`
+	DeviceResources []DeviceResource `json:"deviceResources" yaml:"deviceResources" validate:"required,gt=0,dive"`
+	DeviceCommands  []DeviceCommand  `json:"deviceCommands,omitempty" yaml:"deviceCommands,omitempty" validate:"dive"`
 }
 
 // Validate satisfies the Validator interface
@@ -40,15 +38,14 @@ func (dp *DeviceProfile) Validate() error {
 // UnmarshalYAML implements the Unmarshaler interface for the DeviceProfile type
 func (dp *DeviceProfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var alias struct {
-		common.Versionable `yaml:",inline"`
-		Id                 string           `yaml:"id"`
-		Name               string           `yaml:"name"`
-		Manufacturer       string           `yaml:"manufacturer"`
-		Description        string           `yaml:"description"`
-		Model              string           `yaml:"model"`
-		Labels             []string         `yaml:"labels"`
-		DeviceResources    []DeviceResource `yaml:"deviceResources"`
-		DeviceCommands     []DeviceCommand  `yaml:"deviceCommands"`
+		Id              string           `yaml:"id"`
+		Name            string           `yaml:"name"`
+		Manufacturer    string           `yaml:"manufacturer"`
+		Description     string           `yaml:"description"`
+		Model           string           `yaml:"model"`
+		Labels          []string         `yaml:"labels"`
+		DeviceResources []DeviceResource `yaml:"deviceResources"`
+		DeviceCommands  []DeviceCommand  `yaml:"deviceCommands"`
 	}
 	if err := unmarshal(&alias); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to unmarshal request body as YAML.", err)
@@ -87,7 +84,6 @@ func ToDeviceProfileModel(deviceProfileDTO DeviceProfile) models.DeviceProfile {
 // FromDeviceProfileModelToDTO transforms the DeviceProfile Model to the DeviceProfile DTO
 func FromDeviceProfileModelToDTO(deviceProfile models.DeviceProfile) DeviceProfile {
 	return DeviceProfile{
-		Versionable:     common.NewVersionable(),
 		Id:              deviceProfile.Id,
 		Name:            deviceProfile.Name,
 		Description:     deviceProfile.Description,

--- a/v2/dtos/deviceprofile_test.go
+++ b/v2/dtos/deviceprofile_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 
 	"github.com/stretchr/testify/assert"
@@ -49,7 +48,6 @@ var testDeviceProfile = models.DeviceProfile{
 
 func profileData() DeviceProfile {
 	return DeviceProfile{
-		Versionable:  common.NewVersionable(),
 		Name:         TestDeviceProfileName,
 		Manufacturer: TestManufacturer,
 		Description:  TestDescription,

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -13,17 +13,16 @@ import (
 // DeviceService and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceService
 type DeviceService struct {
-	common.Versionable `json:",inline"`
-	Id                 string   `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name               string   `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Created            int64    `json:"created,omitempty"`
-	Modified           int64    `json:"modified,omitempty"`
-	Description        string   `json:"description,omitempty"`
-	LastConnected      int64    `json:"lastConnected,omitempty"`
-	LastReported       int64    `json:"lastReported,omitempty"`
-	Labels             []string `json:"labels,omitempty"`
-	BaseAddress        string   `json:"baseAddress" validate:"required,uri"`
-	AdminState         string   `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
+	Id            string   `json:"id,omitempty" validate:"omitempty,uuid"`
+	Name          string   `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Created       int64    `json:"created,omitempty"`
+	Modified      int64    `json:"modified,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	LastConnected int64    `json:"lastConnected,omitempty"`
+	LastReported  int64    `json:"lastReported,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	BaseAddress   string   `json:"baseAddress" validate:"required,uri"`
+	AdminState    string   `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 }
 
 // UpdateDeviceService and its properties are defined in the APIv2 specification:
@@ -54,7 +53,6 @@ func ToDeviceServiceModel(dto DeviceService) models.DeviceService {
 // FromDeviceServiceModelToDTO transforms the DeviceService Model to the DeviceService DTO
 func FromDeviceServiceModelToDTO(ds models.DeviceService) DeviceService {
 	var dto DeviceService
-	dto.Versionable = common.NewVersionable()
 	dto.Id = ds.Id
 	dto.Name = ds.Name
 	dto.Description = ds.Description

--- a/v2/dtos/interval.go
+++ b/v2/dtos/interval.go
@@ -13,15 +13,14 @@ import (
 // Interval and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/Interval
 type Interval struct {
-	common.Versionable `json:",inline"`
-	Id                 string `json:"id,omitempty" validate:"omitempty,uuid"`
-	Created            int64  `json:"created,omitempty"`
-	Modified           int64  `json:"modified,omitempty"`
-	Name               string `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Start              string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
-	End                string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
-	Frequency          string `json:"frequency" validate:"required,edgex-dto-frequency"`
-	RunOnce            bool   `json:"runOnce,omitempty"`
+	Id        string `json:"id,omitempty" validate:"omitempty,uuid"`
+	Created   int64  `json:"created,omitempty"`
+	Modified  int64  `json:"modified,omitempty"`
+	Name      string `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Start     string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
+	End       string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
+	Frequency string `json:"frequency" validate:"required,edgex-dto-frequency"`
+	RunOnce   bool   `json:"runOnce,omitempty"`
 }
 
 // UpdateInterval and its properties are defined in the APIv2 specification:
@@ -51,7 +50,6 @@ func ToIntervalModel(dto Interval) models.Interval {
 // FromIntervalModelToDTO transforms the Interval Model to the Interval DTO
 func FromIntervalModelToDTO(model models.Interval) Interval {
 	var dto Interval
-	dto.Versionable = common.NewVersionable()
 	dto.Id = model.Id
 	dto.Name = model.Name
 	dto.Start = model.Start

--- a/v2/dtos/intervalaction.go
+++ b/v2/dtos/intervalaction.go
@@ -15,18 +15,16 @@ import (
 // IntervalAction and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/IntervalAction
 type IntervalAction struct {
-	common.Versionable `json:",inline"`
-	Created            int64   `json:"created,omitempty"`
-	Modified           int64   `json:"modified,omitempty"`
-	Id                 string  `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name               string  `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	IntervalName       string  `json:"intervalName" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Address            Address `json:"address" validate:"required"`
+	Created      int64   `json:"created,omitempty"`
+	Modified     int64   `json:"modified,omitempty"`
+	Id           string  `json:"id,omitempty" validate:"omitempty,uuid"`
+	Name         string  `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	IntervalName string  `json:"intervalName" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Address      Address `json:"address" validate:"required"`
 }
 
 func NewIntervalAction(name string, intervalName string, address Address) IntervalAction {
 	return IntervalAction{
-		Versionable:  common.NewVersionable(),
 		Id:           uuid.NewString(),
 		Name:         name,
 		IntervalName: intervalName,
@@ -57,7 +55,6 @@ func ToIntervalActionModel(dto IntervalAction) models.IntervalAction {
 // FromIntervalActionModelToDTO transforms the IntervalAction Model to the IntervalAction DTO
 func FromIntervalActionModelToDTO(model models.IntervalAction) IntervalAction {
 	var dto IntervalAction
-	dto.Versionable = common.NewVersionable()
 	dto.Id = model.Id
 	dto.Name = model.Name
 	dto.IntervalName = model.IntervalName

--- a/v2/dtos/notification.go
+++ b/v2/dtos/notification.go
@@ -6,7 +6,6 @@
 package dtos
 
 import (
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 
 	"github.com/google/uuid"
@@ -15,30 +14,28 @@ import (
 // Notification and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/Notification
 type Notification struct {
-	common.Versionable `json:",inline"`
-	Id                 string   `json:"id,omitempty" validate:"omitempty,uuid"`
-	Created            int64    `json:"created,omitempty"`
-	Modified           int64    `json:"modified,omitempty"`
-	Category           string   `json:"category,omitempty" validate:"required_without=Labels,omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Labels             []string `json:"labels,omitempty" validate:"required_without=Category,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Content            string   `json:"content" validate:"required,edgex-dto-none-empty-string"`
-	ContentType        string   `json:"contentType,omitempty"`
-	Description        string   `json:"description,omitempty"`
-	Sender             string   `json:"sender" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Severity           string   `json:"severity" validate:"required,oneof='MINOR' 'NORMAL' 'CRITICAL'"`
-	Status             string   `json:"status,omitempty" validate:"omitempty,oneof='NEW' 'PROCESSED' 'ESCALATED'"`
+	Id          string   `json:"id,omitempty" validate:"omitempty,uuid"`
+	Created     int64    `json:"created,omitempty"`
+	Modified    int64    `json:"modified,omitempty"`
+	Category    string   `json:"category,omitempty" validate:"required_without=Labels,omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Labels      []string `json:"labels,omitempty" validate:"required_without=Category,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Content     string   `json:"content" validate:"required,edgex-dto-none-empty-string"`
+	ContentType string   `json:"contentType,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Sender      string   `json:"sender" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Severity    string   `json:"severity" validate:"required,oneof='MINOR' 'NORMAL' 'CRITICAL'"`
+	Status      string   `json:"status,omitempty" validate:"omitempty,oneof='NEW' 'PROCESSED' 'ESCALATED'"`
 }
 
 // NewNotification creates and returns a Notification DTO
 func NewNotification(labels []string, category, content, sender, severity string) Notification {
 	return Notification{
-		Versionable: common.NewVersionable(),
-		Id:          uuid.NewString(),
-		Labels:      labels,
-		Category:    category,
-		Content:     content,
-		Sender:      sender,
-		Severity:    severity,
+		Id:       uuid.NewString(),
+		Labels:   labels,
+		Category: category,
+		Content:  content,
+		Sender:   sender,
+		Severity: severity,
 	}
 }
 
@@ -71,7 +68,6 @@ func ToNotificationModels(notifications []Notification) []models.Notification {
 // FromNotificationModelToDTO transforms the Notification Model to the Notification DTO
 func FromNotificationModelToDTO(n models.Notification) Notification {
 	return Notification{
-		Versionable: common.NewVersionable(),
 		Id:          n.Id,
 		Created:     n.Created,
 		Modified:    n.Modified,

--- a/v2/dtos/notification_test.go
+++ b/v2/dtos/notification_test.go
@@ -3,14 +3,12 @@ package dtos
 import (
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewNotification(t *testing.T) {
-	expectedApiVersion := v2.ApiVersion
 	expectedLabels := []string{"label1", "label2"}
 	expectedCategory := "category"
 	expectedContent := "content"
@@ -19,7 +17,6 @@ func TestNewNotification(t *testing.T) {
 
 	actual := NewNotification(expectedLabels, expectedCategory, expectedContent, expectedSender, expectedSeverity)
 
-	assert.Equal(t, expectedApiVersion, actual.ApiVersion)
 	assert.NotEmpty(t, actual.Id)
 	assert.Equal(t, expectedLabels, actual.Labels)
 	assert.Equal(t, expectedCategory, actual.Category)

--- a/v2/dtos/provisionwatcher.go
+++ b/v2/dtos/provisionwatcher.go
@@ -13,7 +13,6 @@ import (
 // ProvisionWatcher and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/ProvisionWatcher
 type ProvisionWatcher struct {
-	common.Versionable  `json:",inline"`
 	Id                  string              `json:"id,omitempty" validate:"omitempty,uuid"`
 	Name                string              `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Labels              []string            `json:"labels,omitempty"`
@@ -59,7 +58,6 @@ func ToProvisionWatcherModel(dto ProvisionWatcher) models.ProvisionWatcher {
 // FromProvisionWatcherModelToDTO transforms the ProvisionWatcher Model to the ProvisionWatcher DTO
 func FromProvisionWatcherModelToDTO(pw models.ProvisionWatcher) ProvisionWatcher {
 	return ProvisionWatcher{
-		Versionable:         common.NewVersionable(),
 		Id:                  pw.Id,
 		Name:                pw.Name,
 		Labels:              pw.Labels,

--- a/v2/dtos/requests/device.go
+++ b/v2/dtos/requests/device.go
@@ -131,7 +131,6 @@ func ReplaceDeviceModelFieldsWithDTO(device *models.Device, patch dtos.UpdateDev
 }
 
 func NewAddDeviceRequest(dto dtos.Device) AddDeviceRequest {
-	dto.Versionable = common.NewVersionable()
 	return AddDeviceRequest{
 		BaseRequest: common.NewBaseRequest(),
 		Device:      dto,

--- a/v2/dtos/requests/device_test.go
+++ b/v2/dtos/requests/device_test.go
@@ -41,7 +41,6 @@ var testAddDevice = AddDeviceRequest{
 		Versionable: common.NewVersionable(),
 	},
 	Device: dtos.Device{
-		Versionable:    common.NewVersionable(),
 		Name:           TestDeviceName,
 		ServiceName:    TestDeviceServiceName,
 		ProfileName:    TestDeviceProfileName,
@@ -438,7 +437,6 @@ func TestNewAddDeviceRequest(t *testing.T) {
 	actual := NewAddDeviceRequest(dtos.Device{})
 
 	assert.Equal(t, expectedApiVersion, actual.ApiVersion)
-	assert.Equal(t, expectedApiVersion, actual.Device.ApiVersion)
 }
 
 func TestNewUpdateDeviceRequest(t *testing.T) {

--- a/v2/dtos/requests/deviceprofile.go
+++ b/v2/dtos/requests/deviceprofile.go
@@ -75,7 +75,6 @@ func DeviceProfileReqToDeviceProfileModels(addRequests []DeviceProfileRequest) (
 }
 
 func NewDeviceProfileRequest(dto dtos.DeviceProfile) DeviceProfileRequest {
-	dto.Versionable = common.NewVersionable()
 	return DeviceProfileRequest{
 		BaseRequest: common.NewBaseRequest(),
 		Profile:     dto,

--- a/v2/dtos/requests/deviceprofile_test.go
+++ b/v2/dtos/requests/deviceprofile_test.go
@@ -48,7 +48,6 @@ func profileData() DeviceProfileRequest {
 			Versionable: common.NewVersionable(),
 		},
 		Profile: dtos.DeviceProfile{
-			Versionable:     common.NewVersionable(),
 			Name:            TestDeviceProfileName,
 			Manufacturer:    TestManufacturer,
 			Description:     TestDescription,
@@ -195,5 +194,4 @@ func TestNewDeviceProfileRequest(t *testing.T) {
 	actual := NewDeviceProfileRequest(dtos.DeviceProfile{})
 
 	assert.Equal(t, expectedApiVersion, actual.ApiVersion)
-	assert.Equal(t, expectedApiVersion, actual.Profile.ApiVersion)
 }

--- a/v2/dtos/requests/deviceservice.go
+++ b/v2/dtos/requests/deviceservice.go
@@ -104,7 +104,6 @@ func ReplaceDeviceServiceModelFieldsWithDTO(ds *models.DeviceService, patch dtos
 }
 
 func NewAddDeviceServiceRequest(dto dtos.DeviceService) AddDeviceServiceRequest {
-	dto.Versionable = common.NewVersionable()
 	return AddDeviceServiceRequest{
 		BaseRequest: common.NewBaseRequest(),
 		Service:     dto,

--- a/v2/dtos/requests/deviceservice_test.go
+++ b/v2/dtos/requests/deviceservice_test.go
@@ -25,7 +25,6 @@ var testAddDeviceService = AddDeviceServiceRequest{
 		Versionable: common.NewVersionable(),
 	},
 	Service: dtos.DeviceService{
-		Versionable: common.NewVersionable(),
 		Name:        TestDeviceServiceName,
 		BaseAddress: TestBaseAddress,
 		Labels:      []string{"MODBUS", "TEMP"},
@@ -319,7 +318,6 @@ func TestNewAddDeviceServiceRequest(t *testing.T) {
 	actual := NewAddDeviceServiceRequest(dtos.DeviceService{})
 
 	assert.Equal(t, expectedApiVersion, actual.ApiVersion)
-	assert.Equal(t, expectedApiVersion, actual.Service.ApiVersion)
 }
 
 func TestNewUpdateDeviceServiceRequest(t *testing.T) {

--- a/v2/dtos/requests/interval.go
+++ b/v2/dtos/requests/interval.go
@@ -107,7 +107,6 @@ func ReplaceIntervalModelFieldsWithDTO(interval *models.Interval, patch dtos.Upd
 }
 
 func NewAddIntervalRequest(dto dtos.Interval) AddIntervalRequest {
-	dto.Versionable = common.NewVersionable()
 	return AddIntervalRequest{
 		BaseRequest: common.NewBaseRequest(),
 		Interval:    dto,

--- a/v2/dtos/requests/interval_test.go
+++ b/v2/dtos/requests/interval_test.go
@@ -24,12 +24,11 @@ func addIntervalRequestData() AddIntervalRequest {
 			Versionable: common.NewVersionable(),
 		},
 		Interval: dtos.Interval{
-			Versionable: common.NewVersionable(),
-			Name:        TestIntervalName,
-			Start:       TestIntervalStart,
-			End:         TestIntervalEnd,
-			Frequency:   TestIntervalFrequency,
-			RunOnce:     TestIntervalRunOnce,
+			Name:      TestIntervalName,
+			Start:     TestIntervalStart,
+			End:       TestIntervalEnd,
+			Frequency: TestIntervalFrequency,
+			RunOnce:   TestIntervalRunOnce,
 		},
 	}
 }

--- a/v2/dtos/requests/intervalaction.go
+++ b/v2/dtos/requests/intervalaction.go
@@ -117,7 +117,6 @@ func ReplaceIntervalActionModelFieldsWithDTO(action *models.IntervalAction, patc
 }
 
 func NewAddIntervalActionRequest(dto dtos.IntervalAction) AddIntervalActionRequest {
-	dto.Versionable = common.NewVersionable()
 	return AddIntervalActionRequest{
 		BaseRequest: common.NewBaseRequest(),
 		Action:      dto,

--- a/v2/dtos/requests/notification.go
+++ b/v2/dtos/requests/notification.go
@@ -58,7 +58,6 @@ func AddNotificationReqToNotificationModels(reqs []AddNotificationRequest) (n []
 }
 
 func NewAddNotificationRequest(dto dtos.Notification) AddNotificationRequest {
-	dto.Versionable = common.NewVersionable()
 	return AddNotificationRequest{
 		BaseRequest:  common.NewBaseRequest(),
 		Notification: dto,

--- a/v2/dtos/requests/provisionwatcher.go
+++ b/v2/dtos/requests/provisionwatcher.go
@@ -116,7 +116,6 @@ func ReplaceProvisionWatcherModelFieldsWithDTO(pw *models.ProvisionWatcher, patc
 }
 
 func NewAddProvisionWatcherRequest(dto dtos.ProvisionWatcher) AddProvisionWatcherRequest {
-	dto.Versionable = common.NewVersionable()
 	return AddProvisionWatcherRequest{
 		BaseRequest:      common.NewBaseRequest(),
 		ProvisionWatcher: dto,

--- a/v2/dtos/requests/provisionwatcher_test.go
+++ b/v2/dtos/requests/provisionwatcher_test.go
@@ -32,7 +32,6 @@ var testAddProvisionWatcher = AddProvisionWatcherRequest{
 		Versionable: common.NewVersionable(),
 	},
 	ProvisionWatcher: dtos.ProvisionWatcher{
-		Versionable:         common.NewVersionable(),
 		Name:                testProvisionWatcherName,
 		Labels:              testProvisionWatcherLabels,
 		Identifiers:         testIdentifiers,

--- a/v2/dtos/requests/subscription.go
+++ b/v2/dtos/requests/subscription.go
@@ -116,7 +116,6 @@ func ReplaceSubscriptionModelFieldsWithDTO(s *models.Subscription, patch dtos.Up
 }
 
 func NewAddSubscriptionRequest(dto dtos.Subscription) AddSubscriptionRequest {
-	dto.Versionable = common.NewVersionable()
 	return AddSubscriptionRequest{
 		BaseRequest:  common.NewBaseRequest(),
 		Subscription: dto,

--- a/v2/dtos/requests/subscription_test.go
+++ b/v2/dtos/requests/subscription_test.go
@@ -38,7 +38,6 @@ func addSubscriptionRequestData() AddSubscriptionRequest {
 			Versionable: common.NewVersionable(),
 		},
 		Subscription: dtos.Subscription{
-			Versionable:    common.NewVersionable(),
 			Name:           testSubscriptionName,
 			Categories:     testSubscriptionCategories,
 			Labels:         testSubscriptionLabels,

--- a/v2/dtos/subscription.go
+++ b/v2/dtos/subscription.go
@@ -13,18 +13,17 @@ import (
 // Subscription and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/Subscription
 type Subscription struct {
-	common.Versionable `json:",inline"`
-	Id                 string    `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name               string    `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Channels           []Channel `json:"channels" validate:"required,gt=0,dive"`
-	Receiver           string    `json:"receiver" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Categories         []string  `json:"categories,omitempty" validate:"required_without=Labels,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Labels             []string  `json:"labels,omitempty" validate:"required_without=Categories,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Created            int64     `json:"created,omitempty"`
-	Modified           int64     `json:"modified,omitempty"`
-	Description        string    `json:"description,omitempty"`
-	ResendLimit        int64     `json:"resendLimit,omitempty"`
-	ResendInterval     string    `json:"resendInterval,omitempty" validate:"omitempty,edgex-dto-frequency"`
+	Id             string    `json:"id,omitempty" validate:"omitempty,uuid"`
+	Name           string    `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Channels       []Channel `json:"channels" validate:"required,gt=0,dive"`
+	Receiver       string    `json:"receiver" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Categories     []string  `json:"categories,omitempty" validate:"required_without=Labels,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Labels         []string  `json:"labels,omitempty" validate:"required_without=Categories,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Created        int64     `json:"created,omitempty"`
+	Modified       int64     `json:"modified,omitempty"`
+	Description    string    `json:"description,omitempty"`
+	ResendLimit    int64     `json:"resendLimit,omitempty"`
+	ResendInterval string    `json:"resendInterval,omitempty" validate:"omitempty,edgex-dto-frequency"`
 }
 
 // UpdateSubscription and its properties are defined in the APIv2 specification:
@@ -79,7 +78,6 @@ func ToSubscriptionModels(subs []Subscription) []models.Subscription {
 // FromSubscriptionModelToDTO transforms the Subscription Model to the Subscription DTO
 func FromSubscriptionModelToDTO(s models.Subscription) Subscription {
 	return Subscription{
-		Versionable:    common.NewVersionable(),
 		Categories:     s.Categories,
 		Labels:         s.Labels,
 		Channels:       FromChannelModelsToDTOs(s.Channels),


### PR DESCRIPTION
Close #537

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The apiVersion is required.

## Issue Number: #537 


## What is the new behavior?
- Remove the required validation tag from apiVersion.
- Check the requestDTOs and EventDTO which should contains valid api version

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information