### PR TITLE
fix: Update name validator to not allow the "." character

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -31,7 +31,8 @@ const (
 
 const (
 	// Per https://tools.ietf.org/html/rfc3986#section-2.3, unreserved characters= ALPHA / DIGIT / "-" / "." / "_" / "~"
-	rFC3986UnreservedCharsRegexString = "^[a-zA-Z0-9-_.~]+$"
+	// Also due to names used in topics for Redis Pub/Sub, "."are not allowed
+	rFC3986UnreservedCharsRegexString = "^[a-zA-Z0-9-_~]+$"
 	intervalDatetimeLayout            = "20060102T150405"
 )
 
@@ -91,7 +92,7 @@ func getErrorMessage(e validator.FieldError) string {
 	case dtoNoneEmptyStringTag:
 		msg = fmt.Sprintf("%s field should not be empty string", fieldName)
 	case dtoRFC3986UnreservedCharTag:
-		msg = fmt.Sprintf("%s field only allows unreserved characters as defined in https://tools.ietf.org/html/rfc3986#section-2.3, which should be ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~", fieldName)
+		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~", fieldName)
 	default:
 		msg = fmt.Sprintf("%s field validation failed on the %s tag", fieldName, tag)
 	}

--- a/dtos/requests/const_test.go
+++ b/dtos/requests/const_test.go
@@ -75,4 +75,4 @@ var namesWithReservedChar = []string{
 	"name .~_001",
 }
 
-var nameWithUnreservedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+var nameWithUnreservedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
Name validator allows the "." character which causes issues when the name with a "." is used in the publish topic with Redis.

## Issue Number: #636


## What is the new behavior?
Name validator no longer allows the "." character

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information