### PR TITLE
refactor: Refactor DTO's Created and Modified field to DBTimestamp

### DIFF
--- a/v2/dtos/dbtimestamp.go
+++ b/v2/dtos/dbtimestamp.go
@@ -1,0 +1,11 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dtos
+
+type DBTimestamp struct {
+	Created  int64 `json:"created,omitempty"`
+	Modified int64 `json:"modified,omitempty"`
+}

--- a/v2/dtos/device.go
+++ b/v2/dtos/device.go
@@ -12,9 +12,8 @@ import (
 // Device and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/Device
 type Device struct {
+	DBTimestamp    `json:",inline"`
 	Id             string                        `json:"id,omitempty" validate:"omitempty,uuid"`
-	Created        int64                         `json:"created,omitempty"`
-	Modified       int64                         `json:"modified,omitempty"`
 	Name           string                        `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Description    string                        `json:"description,omitempty"`
 	AdminState     string                        `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`

--- a/v2/dtos/deviceprofile.go
+++ b/v2/dtos/deviceprofile.go
@@ -16,6 +16,7 @@ import (
 // DeviceProfile and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceProfile
 type DeviceProfile struct {
+	DBTimestamp     `json:",inline"`
 	Id              string           `json:"id,omitempty" validate:"omitempty,uuid"`
 	Name            string           `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Manufacturer    string           `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
@@ -38,6 +39,7 @@ func (dp *DeviceProfile) Validate() error {
 // UnmarshalYAML implements the Unmarshaler interface for the DeviceProfile type
 func (dp *DeviceProfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var alias struct {
+		DBTimestamp
 		Id              string           `yaml:"id"`
 		Name            string           `yaml:"name"`
 		Manufacturer    string           `yaml:"manufacturer"`
@@ -70,6 +72,7 @@ func (dp *DeviceProfile) UnmarshalYAML(unmarshal func(interface{}) error) error 
 // ToDeviceProfileModel transforms the DeviceProfile DTO to the DeviceProfile model
 func ToDeviceProfileModel(deviceProfileDTO DeviceProfile) models.DeviceProfile {
 	return models.DeviceProfile{
+		DBTimestamp:     models.DBTimestamp(deviceProfileDTO.DBTimestamp),
 		Id:              deviceProfileDTO.Id,
 		Name:            deviceProfileDTO.Name,
 		Description:     deviceProfileDTO.Description,
@@ -84,6 +87,7 @@ func ToDeviceProfileModel(deviceProfileDTO DeviceProfile) models.DeviceProfile {
 // FromDeviceProfileModelToDTO transforms the DeviceProfile Model to the DeviceProfile DTO
 func FromDeviceProfileModelToDTO(deviceProfile models.DeviceProfile) DeviceProfile {
 	return DeviceProfile{
+		DBTimestamp:     DBTimestamp(deviceProfile.DBTimestamp),
 		Id:              deviceProfile.Id,
 		Name:            deviceProfile.Name,
 		Description:     deviceProfile.Description,

--- a/v2/dtos/deviceservice.go
+++ b/v2/dtos/deviceservice.go
@@ -12,10 +12,9 @@ import (
 // DeviceService and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceService
 type DeviceService struct {
+	DBTimestamp   `json:",inline"`
 	Id            string   `json:"id,omitempty" validate:"omitempty,uuid"`
 	Name          string   `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Created       int64    `json:"created,omitempty"`
-	Modified      int64    `json:"modified,omitempty"`
 	Description   string   `json:"description,omitempty"`
 	LastConnected int64    `json:"lastConnected,omitempty"`
 	LastReported  int64    `json:"lastReported,omitempty"`

--- a/v2/dtos/interval.go
+++ b/v2/dtos/interval.go
@@ -12,14 +12,13 @@ import (
 // Interval and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/Interval
 type Interval struct {
-	Id        string `json:"id,omitempty" validate:"omitempty,uuid"`
-	Created   int64  `json:"created,omitempty"`
-	Modified  int64  `json:"modified,omitempty"`
-	Name      string `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Start     string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
-	End       string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
-	Frequency string `json:"frequency" validate:"required,edgex-dto-frequency"`
-	RunOnce   bool   `json:"runOnce,omitempty"`
+	DBTimestamp `json:",inline"`
+	Id          string `json:"id,omitempty" validate:"omitempty,uuid"`
+	Name        string `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Start       string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
+	End         string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
+	Frequency   string `json:"frequency" validate:"required,edgex-dto-frequency"`
+	RunOnce     bool   `json:"runOnce,omitempty"`
 }
 
 // UpdateInterval and its properties are defined in the APIv2 specification:

--- a/v2/dtos/intervalaction.go
+++ b/v2/dtos/intervalaction.go
@@ -14,8 +14,7 @@ import (
 // IntervalAction and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/IntervalAction
 type IntervalAction struct {
-	Created      int64   `json:"created,omitempty"`
-	Modified     int64   `json:"modified,omitempty"`
+	DBTimestamp  `json:",inline"`
 	Id           string  `json:"id,omitempty" validate:"omitempty,uuid"`
 	Name         string  `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	IntervalName string  `json:"intervalName" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
@@ -53,6 +52,7 @@ func ToIntervalActionModel(dto IntervalAction) models.IntervalAction {
 // FromIntervalActionModelToDTO transforms the IntervalAction Model to the IntervalAction DTO
 func FromIntervalActionModelToDTO(model models.IntervalAction) IntervalAction {
 	var dto IntervalAction
+	dto.DBTimestamp = DBTimestamp(model.DBTimestamp)
 	dto.Id = model.Id
 	dto.Name = model.Name
 	dto.IntervalName = model.IntervalName

--- a/v2/dtos/notification.go
+++ b/v2/dtos/notification.go
@@ -14,9 +14,8 @@ import (
 // Notification and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/Notification
 type Notification struct {
+	DBTimestamp `json:",inline"`
 	Id          string   `json:"id,omitempty" validate:"omitempty,uuid"`
-	Created     int64    `json:"created,omitempty"`
-	Modified    int64    `json:"modified,omitempty"`
 	Category    string   `json:"category,omitempty" validate:"required_without=Labels,omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Labels      []string `json:"labels,omitempty" validate:"required_without=Category,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Content     string   `json:"content" validate:"required,edgex-dto-none-empty-string"`
@@ -43,8 +42,7 @@ func NewNotification(labels []string, category, content, sender, severity string
 func ToNotificationModel(n Notification) models.Notification {
 	var m models.Notification
 	m.Id = n.Id
-	m.Created = n.Created
-	m.Modified = n.Modified
+	m.DBTimestamp = models.DBTimestamp(n.DBTimestamp)
 	m.Category = n.Category
 	m.Labels = n.Labels
 	m.Content = n.Content
@@ -68,9 +66,8 @@ func ToNotificationModels(notifications []Notification) []models.Notification {
 // FromNotificationModelToDTO transforms the Notification Model to the Notification DTO
 func FromNotificationModelToDTO(n models.Notification) Notification {
 	return Notification{
+		DBTimestamp: DBTimestamp(n.DBTimestamp),
 		Id:          n.Id,
-		Created:     n.Created,
-		Modified:    n.Modified,
 		Category:    string(n.Category),
 		Labels:      n.Labels,
 		Content:     n.Content,

--- a/v2/dtos/provisionwatcher.go
+++ b/v2/dtos/provisionwatcher.go
@@ -12,6 +12,7 @@ import (
 // ProvisionWatcher and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/ProvisionWatcher
 type ProvisionWatcher struct {
+	DBTimestamp         `json:",inline"`
 	Id                  string              `json:"id,omitempty" validate:"omitempty,uuid"`
 	Name                string              `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Labels              []string            `json:"labels,omitempty"`
@@ -40,7 +41,7 @@ type UpdateProvisionWatcher struct {
 // ToProvisionWatcherModel transforms the ProvisionWatcher DTO to the ProvisionWatcher model
 func ToProvisionWatcherModel(dto ProvisionWatcher) models.ProvisionWatcher {
 	return models.ProvisionWatcher{
-		Timestamps:          models.Timestamps{},
+		DBTimestamp:         models.DBTimestamp(dto.DBTimestamp),
 		Id:                  dto.Id,
 		Name:                dto.Name,
 		Labels:              dto.Labels,

--- a/v2/dtos/subscription.go
+++ b/v2/dtos/subscription.go
@@ -12,14 +12,13 @@ import (
 // Subscription and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/Subscription
 type Subscription struct {
+	DBTimestamp    `json:",inline"`
 	Id             string    `json:"id,omitempty" validate:"omitempty,uuid"`
 	Name           string    `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Channels       []Address `json:"channels" validate:"required,gt=0,dive"`
 	Receiver       string    `json:"receiver" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Categories     []string  `json:"categories,omitempty" validate:"required_without=Labels,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Labels         []string  `json:"labels,omitempty" validate:"required_without=Categories,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Created        int64     `json:"created,omitempty"`
-	Modified       int64     `json:"modified,omitempty"`
 	Description    string    `json:"description,omitempty"`
 	ResendLimit    int64     `json:"resendLimit,omitempty"`
 	ResendInterval string    `json:"resendInterval,omitempty" validate:"omitempty,edgex-dto-frequency"`
@@ -45,8 +44,7 @@ func ToSubscriptionModel(s Subscription) models.Subscription {
 	m.Categories = s.Categories
 	m.Labels = s.Labels
 	m.Channels = ToAddressModels(s.Channels)
-	m.Created = s.Created
-	m.Modified = s.Modified
+	m.DBTimestamp = models.DBTimestamp(s.DBTimestamp)
 	m.Description = s.Description
 	m.Id = s.Id
 	m.Receiver = s.Receiver
@@ -68,11 +66,10 @@ func ToSubscriptionModels(subs []Subscription) []models.Subscription {
 // FromSubscriptionModelToDTO transforms the Subscription Model to the Subscription DTO
 func FromSubscriptionModelToDTO(s models.Subscription) Subscription {
 	return Subscription{
+		DBTimestamp:    DBTimestamp(s.DBTimestamp),
 		Categories:     s.Categories,
 		Labels:         s.Labels,
 		Channels:       FromAddressModelsToDTOs(s.Channels),
-		Created:        s.Created,
-		Modified:       s.Modified,
 		Description:    s.Description,
 		Id:             s.Id,
 		Receiver:       s.Receiver,

--- a/v2/models/dbtimestamp.go
+++ b/v2/models/dbtimestamp.go
@@ -5,7 +5,7 @@
 
 package models
 
-type Timestamps struct {
+type DBTimestamp struct {
 	Created  int64 // Created is a timestamp indicating when the entity was created.
 	Modified int64 // Modified is a timestamp indicating when the entity was last modified.
 }

--- a/v2/models/device.go
+++ b/v2/models/device.go
@@ -9,7 +9,7 @@ package models
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/Device
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type Device struct {
-	Timestamps
+	DBTimestamp
 	Id             string
 	Name           string
 	Description    string

--- a/v2/models/deviceprofile.go
+++ b/v2/models/deviceprofile.go
@@ -9,7 +9,7 @@ package models
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceProfile
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type DeviceProfile struct {
-	Timestamps
+	DBTimestamp
 	Description     string
 	Id              string
 	Name            string

--- a/v2/models/deviceservice.go
+++ b/v2/models/deviceservice.go
@@ -9,7 +9,7 @@ package models
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/DeviceService
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type DeviceService struct {
-	Timestamps
+	DBTimestamp
 	Id            string
 	Name          string
 	Description   string

--- a/v2/models/interval.go
+++ b/v2/models/interval.go
@@ -9,7 +9,7 @@ package models
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/Interval
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type Interval struct {
-	Timestamps
+	DBTimestamp
 	Id        string
 	Name      string
 	Start     string

--- a/v2/models/intervalaction.go
+++ b/v2/models/intervalaction.go
@@ -15,7 +15,7 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/IntervalAction
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type IntervalAction struct {
-	Timestamps
+	DBTimestamp
 	Id           string
 	Name         string
 	IntervalName string
@@ -24,7 +24,7 @@ type IntervalAction struct {
 
 func (intervalAction *IntervalAction) UnmarshalJSON(b []byte) error {
 	var alias struct {
-		Timestamps
+		DBTimestamp
 		Id           string
 		Name         string
 		IntervalName string
@@ -39,7 +39,7 @@ func (intervalAction *IntervalAction) UnmarshalJSON(b []byte) error {
 	}
 
 	*intervalAction = IntervalAction{
-		Timestamps:   alias.Timestamps,
+		DBTimestamp:  alias.DBTimestamp,
 		Id:           alias.Id,
 		Name:         alias.Name,
 		IntervalName: alias.IntervalName,

--- a/v2/models/intervalaction_test.go
+++ b/v2/models/intervalaction_test.go
@@ -17,7 +17,7 @@ import (
 
 func actionWithRESTAddressData() IntervalAction {
 	return IntervalAction{
-		Timestamps:   Timestamps{},
+		DBTimestamp:  DBTimestamp{},
 		Id:           ExampleUUID,
 		Name:         TestIntervalActionName,
 		IntervalName: TestIntervalName,
@@ -33,7 +33,7 @@ func actionWithRESTAddressData() IntervalAction {
 }
 func actionWithMQTTPubAddressData() IntervalAction {
 	return IntervalAction{
-		Timestamps:   Timestamps{},
+		DBTimestamp:  DBTimestamp{},
 		Id:           ExampleUUID,
 		Name:         TestIntervalActionName,
 		IntervalName: TestIntervalName,

--- a/v2/models/notification.go
+++ b/v2/models/notification.go
@@ -9,7 +9,7 @@ package models
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/Notification
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type Notification struct {
-	Timestamps
+	DBTimestamp
 	Category    string
 	Content     string
 	ContentType string

--- a/v2/models/provisionwatcher.go
+++ b/v2/models/provisionwatcher.go
@@ -9,7 +9,7 @@ package models
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/ProvisionWatcher
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type ProvisionWatcher struct {
-	Timestamps
+	DBTimestamp
 	Id                  string
 	Name                string
 	Labels              []string

--- a/v2/models/subscription.go
+++ b/v2/models/subscription.go
@@ -15,7 +15,7 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/Subscription
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
 type Subscription struct {
-	Timestamps
+	DBTimestamp
 	Categories     []string
 	Labels         []string
 	Channels       []Address
@@ -29,7 +29,7 @@ type Subscription struct {
 
 func (subscription *Subscription) UnmarshalJSON(b []byte) error {
 	var alias struct {
-		Timestamps
+		DBTimestamp
 		Categories     []string
 		Labels         []string
 		Channels       []interface{}
@@ -53,7 +53,7 @@ func (subscription *Subscription) UnmarshalJSON(b []byte) error {
 	}
 
 	*subscription = Subscription{
-		Timestamps:     alias.Timestamps,
+		DBTimestamp:    alias.DBTimestamp,
 		Categories:     alias.Categories,
 		Labels:         alias.Labels,
 		Description:    alias.Description,


### PR DESCRIPTION
Close #560

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #560


## What is the new behavior?
For reusing the Created and Modified fields, extract these fields to a single struct.
- Rename the Timestamps to DBTimestamp
- Refactor DTO's Created and Modified field to DBTimestamp struct

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information