### PR TITLE
feat: Add parameters field to Core Command

### DIFF
--- a/v2/dtos/corecommand.go
+++ b/v2/dtos/corecommand.go
@@ -16,9 +16,17 @@ type DeviceCoreCommand struct {
 // CoreCommand and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/CoreCommand
 type CoreCommand struct {
-	Name string `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Get  bool   `json:"get,omitempty" validate:"required_without=Set"`
-	Set  bool   `json:"set,omitempty" validate:"required_without=Get"`
-	Path string `json:"path,omitempty"`
-	Url  string `json:"url,omitempty"`
+	Name       string                 `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Get        bool                   `json:"get,omitempty" validate:"required_without=Set"`
+	Set        bool                   `json:"set,omitempty" validate:"required_without=Get"`
+	Path       string                 `json:"path,omitempty"`
+	Url        string                 `json:"url,omitempty"`
+	Parameters []CoreCommandParameter `json:"parameters,omitempty"`
+}
+
+// CoreCommandParameter and its properties are defined in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-command/2.x#/CoreCommandParameter
+type CoreCommandParameter struct {
+	ResourceName string `json:"resourceName"`
+	ValueType    string `json:"valueType"`
 }

--- a/v2/dtos/responses/corecommand_test.go
+++ b/v2/dtos/responses/corecommand_test.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,12 +19,15 @@ func TestNewDeviceCoreCommandResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := http.StatusOK
 	expectedMessage := "unit test message"
+	testParameters := []dtos.CoreCommandParameter{
+		{ResourceName: "resource", ValueType: v2.ValueTypeInt8},
+	}
 	expectedDeviceCoreCommand := dtos.DeviceCoreCommand{
 		DeviceName:  "testDevice1",
 		ProfileName: "testProfile",
 		CoreCommands: []dtos.CoreCommand{
-			{Name: "testCommand1", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
-			{Name: "testCommand2", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+			{Name: "testCommand1", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082", Parameters: testParameters},
+			{Name: "testCommand2", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082", Parameters: testParameters},
 		},
 	}
 	actual := NewDeviceCoreCommandResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedDeviceCoreCommand)
@@ -37,21 +42,24 @@ func TestNewMultiDeviceCoreCommandsResponse(t *testing.T) {
 	expectedRequestId := "123456"
 	expectedStatusCode := http.StatusOK
 	expectedMessage := "unit test message"
+	testParameters := []dtos.CoreCommandParameter{
+		{ResourceName: "resource", ValueType: v2.ValueTypeInt8},
+	}
 	expectedDeviceCoreCommands := []dtos.DeviceCoreCommand{
 		dtos.DeviceCoreCommand{
 			DeviceName:  "testDevice1",
 			ProfileName: "testProfile",
 			CoreCommands: []dtos.CoreCommand{
-				{Name: "testCommand1", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
-				{Name: "testCommand2", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+				{Name: "testCommand1", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082", Parameters: testParameters},
+				{Name: "testCommand2", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082", Parameters: testParameters},
 			},
 		},
 		dtos.DeviceCoreCommand{
 			DeviceName:  "testDevice2",
 			ProfileName: "testProfile",
 			CoreCommands: []dtos.CoreCommand{
-				{Name: "testCommand3", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082"},
-				{Name: "testCommand4", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082"},
+				{Name: "testCommand3", Get: true, Set: false, Path: "/device/name/testDevice1/command/testCommand1", Url: "http://127.0.0.1:48082", Parameters: testParameters},
+				{Name: "testCommand4", Get: false, Set: true, Path: "/device/name/testDevice1/command/testCommand2", Url: "http://127.0.0.1:48082", Parameters: testParameters},
 			},
 		},
 	}


### PR DESCRIPTION
Close #574

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #574 


## What is the new behavior?
Add a field called parameters to Core Command. For Get command, it describes the expected readings. For Set command, it describes the parameters in the payload.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information