### PR TITLE
feat: Add omitempty tag To Reading DTO

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -33,14 +33,14 @@ type BaseReading struct {
 // SimpleReading and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/SimpleReading
 type SimpleReading struct {
-	Value string `json:"value" validate:"required"`
+	Value string `json:"value,omitempty" validate:"required"`
 }
 
 // BinaryReading and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/BinaryReading
 type BinaryReading struct {
-	BinaryValue []byte `json:"binaryValue" validate:"gt=0,required"`
-	MediaType   string `json:"mediaType" validate:"required"`
+	BinaryValue []byte `json:"binaryValue,omitempty" validate:"gt=0,required"`
+	MediaType   string `json:"mediaType,omitempty" validate:"required"`
 }
 
 func newBaseReading(profileName string, deviceName string, resourceName string, valueType string) BaseReading {


### PR DESCRIPTION
Close #650

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

## Issue Number: #650


## What is the new behavior?
Since BaseReading DTO contains SimpleReading and BinaryReading, so the query result will show empty value or null value in reading DTO for different valueType like:
- { "valueType":"Binary", "binaryValue":"...", "value":"" }
- { "valueType":"Int32", "binaryValue":null, "value":"123" }

To resolve it, add omitempty tag to SimpleReading and BinaryReading DTO.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information