### PR TITLE
feat: prepare new route and DTO for SMA v2 redesign

### DIFF
--- a/v2/constants.go
+++ b/v2/constants.go
@@ -113,10 +113,11 @@ const (
 	ApiIntervalActionByNameRoute   = ApiIntervalActionRoute + "/" + Name + "/{" + Name + "}"
 	ApiIntervalActionByTargetRoute = ApiIntervalActionRoute + "/" + Target + "/{" + Target + "}"
 
-	ApiOperationRoute    = ApiBase + "/operation"
-	ApiHealthRoute       = ApiBase + "/health/{" + Services + "}"
-	ApiMultiMetricsRoute = ApiMetricsRoute + "/{" + Services + "}"
-	ApiMultiConfigsRoute = ApiBase + "/configs/{" + Services + "}"
+	ApiSystemRoute       = ApiBase + "/system"
+	ApiOperationRoute    = ApiSystemRoute + "/operation"
+	ApiHealthRoute       = ApiSystemRoute + "/health"
+	ApiMultiMetricsRoute = ApiSystemRoute + "/metrics"
+	ApiMultiConfigRoute  = ApiSystemRoute + "/config"
 )
 
 // Constants related to defined url path names and parameters in the v2 service APIs

--- a/v2/dtos/common/base.go
+++ b/v2/dtos/common/base.go
@@ -8,7 +8,7 @@ package common
 import (
 	"github.com/google/uuid"
 
-	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 )
 
 // Request defines the base content for request DTOs (data transfer objects).
@@ -67,4 +67,30 @@ func NewBaseWithIdResponse(requestId string, message string, statusCode int, id 
 		BaseResponse: NewBaseResponse(requestId, message, statusCode),
 		Id:           id,
 	}
+}
+
+// BaseWithServiceNameResponse defines the base content for response DTOs (data transfer objects).
+// This object and its properties correspond to the BaseWithServiceNameResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/system-agent/2.x#/BaseWithServiceNameResponse
+type BaseWithServiceNameResponse struct {
+	BaseResponse `json:",inline"`
+	ServiceName  string `json:"serviceName"`
+}
+
+// BaseWithMetricsResponse defines the base content for response DTOs (data transfer objects).
+// This object and its properties correspond to the BaseWithMetricsResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/system-agent/2.x#/BaseWithMetricsResponse
+type BaseWithMetricsResponse struct {
+	BaseResponse `json:",inline"`
+	ServiceName  string      `json:"serviceName"`
+	Metrics      interface{} `json:"metrics"`
+}
+
+// BaseWithConfigResponse defines the base content for response DTOs (data transfer objects).
+// This object and its properties correspond to the BaseWithConfigResponse object in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/system-agent/2.x#/BaseWithConfigResponse
+type BaseWithConfigResponse struct {
+	BaseResponse `json:",inline"`
+	ServiceName  string      `json:"serviceName"`
+	Config       interface{} `json:"config"`
 }

--- a/v2/dtos/common/config.go
+++ b/v2/dtos/common/config.go
@@ -21,15 +21,3 @@ func NewConfigResponse(serviceConfig interface{}) ConfigResponse {
 		Config:      serviceConfig,
 	}
 }
-
-type MultiConfigsResponse struct {
-	BaseResponse `json:",inline"`
-	Configs      map[string]ConfigResponse `json:"configs"`
-}
-
-func NewMultiConfigsResponse(requestId string, message string, statusCode int, configs map[string]ConfigResponse) MultiConfigsResponse {
-	return MultiConfigsResponse{
-		BaseResponse: NewBaseResponse(requestId, message, statusCode),
-		Configs:      configs,
-	}
-}

--- a/v2/dtos/common/config_test.go
+++ b/v2/dtos/common/config_test.go
@@ -37,24 +37,3 @@ func TestNewConfigResponse(t *testing.T) {
 	json.Unmarshal(data, &actual)
 	assert.Equal(t, expected, actual)
 }
-
-func TestNewMultiConfigsResponse(t *testing.T) {
-	type testConfig struct {
-		Name string
-		Host string
-		Port int
-	}
-
-	c := testConfig{
-		Name: "UnitTest",
-		Host: "localhost",
-		Port: 8080,
-	}
-
-	expected := make(map[string]ConfigResponse)
-	expected["test"] = NewConfigResponse(c)
-	target := NewMultiConfigsResponse("", "", 200, expected)
-
-	assert.Equal(t, v2.ApiVersion, target.ApiVersion)
-	assert.Equal(t, expected, target.Configs)
-}

--- a/v2/dtos/common/metrics.go
+++ b/v2/dtos/common/metrics.go
@@ -31,15 +31,3 @@ func NewMetricsResponse(metrics Metrics) MetricsResponse {
 		Metrics:     metrics,
 	}
 }
-
-type MultiMetricsResponse struct {
-	BaseResponse `json:",inline"`
-	Metrics      map[string]interface{} `json:"metrics"`
-}
-
-func NewMultiMetricsResponse(requestId string, message string, statusCode int, metrics map[string]interface{}) MultiMetricsResponse {
-	return MultiMetricsResponse{
-		BaseResponse: NewBaseResponse(requestId, message, statusCode),
-		Metrics:      metrics,
-	}
-}

--- a/v2/dtos/common/metrics_test.go
+++ b/v2/dtos/common/metrics_test.go
@@ -8,7 +8,6 @@
 package common
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,26 +26,6 @@ func TestNewMetricsResponse(t *testing.T) {
 		CpuBusyAvg:     uint8(99),
 	}
 	target := NewMetricsResponse(expected)
-
-	actual := target.Metrics
-	assert.Equal(t, v2.ApiVersion, target.ApiVersion)
-	assert.Equal(t, expected, actual)
-}
-
-func TestNewMultiMetricsResponse(t *testing.T) {
-	m := Metrics{
-		MemAlloc:       uint64(234),
-		MemFrees:       uint64(1204),
-		MemLiveObjects: uint64(999),
-		MemSys:         uint64(123456789),
-		MemTotalAlloc:  uint64(9999999),
-		MemMallocs:     uint64(1589),
-		CpuBusyAvg:     uint8(99),
-	}
-
-	expected := make(map[string]interface{})
-	expected["test"] = NewMetricsResponse(m)
-	target := NewMultiMetricsResponse("", "", http.StatusOK, expected)
 
 	actual := target.Metrics
 	assert.Equal(t, v2.ApiVersion, target.ApiVersion)


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
pre-requisite of https://github.com/edgexfoundry/edgex-go/issues/3524

## What is the new behavior?
Because SMA original `api/v2/metrics` API is collided with each service's common API, update the SMA v2 API to have `api/v2/system` route prefix.

example of new sma v2 API:
```
$curl http://localhost:58890/api/v2/system/health?services=core-data,core-metadata
207
[
    {
        "apiVersion": "v2",
        "message": "core-data service is not registered. Might not have started... ",
        "statusCode": 404,
        "serviceName": "core-data"
    },
    {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "core-metadata"
    }
]

curl http://localhost:58890/api/v2/system/config?services=core-data,core-metadata
207
[
  {
        "apiVersion": "v2",
        "message": "core-data service is not registered. Might not have started... ",
        "statusCode": 404,
        "serviceName": "core-data",
        "config": null
    },
    {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "core-metadata",
        "config": {...}
    }
]

curl http://localhost:58890/api/v2/system/metrics?services=edgex-core-data,edgex-core-metadata
207
[
  {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "edgex-core-data",
        "metrics": {...}
    },
    {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "edgex-core-metadata",
        "metrics": {...}
    }
]
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
