### PR TITLE
fix: Add Address model unmarshal func

### DIFF
--- a/v2/dtos/address.go
+++ b/v2/dtos/address.go
@@ -121,6 +121,9 @@ func ToAddressModel(a Address) models.Address {
 		break
 	case v2.EMAIL:
 		address = models.EmailAddress{
+			BaseAddress: models.BaseAddress{
+				Type: a.Type,
+			},
 			Recipients: a.EmailAddresses,
 		}
 	}

--- a/v2/models/address.go
+++ b/v2/models/address.go
@@ -16,16 +16,16 @@ type Address interface {
 	GetBaseAddress() BaseAddress
 }
 
-// FormatAddress convert the interface to the corresponding address type
-func FormatAddress(i interface{}) (address Address, err error) {
+// instantiateAddress instantiate the interface to the corresponding address type
+func instantiateAddress(i interface{}) (address Address, err error) {
 	a, err := json.Marshal(i)
 	if err != nil {
 		return address, errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to marshal address.", err)
 	}
-	return UnmarshalAddress(a)
+	return unmarshalAddress(a)
 }
 
-func UnmarshalAddress(b []byte) (address Address, err error) {
+func unmarshalAddress(b []byte) (address Address, err error) {
 	var alias struct {
 		Type string
 	}

--- a/v2/models/const_test.go
+++ b/v2/models/const_test.go
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package models
+
+const (
+	ExampleUUID            = "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc"
+	TestIntervalName       = "TestInterval"
+	TestIntervalActionName = "TestIntervalAction"
+	TestHost               = "localhost"
+	TestPort               = 48089
+	TestHTTPMethod         = "GET"
+	TestPublisher          = "testPublisher"
+	TestTopic              = "testTopic"
+
+	TestSubscriptionName     = "TestSubscriptionName"
+	TestSubscriptionReceiver = "TestReceiver"
+)

--- a/v2/models/intervalaction.go
+++ b/v2/models/intervalaction.go
@@ -5,6 +5,12 @@
 
 package models
 
+import (
+	"encoding/json"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+)
+
 // IntervalAction and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/IntervalAction
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
@@ -14,4 +20,30 @@ type IntervalAction struct {
 	Name         string
 	IntervalName string
 	Address      Address
+}
+
+func (intervalAction *IntervalAction) UnmarshalJSON(b []byte) error {
+	var alias struct {
+		Timestamps
+		Id           string
+		Name         string
+		IntervalName string
+		Address      interface{}
+	}
+	if err := json.Unmarshal(b, &alias); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal intervalAction.", err)
+	}
+	address, err := FormatAddress(alias.Address)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	*intervalAction = IntervalAction{
+		Timestamps:   alias.Timestamps,
+		Id:           alias.Id,
+		Name:         alias.Name,
+		IntervalName: alias.IntervalName,
+		Address:      address,
+	}
+	return nil
 }

--- a/v2/models/intervalaction.go
+++ b/v2/models/intervalaction.go
@@ -33,7 +33,7 @@ func (intervalAction *IntervalAction) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &alias); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal intervalAction.", err)
 	}
-	address, err := FormatAddress(alias.Address)
+	address, err := instantiateAddress(alias.Address)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/models/intervalaction_test.go
+++ b/v2/models/intervalaction_test.go
@@ -1,0 +1,83 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func actionWithRESTAddressData() IntervalAction {
+	return IntervalAction{
+		Timestamps:   Timestamps{},
+		Id:           ExampleUUID,
+		Name:         TestIntervalActionName,
+		IntervalName: TestIntervalName,
+		Address: RESTAddress{
+			BaseAddress: BaseAddress{
+				Type: v2.REST,
+				Host: TestHost,
+				Port: TestPort,
+			},
+			HTTPMethod: TestHTTPMethod,
+		},
+	}
+}
+func actionWithMQTTPubAddressData() IntervalAction {
+	return IntervalAction{
+		Timestamps:   Timestamps{},
+		Id:           ExampleUUID,
+		Name:         TestIntervalActionName,
+		IntervalName: TestIntervalName,
+		Address: MQTTPubAddress{
+			BaseAddress: BaseAddress{
+				Type: v2.MQTT,
+				Host: TestHost,
+				Port: TestPort,
+			},
+			Publisher: TestPublisher,
+			Topic:     TestTopic,
+		},
+	}
+}
+
+func TestIntervalAction_UnmarshalJSON(t *testing.T) {
+	actionWithRestAddress := actionWithRESTAddressData()
+	actionWithRestAddressJsonData, err := json.Marshal(actionWithRestAddress)
+	require.NoError(t, err)
+	actionWithMQTTPubAddress := actionWithMQTTPubAddressData()
+	actionWithMQTTPubAddressJsonData, err := json.Marshal(actionWithMQTTPubAddress)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expected IntervalAction
+		data     []byte
+		wantErr  bool
+	}{
+		{"valid, unmarshal intervalAction with REST address", actionWithRestAddress, actionWithRestAddressJsonData, false},
+		{"valid, unmarshal intervalAction with MQTT address", actionWithMQTTPubAddress, actionWithMQTTPubAddressJsonData, false},
+		{"unmarshal invalid AddIntervalActionRequest, empty data", IntervalAction{}, []byte{}, true},
+		{"unmarshal invalid AddIntervalActionRequest, string data", IntervalAction{}, []byte("Invalid IntervalAction"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result IntervalAction
+			err := json.Unmarshal(tt.data, &result)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result, "Unmarshal did not result in expected AddIntervalActionRequest.")
+			}
+		})
+	}
+}

