### PR TITLE
feat: add encoding method for AddEventRequest

### DIFF
--- a/v2/clients/http/device.go
+++ b/v2/clients/http/device.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
@@ -29,7 +28,7 @@ func NewDeviceClient(baseUrl string) interfaces.DeviceClient {
 }
 
 func (dc DeviceClient) Add(ctx context.Context, reqs []requests.AddDeviceRequest) (res []common.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequest(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, reqs, clients.ContentTypeJSON)
+	err = utils.PostRequestWithRawData(ctx, &res, dc.baseUrl+v2.ApiDeviceRoute, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceprofile.go
+++ b/v2/clients/http/deviceprofile.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
@@ -35,7 +34,7 @@ func NewDeviceProfileClient(baseUrl string) interfaces.DeviceProfileClient {
 
 func (client *DeviceProfileClient) Add(ctx context.Context, reqs []requests.DeviceProfileRequest) ([]common.BaseWithIdResponse, errors.EdgeX) {
 	var responses []common.BaseWithIdResponse
-	err := utils.PostRequest(ctx, &responses, client.baseUrl+v2.ApiDeviceProfileRoute, reqs, clients.ContentTypeJSON)
+	err := utils.PostRequestWithRawData(ctx, &responses, client.baseUrl+v2.ApiDeviceProfileRoute, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservice.go
+++ b/v2/clients/http/deviceservice.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
@@ -30,7 +29,7 @@ func NewDeviceServiceClient(baseUrl string) interfaces.DeviceServiceClient {
 
 func (dsc DeviceServiceClient) Add(ctx context.Context, reqs []requests.AddDeviceServiceRequest) (
 	res []common.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequest(ctx, &res, dsc.baseUrl+v2.ApiDeviceServiceRoute, reqs, clients.ContentTypeJSON)
+	err = utils.PostRequestWithRawData(ctx, &res, dsc.baseUrl+v2.ApiDeviceServiceRoute, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/deviceservicecallback.go
+++ b/v2/clients/http/deviceservicecallback.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"path"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
@@ -31,7 +30,7 @@ func NewDeviceServiceCallbackClient(baseUrl string) interfaces.DeviceServiceCall
 
 func (client *deviceServiceCallbackClient) AddDeviceCallback(ctx context.Context, request requests.AddDeviceRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PostRequest(ctx, &response, client.baseUrl+v2.ApiDeviceCallbackRoute, request, clients.ContentTypeJSON)
+	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl+v2.ApiDeviceCallbackRoute, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -68,7 +67,7 @@ func (client *deviceServiceCallbackClient) UpdateDeviceProfileCallback(ctx conte
 
 func (client *deviceServiceCallbackClient) AddProvisionWatcherCallback(ctx context.Context, request requests.AddProvisionWatcherRequest) (common.BaseResponse, errors.EdgeX) {
 	var response common.BaseResponse
-	err := utils.PostRequest(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, request, clients.ContentTypeJSON)
+	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl+v2.ApiWatcherCallbackRoute, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/event.go
+++ b/v2/clients/http/event.go
@@ -8,11 +8,9 @@ package http
 import (
 	"context"
 	"net/url"
-	"os"
 	"path"
 	"strconv"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
@@ -37,20 +35,13 @@ func (ec *eventClient) Add(ctx context.Context, req requests.AddEventRequest) (
 	common.BaseWithIdResponse, errors.EdgeX) {
 	path := path.Join(v2.ApiEventRoute, url.QueryEscape(req.Event.ProfileName), url.QueryEscape(req.Event.DeviceName), url.QueryEscape(req.Event.SourceName))
 	var br common.BaseWithIdResponse
-	var encoding string
 
-	for _, r := range req.Event.Readings {
-		if r.ValueType == v2.ValueTypeBinary {
-			encoding = clients.ContentTypeCBOR
-			break
-		}
+	bytes, encoding, err := req.Encode()
+	if err != nil {
+		return br, errors.NewCommonEdgeXWrapper(err)
 	}
 
-	if v := os.Getenv(v2.EnvEncodeAllEvents); v == v2.ValueTrue {
-		encoding = clients.ContentTypeCBOR
-	}
-
-	err := utils.PostRequest(ctx, &br, ec.baseUrl+path, req, encoding)
+	err = utils.PostRequest(ctx, &br, ec.baseUrl+path, bytes, encoding)
 	if err != nil {
 		return br, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/provisionwatcher.go
+++ b/v2/clients/http/provisionwatcher.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
@@ -34,7 +33,7 @@ func NewProvisionWatcherClient(baseUrl string) interfaces.ProvisionWatcherClient
 }
 
 func (pwc ProvisionWatcherClient) Add(ctx context.Context, reqs []requests.AddProvisionWatcherRequest) (res []common.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequest(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, reqs, clients.ContentTypeJSON)
+	err = utils.PostRequestWithRawData(ctx, &res, pwc.baseUrl+v2.ApiProvisionWatcherRoute, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/v2/clients/http/utils/request.go
+++ b/v2/clients/http/utils/request.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 )
 
@@ -32,15 +31,37 @@ func GetRequest(ctx context.Context, returnValuePointer interface{}, baseUrl str
 	return nil
 }
 
-// Helper method to make the post JSON/CBOR request and return the body
+// Helper method to make the post request with encoded data and return the body
 func PostRequest(
 	ctx context.Context,
 	returnValuePointer interface{},
 	url string,
-	data interface{},
+	data []byte,
 	encoding string) errors.EdgeX {
 
-	req, err := createRequestWithRawData(ctx, http.MethodPost, url, data, encoding)
+	req, err := createRequestWithEncodedData(ctx, http.MethodPost, url, data, encoding)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	res, err := sendRequest(ctx, req)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if err := json.Unmarshal(res, returnValuePointer); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse the response body", err)
+	}
+	return nil
+}
+
+// Helper method to make the post JSON request with raw data and return the body
+func PostRequestWithRawData(
+	ctx context.Context,
+	returnValuePointer interface{},
+	url string,
+	data interface{}) errors.EdgeX {
+
+	req, err := createRequestWithRawData(ctx, http.MethodPost, url, data)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -62,7 +83,7 @@ func PutRequest(
 	url string,
 	data interface{}) errors.EdgeX {
 
-	req, err := createRequestWithRawData(ctx, http.MethodPut, url, data, clients.ContentTypeJSON)
+	req, err := createRequestWithRawData(ctx, http.MethodPut, url, data)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -84,7 +105,7 @@ func PatchRequest(
 	url string,
 	data interface{}) errors.EdgeX {
 
-	req, err := createRequestWithRawData(ctx, http.MethodPatch, url, data, clients.ContentTypeJSON)
+	req, err := createRequestWithRawData(ctx, http.MethodPatch, url, data)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}


### PR DESCRIPTION
- revert #550
- add utils functions to create request and post request with encoded data

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
the encoding logic is in `EventClient`, which cannot be reused by Device-SDK

## Issue Number: 
prerequisite of https://github.com/edgexfoundry/device-sdk-go/issues/688


## What is the new behavior?
encoding logic is now under `AddEventRequest` and can be reused by Device-SDK

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information