### PR TITLE
fix: remove unnecessary arrow sign in error message

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -96,7 +96,11 @@ func (ce CommonEdgeX) Error() string {
 
 	// ce.err.Error functionality gets the error message of the nested error and which will handle both CommonEdgeX
 	// types and Go standard errors(both wrapped and non-wrapped).
-	return ce.message + " -> " + ce.err.Error()
+	if ce.message != "" {
+		return ce.message + " -> " + ce.err.Error()
+	} else {
+		return ce.err.Error()
+	}
 }
 
 // DebugMessages returns a string taking all nested and wrapped operations and errors into account.


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
`errors.NewCommonEdgexWrapper` is used to record the function call stacks, it doesn't add additional error/info message:
https://github.com/edgexfoundry/go-mod-core-contracts/blob/9675502d886e98cc9b362e5032cc42b972c2765c/errors/types.go#L164-L174
If the returning error is wrapped by multiple `errors.NewCommonEdgexWrapper` calls, the error message is a bit confusing:
```
level=ERROR ts=2021-04-01T04:02:20.277154Z app=device-simple source=init.go:76 msg="Failed to create the pre-defined devices: failed to add devices with DeviceClient ->  ->  -> request failed, status code: 400, err: {\"apiVersion\":\"v2\",\"message\":\"device json decoding failed\",\"statusCode\":400}\n"
``` 

## Issue Number:


## What is the new behavior?
```
level=ERROR ts=2021-04-01T04:05:55.785878Z app=device-simple source=init.go:76 msg="Failed to create the pre-defined devices: failed to add devices with DeviceClient -> request failed, status code: 400, err: {\"apiVersion\":\"v2\",\"message\":\"device json decoding failed\",\"statusCode\":400}\n"
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information