--- a/v2/models/subscription.go
+++ b/v2/models/subscription.go
@@ -45,7 +45,7 @@ func (subscription *Subscription) UnmarshalJSON(b []byte) error {
 	}
 	channels := make([]Address, len(alias.Channels))
 	for i, c := range alias.Channels {
-		address, err := FormatAddress(c)
+		address, err := instantiateAddress(c)
 		if err != nil {
 			return errors.NewCommonEdgeXWrapper(err)
 		}

--- a/v2/models/subscription.go
+++ b/v2/models/subscription.go
@@ -5,6 +5,12 @@
 
 package models
 
+import (
+	"encoding/json"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+)
+
 // Subscription and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/Subscription
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
@@ -13,12 +19,50 @@ type Subscription struct {
 	Categories     []string
 	Labels         []string
 	Channels       []Address
-	Created        int64
-	Modified       int64
 	Description    string
 	Id             string
 	Receiver       string
 	Name           string
 	ResendLimit    int64
 	ResendInterval string
+}
+
+func (subscription *Subscription) UnmarshalJSON(b []byte) error {
+	var alias struct {
+		Timestamps
+		Categories     []string
+		Labels         []string
+		Channels       []interface{}
+		Description    string
+		Id             string
+		Receiver       string
+		Name           string
+		ResendLimit    int64
+		ResendInterval string
+	}
+	if err := json.Unmarshal(b, &alias); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal intervalAction.", err)
+	}
+	channels := make([]Address, len(alias.Channels))
+	for i, c := range alias.Channels {
+		address, err := FormatAddress(c)
+		if err != nil {
+			return errors.NewCommonEdgeXWrapper(err)
+		}
+		channels[i] = address
+	}
+
+	*subscription = Subscription{
+		Timestamps:     alias.Timestamps,
+		Categories:     alias.Categories,
+		Labels:         alias.Labels,
+		Description:    alias.Description,
+		Id:             alias.Id,
+		Receiver:       alias.Receiver,
+		Name:           alias.Name,
+		ResendLimit:    alias.ResendLimit,
+		ResendInterval: alias.ResendInterval,
+		Channels:       channels,
+	}
+	return nil
 }

--- a/v2/models/subscription_test.go
+++ b/v2/models/subscription_test.go
@@ -1,0 +1,58 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func subscriptionData() Subscription {
+	return Subscription{
+		Id:   ExampleUUID,
+		Name: TestSubscriptionName,
+		Channels: []Address{
+			EmailAddress{
+				BaseAddress: BaseAddress{Type: v2.EMAIL},
+				Recipients:  []string{"test@example.com"},
+			},
+		},
+		Receiver: TestSubscriptionReceiver,
+	}
+}
+
+func TestSubscription_UnmarshalJSON(t *testing.T) {
+	valid := subscriptionData()
+	jsonData, err := json.Marshal(valid)
+	require.NoError(t, err)
+	tests := []struct {
+		name     string
+		expected Subscription
+		data     []byte
+		wantErr  bool
+	}{
+		{"valid, unmarshal Subscription", valid, jsonData, false},
+		{"invalid, unmarshal invalid Subscription, empty data", Subscription{}, []byte{}, true},
+		{"invalid, unmarshal invalid Subscription, string data", Subscription{}, []byte("Invalid Subscription"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result Subscription
+			err := result.UnmarshalJSON(tt.data)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result, "Unmarshal did not result in expected AddSubscriptionRequest.")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Close #554

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
JSON unmarshal fun can't unmarshal the interface type.

## Issue Number: #554 


## What is the new behavior?
Add custom function for IntervalAction and Subscription model to unmarshal the Address.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information