### PR TITLE
feat: add HealthResponse for SMA GET health API

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -111,6 +111,8 @@ const (
 	ApiAllIntervalActionRoute      = ApiIntervalActionRoute + "/" + All
 	ApiIntervalActionByNameRoute   = ApiIntervalActionRoute + "/" + Name + "/{" + Name + "}"
 	ApiIntervalActionByTargetRoute = ApiIntervalActionRoute + "/" + Target + "/{" + Target + "}"
+
+	ApiHealthRoute = ApiBase + "/health/{services}"
 )
 
 // Constants related to defined url path names and parameters in the v2 service APIs

--- a/v2/dtos/responses/health.go
+++ b/v2/dtos/responses/health.go
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package responses
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+)
+
+// HealthResponse defines the Response Content for GET health status.
+// This object and its properties correspond to the HealthResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis/EdgeXFoundry1/system-agent/2.0#/HealthResponse
+type HealthResponse struct {
+	common.BaseResponse `json:",inline"`
+	Health              map[string]string `json:"health"`
+}
+
+func NewHealthResponse(requestId string, message string, statusCode int, health map[string]string) HealthResponse {
+	return HealthResponse{
+		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
+		Health:       health,
+	}
+}

--- a/v2/dtos/responses/health_test.go
+++ b/v2/dtos/responses/health_test.go
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package responses
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHealthResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedHealth := map[string]string{"serviceA": "healthy", "serviceB": "unhealthy"}
+	actual := NewHealthResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedHealth)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedHealth, actual.Health)
+}


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: related to https://github.com/edgexfoundry/edgex-go/issues/3418


## What is the new behavior?
example result of the HealthResponse:
```
{
    apiVersion: "v2"
    message: "message"
    statusCode: 200
    health: {
        edgex-core-command: "healthy"
        edgex-core-data: "healthy"
        support-scheduler: "support-scheduler service is not registered. Might not have started... "
}
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information