### PR TITLE
fix: Add missing DBTimestamp for Model To DTO conversion

### DIFF
--- a/dtos/device.go
+++ b/dtos/device.go
@@ -69,6 +69,7 @@ func ToDeviceModel(dto Device) models.Device {
 // FromDeviceModelToDTO transforms the Device Model to the Device DTO
 func FromDeviceModelToDTO(d models.Device) Device {
 	var dto Device
+	dto.DBTimestamp = DBTimestamp(d.DBTimestamp)
 	dto.Id = d.Id
 	dto.Name = d.Name
 	dto.Description = d.Description

--- a/dtos/deviceservice.go
+++ b/dtos/deviceservice.go
@@ -53,6 +53,7 @@ func ToDeviceServiceModel(dto DeviceService) models.DeviceService {
 // FromDeviceServiceModelToDTO transforms the DeviceService Model to the DeviceService DTO
 func FromDeviceServiceModelToDTO(ds models.DeviceService) DeviceService {
 	var dto DeviceService
+	dto.DBTimestamp = DBTimestamp(ds.DBTimestamp)
 	dto.Id = ds.Id
 	dto.Name = ds.Name
 	dto.Description = ds.Description

--- a/dtos/interval.go
+++ b/dtos/interval.go
@@ -54,6 +54,7 @@ func ToIntervalModel(dto Interval) models.Interval {
 // FromIntervalModelToDTO transforms the Interval Model to the Interval DTO
 func FromIntervalModelToDTO(model models.Interval) Interval {
 	var dto Interval
+	dto.DBTimestamp = DBTimestamp(model.DBTimestamp)
 	dto.Id = model.Id
 	dto.Name = model.Name
 	dto.Start = model.Start

--- a/dtos/provisionwatcher.go
+++ b/dtos/provisionwatcher.go
@@ -57,6 +57,7 @@ func ToProvisionWatcherModel(dto ProvisionWatcher) models.ProvisionWatcher {
 // FromProvisionWatcherModelToDTO transforms the ProvisionWatcher Model to the ProvisionWatcher DTO
 func FromProvisionWatcherModelToDTO(pw models.ProvisionWatcher) ProvisionWatcher {
 	return ProvisionWatcher{
+		DBTimestamp:         DBTimestamp(pw.DBTimestamp),
 		Id:                  pw.Id,
 		Name:                pw.Name,
 		Labels:              pw.Labels,


### PR DESCRIPTION
Close #652

Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #652 


## What is the new behavior?
Add DBTimestamp for device, deviceService, interval, provisionwatcher Model when converting to DTO.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information