### PR TITLE
fix: Fix ambiguous import path for V2 module

### DIFF
--- a/v2/clients/constants.go
+++ b/v2/clients/constants.go
@@ -1,0 +1,17 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+const (
+	CorrelationHeader = "X-Correlation-ID" // Sets the key of the Correlation ID HTTP header
+)
+
+// Constants related to the possible content types supported by the APIs
+const (
+	ContentType     = "Content-Type"
+	ContentTypeCBOR = "application/cbor"
+	ContentTypeJSON = "application/json"
+)

--- a/v2/clients/http/deviceservicecommand.go
+++ b/v2/clients/http/deviceservicecommand.go
@@ -11,9 +11,9 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http/utils"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"

--- a/v2/clients/http/utils/common.go
+++ b/v2/clients/http/utils/common.go
@@ -17,8 +17,8 @@ import (
 	"net/url"
 	"path/filepath"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients"
 
 	"github.com/google/uuid"
 )

--- a/v2/clients/http/utils/request.go
+++ b/v2/clients/http/utils/request.go
@@ -12,8 +12,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients"
 )
 
 // GetRequest makes the get request and return the body

--- a/v2/dtos/address_test.go
+++ b/v2/dtos/address_test.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 
 	"github.com/stretchr/testify/assert"

--- a/v2/dtos/requests/event.go
+++ b/v2/dtos/requests/event.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"

--- a/v2/dtos/responses/event.go
+++ b/v2/dtos/responses/event.go
@@ -9,9 +9,9 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	"github.com/fxamacker/cbor/v2"


### PR DESCRIPTION
Close #596

Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #596


## What is the new behavior?
Fix the ambiguous import that is referencing either V1 clients or V2 clients from V1 Modules.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information