### PR TITLE
feat: Address add json omitempty and emailAddress struct to DTO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
-	github.com/go-playground/validator/v10 v10.3.0
+	github.com/go-playground/validator/v10 v10.4.1
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Close #557

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
JSON marshal result contains other address's empty fields.

## Issue Number: #557 


## What is the new behavior?
- Upgrade the github.com/go-playground/validator lib to v10.4.1 to apply the new validation tag
- Address add JSON omitempty tag to omit the empty values from other address types.  The issue can refer to https://github.com/edgexfoundry/edgex-go/issues/3294
- Add EmailAddress struct to DTO to consistent with other address types
- Rename the DTO's emailAddresses to recipients to consistent with model

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information