### PR TITLE
feat(data): Use generic interface in the Event Tagging value

### DIFF
--- a/clients/http/deviceservicecommand_test.go
+++ b/clients/http/deviceservicecommand_test.go
@@ -34,7 +34,7 @@ var testEventDTO = dtos.Event{
 	DeviceName:  TestDeviceName,
 	ProfileName: TestDeviceProfileName,
 	Origin:      TestTimestamp,
-	Tags: map[string]string{
+	Tags: map[string]interface{}{
 		"GatewayID": "Houston-0001",
 		"Latitude":  "29.630771",
 		"Longitude": "-95.377603",

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -21,13 +21,13 @@ import (
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/Event
 type Event struct {
 	common.Versionable `json:",inline"`
-	Id                 string            `json:"id" validate:"required,uuid"`
-	DeviceName         string            `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	ProfileName        string            `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	SourceName         string            `json:"sourceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	Origin             int64             `json:"origin" validate:"required"`
-	Readings           []BaseReading     `json:"readings" validate:"gt=0,dive,required"`
-	Tags               map[string]string `json:"tags,omitempty" xml:"-"` // Have to ignore since map not supported for XML
+	Id                 string                 `json:"id" validate:"required,uuid"`
+	DeviceName         string                 `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName        string                 `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	SourceName         string                 `json:"sourceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	Origin             int64                  `json:"origin" validate:"required"`
+	Readings           []BaseReading          `json:"readings" validate:"gt=0,dive,required"`
+	Tags               map[string]interface{} `json:"tags,omitempty" xml:"-"` // Have to ignore since map not supported for XML
 }
 
 // NewEvent creates and returns an initialized Event with no Readings
@@ -49,7 +49,7 @@ func FromEventModelToDTO(event models.Event) Event {
 		readings = append(readings, FromReadingModelToDTO(reading))
 	}
 
-	tags := make(map[string]string)
+	tags := make(map[string]interface{})
 	for tag, value := range event.Tags {
 		tags[tag] = value
 	}
@@ -92,6 +92,7 @@ func (e *Event) ToXML() (string, error) {
 	// We have to provide our own marshaling of the Tags field if it is non-empty
 	if len(e.Tags) > 0 {
 		tagsXmlElements := []string{"<Tags>"}
+		// Since we change the tags value from string to interface{}, we need to write more complex func or use third-party lib to handle the marshaling
 		for key, value := range e.Tags {
 			tag := fmt.Sprintf("<%s>%s</%s>", key, value, key)
 			tagsXmlElements = append(tagsXmlElements, tag)

--- a/dtos/event_test.go
+++ b/dtos/event_test.go
@@ -24,10 +24,18 @@ var valid = models.Event{
 	ProfileName: TestDeviceProfileName,
 	SourceName:  TestSourceName,
 	Origin:      TestTimestamp,
-	Tags: map[string]string{
+	Tags: map[string]interface{}{
 		"GatewayID": "Houston-0001",
-		"Latitude":  "29.630771",
-		"Longitude": "-95.377603",
+		"latitude": map[string]interface{}{
+			"degrees": 25.0,
+			"minute":  1.0,
+			"second":  26.6268000000062,
+		},
+		"longitude": map[string]interface{}{
+			"degree": 121.0,
+			"minute": 31.0,
+			"second": 19.600799999980154,
+		},
 	},
 }
 
@@ -38,10 +46,18 @@ var expectedDTO = Event{
 	ProfileName: TestDeviceProfileName,
 	SourceName:  TestSourceName,
 	Origin:      TestTimestamp,
-	Tags: map[string]string{
+	Tags: map[string]interface{}{
 		"GatewayID": "Houston-0001",
-		"Latitude":  "29.630771",
-		"Longitude": "-95.377603",
+		"latitude": map[string]interface{}{
+			"degrees": 25.0,
+			"minute":  1.0,
+			"second":  26.6268000000062,
+		},
+		"longitude": map[string]interface{}{
+			"degree": 121.0,
+			"minute": 31.0,
+			"second": 19.600799999980154,
+		},
 	},
 }
 
@@ -61,6 +77,19 @@ func TestFromEventModelToDTO(t *testing.T) {
 }
 
 func TestEvent_ToXML(t *testing.T) {
+	var expectedDTO = Event{
+		Versionable: dtoCommon.Versionable{ApiVersion: common.ApiVersion},
+		Id:          TestUUID,
+		DeviceName:  TestDeviceName,
+		ProfileName: TestDeviceProfileName,
+		SourceName:  TestSourceName,
+		Origin:      TestTimestamp,
+		Tags: map[string]interface{}{
+			"GatewayID": "Houston-0001",
+			"Latitude":  "29.630771",
+			"Longitude": "-95.377603",
+		},
+	}
 	// Since the order in map is random we have to verify the individual items exists without depending on order
 	contains := []string{
 		"<Event><ApiVersion>v2</ApiVersion><Id>7a1707f0-166f-4c4b-bc9d-1d54c74e0137</Id><DeviceName>TestDevice</DeviceName><ProfileName>TestDeviceProfileName</ProfileName><SourceName>TestSourceName</SourceName><Origin>1594963842</Origin><Tags>",

--- a/dtos/requests/event.go
+++ b/dtos/requests/event.go
@@ -128,7 +128,7 @@ func AddEventReqToEventModel(addEventReq AddEventRequest) (event models.Event) {
 		readings[i] = dtos.ToReadingModel(r)
 	}
 
-	tags := make(map[string]string)
+	tags := make(map[string]interface{})
 	for tag, value := range addEventReq.Event.Tags {
 		tags[tag] = value
 	}

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -24,7 +24,7 @@ func eventData() dtos.Event {
 	event := dtos.NewEvent(TestDeviceProfileName, TestDeviceName, TestSourceName)
 	event.Id = ExampleUUID
 	event.Origin = TestOriginTime
-	event.Tags = map[string]string{
+	event.Tags = map[string]interface{}{
 		"GatewayId": "Houston-0001",
 	}
 	value, _ := strconv.ParseUint(TestReadingValue, 10, 8)
@@ -298,7 +298,7 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 		SourceName:  TestSourceName,
 		Origin:      TestOriginTime,
 		Readings:    []models.Reading{s},
-		Tags: map[string]string{
+		Tags: map[string]interface{}{
 			"GatewayId": "Houston-0001",
 		},
 	}

--- a/models/event.go
+++ b/models/event.go
@@ -15,5 +15,5 @@ type Event struct {
 	SourceName  string
 	Origin      int64
 	Readings    []Reading
-	Tags        map[string]string
+	Tags        map[string]interface{}
 }


### PR DESCRIPTION
- change map[string]string to map[string]interface{} to meet more user requirement.
- The string can still be used in the Tag. It's backward compatible.

Closes #661

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **only update the test data**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-go/pull/3727

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Modify the edgex-go's go.mod to replace the core-contracts lib
2. Run core-data
3. Add event and query event to see the change

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->