### PR TITLE
feat(v2): BaseResponse omit empty RequestId and Message

### DIFF
--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -31,9 +31,9 @@ func NewBaseRequest() BaseRequest {
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BaseResponse
 type BaseResponse struct {
 	Versionable `json:",inline"`
-	RequestId   string      `json:"requestId"`
-	Message     interface{} `json:"message,omitempty"`
-	StatusCode  int         `json:"statusCode"`
+	RequestId   string `json:"requestId,omitempty"`
+	Message     string `json:"message,omitempty"`
+	StatusCode  int    `json:"statusCode"`
 }
 
 // Versionable shows the API version in DTOs

--- a/v2/dtos/common/base_test.go
+++ b/v2/dtos/common/base_test.go
@@ -7,11 +7,14 @@
 package common
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewBaseRequest(t *testing.T) {
@@ -47,4 +50,39 @@ func TestNewBaseWithIdResponse(t *testing.T) {
 	assert.Equal(t, expectedStatusCode, actual.StatusCode)
 	assert.Equal(t, expectedMessage, actual.Message)
 	assert.Equal(t, expectedId, actual.Id)
+}
+
+func TestBaseResponse_Marshal(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	response := NewBaseResponse(expectedRequestId, expectedMessage, expectedStatusCode)
+	expectedResponseJsonStr := fmt.Sprintf(
+		`{"apiVersion":"%s","requestId":"%s","message":"%s","statusCode":%d}`,
+		response.ApiVersion, response.RequestId, response.Message, response.StatusCode)
+	noRequestId := NewBaseResponse("", expectedMessage, expectedStatusCode)
+	expectedNoRequestIdJsonStr := fmt.Sprintf(
+		`{"apiVersion":"%s","message":"%s","statusCode":%d}`,
+		noRequestId.ApiVersion, noRequestId.Message, noRequestId.StatusCode)
+	noMessage := NewBaseResponse(expectedRequestId, "", expectedStatusCode)
+	expectedNoMessageJsonStr := fmt.Sprintf(
+		`{"apiVersion":"%s","requestId":"%s","statusCode":%d}`,
+		noMessage.ApiVersion, noMessage.RequestId, noMessage.StatusCode)
+
+	tests := []struct {
+		name     string
+		data     BaseResponse
+		expected string
+	}{
+		{"JSON marshal base response", response, expectedResponseJsonStr},
+		{"JSON marshal base response, no requestId", noRequestId, expectedNoRequestIdJsonStr},
+		{"JSON marshal base response, no message", noMessage, expectedNoMessageJsonStr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := json.Marshal(tt.data)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
 }


### PR DESCRIPTION
Close #567

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

## Issue Number: #567


## What is the new behavior?
- Add omitempty json tag to RequestId
- Message use string instead of interface{} data type

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information