### PR TITLE
feat: Return 400 when UpdateSubscription with empty categories and labels

### DIFF
--- a/v2/dtos/requests/subscription.go
+++ b/v2/dtos/requests/subscription.go
@@ -92,6 +92,10 @@ func (request UpdateSubscriptionRequest) Validate() error {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, "MQTT is not valid type for Channel", nil)
 		}
 	}
+	if request.Subscription.Categories != nil && request.Subscription.Labels != nil &&
+		len(request.Subscription.Categories) == 0 && len(request.Subscription.Labels) == 0 {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "categories and labels can not be both empty", nil)
+	}
 	return nil
 }
 

--- a/v2/dtos/requests/subscription_test.go
+++ b/v2/dtos/requests/subscription_test.go
@@ -226,6 +226,22 @@ func TestUpdateSubscriptionRequest_Validate(t *testing.T) {
 	invalidResendIntervalValue := "10"
 	invalidResendInterval.Subscription.ResendInterval = &invalidResendIntervalValue
 
+	noCategories := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	noCategories.Subscription.Categories = nil
+	noLabels := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	noLabels.Subscription.Labels = nil
+	noCategoriesAndLabels := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	noCategoriesAndLabels.Subscription.Categories = nil
+	noCategoriesAndLabels.Subscription.Labels = nil
+
+	emptyCategories := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	emptyCategories.Subscription.Categories = []string{}
+	emptyLabels := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	emptyLabels.Subscription.Labels = []string{}
+	emptyCategoriesAndLabels := NewUpdateSubscriptionRequest(updateSubscriptionData())
+	emptyCategoriesAndLabels.Subscription.Categories = []string{}
+	emptyCategoriesAndLabels.Subscription.Labels = []string{}
+
 	tests := []struct {
 		name        string
 		req         UpdateSubscriptionRequest
@@ -245,6 +261,12 @@ func TestUpdateSubscriptionRequest_Validate(t *testing.T) {
 		{"invalid, resendInterval is not specified in ISO8601 format", invalidResendInterval, true},
 		{"valid, without channels", validWithoutChannels, false},
 		{"invalid, empty channels", invalidEmptyChannels, true},
+		{"valid, no categories", noCategories, false},
+		{"valid, no labels", noLabels, false},
+		{"valid, no categories and labels", noCategoriesAndLabels, false},
+		{"valid, empty categories", emptyCategories, false},
+		{"valid, empty labels", emptyLabels, false},
+		{"invalid, empty categories and labels", emptyCategoriesAndLabels, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Close #569

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
UpdateSubscriptionRequest accept empty categories and labels.

## Issue Number: #569 


## What is the new behavior?
UpdateSubscriptionRequest verify the categories and labels which can not be both empty

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information