### PR TITLE
refactor: Remove edgex-prefix from all service keys

### DIFF
--- a/clients/constants.go
+++ b/clients/constants.go
@@ -56,20 +56,19 @@ const (
 
 // Constants related to how services identify themselves in the Service Registry
 const (
-	ServiceKeyPrefix                    = "edgex-"
-	ConfigSeedServiceKey                = "edgex-config-seed"
-	CoreCommandServiceKey               = "edgex-core-command"
-	CoreDataServiceKey                  = "edgex-core-data"
-	CoreMetaDataServiceKey              = "edgex-core-metadata"
-	SupportLoggingServiceKey            = "edgex-support-logging"
-	SupportNotificationsServiceKey      = "edgex-support-notifications"
-	SystemManagementAgentServiceKey     = "edgex-sys-mgmt-agent"
-	SupportSchedulerServiceKey          = "edgex-support-scheduler"
-	SecuritySecretStoreSetupServiceKey  = "edgex-security-secretstore-setup"
-	SecuritySecretsSetupServiceKey      = "edgex-security-secrets-setup"
-	SecurityProxySetupServiceKey        = "edgex-security-proxy-setup"
-	SecurityFileTokenProviderServiceKey = "edgex-security-file-token-provider"
-	SecurityBootstrapRedisKey           = "edgex-security-bootstrap-redis"
+	CoreCommandServiceKey               = "core-command"
+	CoreDataServiceKey                  = "core-data"
+	CoreMetaDataServiceKey              = "core-metadata"
+	SupportLoggingServiceKey            = "support-logging"
+	SupportNotificationsServiceKey      = "support-notifications"
+	SystemManagementAgentServiceKey     = "sys-mgmt-agent"
+	SupportSchedulerServiceKey          = "support-scheduler"
+	SecuritySecretStoreSetupServiceKey  = "security-secretstore-setup"
+	SecuritySecretsSetupServiceKey      = "security-secrets-setup"
+	SecurityProxySetupServiceKey        = "security-proxy-setup"
+	SecurityFileTokenProviderServiceKey = "security-file-token-provider"
+	SecurityBootstrapperKey             = "security-bootstrapper"
+	SecurityBootstrapperRedisKey        = "security-bootstrapper-redis"
 )
 
 // Constants related to the possible content types supported by the APIs

--- a/clients/constants.go
+++ b/clients/constants.go
@@ -64,7 +64,6 @@ const (
 	SystemManagementAgentServiceKey     = "sys-mgmt-agent"
 	SupportSchedulerServiceKey          = "support-scheduler"
 	SecuritySecretStoreSetupServiceKey  = "security-secretstore-setup"
-	SecuritySecretsSetupServiceKey      = "security-secrets-setup"
 	SecurityProxySetupServiceKey        = "security-proxy-setup"
 	SecurityFileTokenProviderServiceKey = "security-file-token-provider"
 	SecurityBootstrapperKey             = "security-bootstrapper"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
Service key constants have the `edgex-` prefix

## Issue Number: #612


## What is the new behavior?
Service key constants no longer have the `edgex-` prefix

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Service key names have changed.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information