### PR TITLE
feat: Remove created field from Event and Reading

### DIFF
--- a/v2/clients/http/deviceservicecommand_test.go
+++ b/v2/clients/http/deviceservicecommand_test.go
@@ -33,7 +33,6 @@ var testEventDTO = dtos.Event{
 	Id:          TestUUID,
 	DeviceName:  TestDeviceName,
 	ProfileName: TestDeviceProfileName,
-	Created:     TestTimestamp,
 	Origin:      TestTimestamp,
 	Tags: map[string]string{
 		"GatewayID": "Houston-0001",

--- a/v2/dtos/event.go
+++ b/v2/dtos/event.go
@@ -25,7 +25,6 @@ type Event struct {
 	DeviceName         string            `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
 	ProfileName        string            `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
 	SourceName         string            `json:"sourceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	Created            int64             `json:"created,omitempty"`
 	Origin             int64             `json:"origin" validate:"required"`
 	Readings           []BaseReading     `json:"readings" validate:"gt=0,dive,required"`
 	Tags               map[string]string `json:"tags,omitempty" xml:"-"` // Have to ignore since map not supported for XML
@@ -61,7 +60,6 @@ func FromEventModelToDTO(event models.Event) Event {
 		DeviceName:  event.DeviceName,
 		ProfileName: event.ProfileName,
 		SourceName:  event.SourceName,
-		Created:     event.Created,
 		Origin:      event.Origin,
 		Readings:    readings,
 		Tags:        tags,

--- a/v2/dtos/event_test.go
+++ b/v2/dtos/event_test.go
@@ -23,7 +23,6 @@ var valid = models.Event{
 	DeviceName:  TestDeviceName,
 	ProfileName: TestDeviceProfileName,
 	SourceName:  TestSourceName,
-	Created:     TestTimestamp,
 	Origin:      TestTimestamp,
 	Tags: map[string]string{
 		"GatewayID": "Houston-0001",
@@ -38,7 +37,6 @@ var expectedDTO = Event{
 	DeviceName:  TestDeviceName,
 	ProfileName: TestDeviceProfileName,
 	SourceName:  TestSourceName,
-	Created:     TestTimestamp,
 	Origin:      TestTimestamp,
 	Tags: map[string]string{
 		"GatewayID": "Houston-0001",
@@ -65,7 +63,7 @@ func TestFromEventModelToDTO(t *testing.T) {
 func TestEvent_ToXML(t *testing.T) {
 	// Since the order in map is random we have to verify the individual items exists without depending on order
 	contains := []string{
-		"<Event><ApiVersion>v2</ApiVersion><Id>7a1707f0-166f-4c4b-bc9d-1d54c74e0137</Id><DeviceName>TestDevice</DeviceName><ProfileName>TestDeviceProfileName</ProfileName><SourceName>TestSourceName</SourceName><Created>1594963842</Created><Origin>1594963842</Origin><Tags>",
+		"<Event><ApiVersion>v2</ApiVersion><Id>7a1707f0-166f-4c4b-bc9d-1d54c74e0137</Id><DeviceName>TestDevice</DeviceName><ProfileName>TestDeviceProfileName</ProfileName><SourceName>TestSourceName</SourceName><Origin>1594963842</Origin><Tags>",
 		"<GatewayID>Houston-0001</GatewayID>",
 		"<Latitude>29.630771</Latitude>",
 		"<Longitude>-95.377603</Longitude>",
@@ -91,7 +89,6 @@ func TestNewEvent(t *testing.T) {
 	assert.Equal(t, expectedProfileName, actual.ProfileName)
 	assert.Equal(t, expectedDeviceName, actual.DeviceName)
 	assert.Zero(t, len(actual.Readings))
-	assert.Zero(t, actual.Created)
 	assert.NotZero(t, actual.Origin)
 }
 
@@ -126,7 +123,6 @@ func TestEvent_AddSimpleReading(t *testing.T) {
 		assert.Equal(t, expectedReadingDetails[index].resourceName, actual.ResourceName)
 		assert.Equal(t, expectedReadingDetails[index].valueType, actual.ValueType)
 		assert.Equal(t, expectedReadingDetails[index].value, actual.Value)
-		assert.Zero(t, actual.Created)
 		assert.NotZero(t, actual.Origin)
 	}
 }
@@ -152,6 +148,5 @@ func TestEvent_AddBinaryReading(t *testing.T) {
 	assert.Equal(t, expectedResourceName, actual.ResourceName)
 	assert.Equal(t, expectedValueType, actual.ValueType)
 	assert.Equal(t, expectedValue, actual.BinaryValue)
-	assert.Zero(t, actual.Created)
 	assert.NotZero(t, actual.Origin)
 }

--- a/v2/dtos/reading.go
+++ b/v2/dtos/reading.go
@@ -21,7 +21,6 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BaseReading
 type BaseReading struct {
 	Id            string `json:"id,omitempty"`
-	Created       int64  `json:"created,omitempty"`
 	Origin        int64  `json:"origin" validate:"required"`
 	DeviceName    string `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
 	ResourceName  string `json:"resourceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
@@ -291,7 +290,6 @@ func FromReadingModelToDTO(reading models.Reading) BaseReading {
 	case models.BinaryReading:
 		baseReading = BaseReading{
 			Id:            r.Id,
-			Created:       r.Created,
 			Origin:        r.Origin,
 			DeviceName:    r.DeviceName,
 			ResourceName:  r.ResourceName,
@@ -302,7 +300,6 @@ func FromReadingModelToDTO(reading models.Reading) BaseReading {
 	case models.SimpleReading:
 		baseReading = BaseReading{
 			Id:            r.Id,
-			Created:       r.Created,
 			Origin:        r.Origin,
 			DeviceName:    r.DeviceName,
 			ResourceName:  r.ResourceName,

--- a/v2/dtos/reading_test.go
+++ b/v2/dtos/reading_test.go
@@ -57,7 +57,6 @@ func TestFromReadingModelToDTO(t *testing.T) {
 	valid := models.SimpleReading{
 		BaseReading: models.BaseReading{
 			Id:           TestUUID,
-			Created:      TestTimestamp,
 			Origin:       TestTimestamp,
 			DeviceName:   TestDeviceName,
 			ResourceName: TestReadingName,
@@ -68,7 +67,6 @@ func TestFromReadingModelToDTO(t *testing.T) {
 	}
 	expectedDTO := BaseReading{
 		Id:           TestUUID,
-		Created:      TestTimestamp,
 		Origin:       TestTimestamp,
 		DeviceName:   TestDeviceName,
 		ResourceName: TestReadingName,
@@ -141,7 +139,6 @@ func TestNewSimpleReading(t *testing.T) {
 			assert.Equal(t, expectedResourceName, actual.ResourceName)
 			assert.Equal(t, tt.expectedValueType, actual.ValueType)
 			assert.Equal(t, tt.expectedValue, actual.Value)
-			assert.Zero(t, actual.Created)
 			assert.NotZero(t, actual.Origin)
 		})
 	}
@@ -204,6 +201,5 @@ func TestNewBinaryReading(t *testing.T) {
 	assert.Equal(t, expectedResourceName, actual.ResourceName)
 	assert.Equal(t, expectedValueType, actual.ValueType)
 	assert.Equal(t, expectedBinaryValue, actual.BinaryValue)
-	assert.Zero(t, actual.Created)
 	assert.NotZero(t, actual.Origin)
 }

--- a/v2/dtos/requests/event_test.go
+++ b/v2/dtos/requests/event_test.go
@@ -333,6 +333,5 @@ func TestNewAddEventRequest(t *testing.T) {
 	assert.Equal(t, expectedDeviceName, actual.Event.DeviceName)
 	assert.Equal(t, expectedSourceName, actual.Event.SourceName)
 	assert.NotZero(t, len(actual.Event.Readings))
-	assert.Zero(t, actual.Event.Created)
 	assert.NotZero(t, actual.Event.Origin)
 }

--- a/v2/models/event.go
+++ b/v2/models/event.go
@@ -13,7 +13,6 @@ type Event struct {
 	DeviceName  string
 	ProfileName string
 	SourceName  string
-	Created     int64
 	Origin      int64
 	Readings    []Reading
 	Tags        map[string]string

--- a/v2/models/reading.go
+++ b/v2/models/reading.go
@@ -10,7 +10,6 @@ package models
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type BaseReading struct {
 	Id           string
-	Created      int64
 	Origin       int64
 	DeviceName   string
 	ResourceName string


### PR DESCRIPTION
Close #553

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #553


## What is the new behavior?
In March-18-2021 Core WG meeting, we decided to remove created field from Event and Reading

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information