### PR TITLE
fix: Add validation tag to verify subscription with empty Channels

### DIFF
--- a/v2/dtos/requests/subscription_test.go
+++ b/v2/dtos/requests/subscription_test.go
@@ -211,6 +211,10 @@ func TestUpdateSubscriptionRequest_Validate(t *testing.T) {
 	unsupportedChannelType.Subscription.Channels = []dtos.Address{
 		dtos.NewMQTTAddress("host", 123, "publisher", "topic"),
 	}
+	validWithoutChannels := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	validWithoutChannels.Subscription.Channels = nil
+	invalidEmptyChannels := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	invalidEmptyChannels.Subscription.Channels = []dtos.Address{}
 
 	categoryNameWithReservedChar := NewUpdateSubscriptionRequest(updateSubscriptionData())
 	categoryNameWithReservedChar.Subscription.Categories = []string{namesWithReservedChar[0]}
@@ -239,6 +243,8 @@ func TestUpdateSubscriptionRequest_Validate(t *testing.T) {
 		{"invalid, category name containing reserved chars", categoryNameWithReservedChar, true},
 		{"invalid, receiver name containing reserved chars", receiverNameWithReservedChars, true},
 		{"invalid, resendInterval is not specified in ISO8601 format", invalidResendInterval, true},
+		{"valid, without channels", validWithoutChannels, false},
+		{"invalid, empty channels", invalidEmptyChannels, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v2/dtos/subscription.go
+++ b/v2/dtos/subscription.go
@@ -29,7 +29,7 @@ type Subscription struct {
 type UpdateSubscription struct {
 	Id             *string   `json:"id,omitempty" validate:"required_without=Name,edgex-dto-uuid"`
 	Name           *string   `json:"name,omitempty" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Channels       []Address `json:"channels,omitempty" validate:"omitempty,dive"`
+	Channels       []Address `json:"channels,omitempty" validate:"omitempty,gt=0,dive"`
 	Receiver       *string   `json:"receiver,omitempty" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Categories     []string  `json:"categories,omitempty" validate:"omitempty,dive,gt=0,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Labels         []string  `json:"labels,omitempty" validate:"omitempty,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`


### PR DESCRIPTION
Close #565

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #565 


## What is the new behavior?
Add validation tag `gt=0` to verify subscription:
- empty Channels should be invalid
- nil Channels should be valid

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information