### PR TITLE
refactor: Remove runOnce from the Interval

### DIFF
--- a/v2/dtos/interval.go
+++ b/v2/dtos/interval.go
@@ -18,7 +18,6 @@ type Interval struct {
 	Start       string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	End         string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	Interval    string `json:"interval" validate:"required,edgex-dto-duration"`
-	RunOnce     bool   `json:"runOnce,omitempty"`
 }
 
 // NewInterval creates interval DTO with required fields
@@ -34,7 +33,6 @@ type UpdateInterval struct {
 	Start    *string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	End      *string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	Interval *string `json:"interval,omitempty" validate:"omitempty,edgex-dto-duration"`
-	RunOnce  *bool   `json:"runOnce,omitempty"`
 }
 
 // NewUpdateInterval creates updateInterval DTO with required field
@@ -50,7 +48,6 @@ func ToIntervalModel(dto Interval) models.Interval {
 	model.Start = dto.Start
 	model.End = dto.End
 	model.Interval = dto.Interval
-	model.RunOnce = dto.RunOnce
 	return model
 }
 
@@ -62,6 +59,5 @@ func FromIntervalModelToDTO(model models.Interval) Interval {
 	dto.Start = model.Start
 	dto.End = model.End
 	dto.Interval = model.Interval
-	dto.RunOnce = model.RunOnce
 	return dto
 }

--- a/v2/dtos/requests/const_test.go
+++ b/v2/dtos/requests/const_test.go
@@ -34,7 +34,6 @@ const (
 	TestIntervalStart    = "20190102T150405"
 	TestIntervalEnd      = "20190802T150405"
 	TestIntervalInterval = "30ms"
-	TestIntervalRunOnce  = false
 
 	TestIntervalActionName = "TestIntervalAction"
 	TestProtocol           = "http"

--- a/v2/dtos/requests/interval.go
+++ b/v2/dtos/requests/interval.go
@@ -101,9 +101,6 @@ func ReplaceIntervalModelFieldsWithDTO(interval *models.Interval, patch dtos.Upd
 	if patch.Interval != nil {
 		interval.Interval = *patch.Interval
 	}
-	if patch.RunOnce != nil {
-		interval.RunOnce = *patch.RunOnce
-	}
 }
 
 func NewAddIntervalRequest(dto dtos.Interval) AddIntervalRequest {

--- a/v2/dtos/requests/interval_test.go
+++ b/v2/dtos/requests/interval_test.go
@@ -28,7 +28,6 @@ func addIntervalRequestData() AddIntervalRequest {
 			Start:    TestIntervalStart,
 			End:      TestIntervalEnd,
 			Interval: TestIntervalInterval,
-			RunOnce:  TestIntervalRunOnce,
 		},
 	}
 }
@@ -49,14 +48,12 @@ func updateIntervalData() dtos.UpdateInterval {
 	testStart := TestIntervalStart
 	testEnd := TestIntervalEnd
 	testFrequency := TestIntervalInterval
-	testRunOnce := TestIntervalRunOnce
 	dto := dtos.UpdateInterval{}
 	dto.Id = &testId
 	dto.Name = &testName
 	dto.Start = &testStart
 	dto.End = &testEnd
 	dto.Interval = &testFrequency
-	dto.RunOnce = &testRunOnce
 	return dto
 }
 
@@ -141,7 +138,6 @@ func TestAddIntervalReqToIntervalModels(t *testing.T) {
 			Start:    TestIntervalStart,
 			End:      TestIntervalEnd,
 			Interval: TestIntervalInterval,
-			RunOnce:  TestIntervalRunOnce,
 		},
 	}
 	resultModels := AddIntervalReqToIntervalModels(requests)
@@ -244,7 +240,6 @@ func TestUpdateIntervalRequest_UnmarshalJSON_NilField(t *testing.T) {
 	assert.Nil(t, req.Interval.Start)
 	assert.Nil(t, req.Interval.End)
 	assert.Nil(t, req.Interval.Interval)
-	assert.Nil(t, req.Interval.RunOnce)
 }
 
 func TestReplaceIntervalModelFieldsWithDTO(t *testing.T) {
@@ -260,5 +255,4 @@ func TestReplaceIntervalModelFieldsWithDTO(t *testing.T) {
 	assert.Equal(t, TestIntervalStart, interval.Start)
 	assert.Equal(t, TestIntervalEnd, interval.End)
 	assert.Equal(t, TestIntervalInterval, interval.Interval)
-	assert.Equal(t, TestIntervalRunOnce, interval.RunOnce)
 }

--- a/v2/models/interval.go
+++ b/v2/models/interval.go
@@ -15,5 +15,4 @@ type Interval struct {
 	Start    string
 	End      string
 	Interval string
-	RunOnce  bool
 }


### PR DESCRIPTION
Close #629

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #629 


## What is the new behavior?
Remove the runOnce field from the Interval model and DTO according to the issue edgexfoundry/edgex-go#3532.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information