### PR TITLE
feat: Support object value type in Reading

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -211,6 +211,7 @@ const (
 	ValueTypeInt64Array   = "Int64Array"
 	ValueTypeFloat32Array = "Float32Array"
 	ValueTypeFloat64Array = "Float64Array"
+	ValueTypeObject       = "Object"
 )
 
 // Constants related to configuration file's map key

--- a/common/utils.go
+++ b/common/utils.go
@@ -22,6 +22,7 @@ var valueTypes = []string{
 	ValueTypeUint8Array, ValueTypeUint16Array, ValueTypeUint32Array, ValueTypeUint64Array,
 	ValueTypeInt8Array, ValueTypeInt16Array, ValueTypeInt32Array, ValueTypeInt64Array,
 	ValueTypeFloat32Array, ValueTypeFloat64Array,
+	ValueTypeObject,
 }
 
 // // NormalizeValueType normalizes the valueType to upper camel case

--- a/dtos/deviceprofile.go
+++ b/dtos/deviceprofile.go
@@ -7,6 +7,7 @@ package dtos
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
@@ -103,6 +104,10 @@ func ValidateDeviceProfileDTO(profile DeviceProfile) error {
 	// deviceResources validation
 	dupCheck := make(map[string]bool)
 	for _, resource := range profile.DeviceResources {
+		if (resource.Properties.ValueType == common.ValueTypeBinary || resource.Properties.ValueType == common.ValueTypeObject) &&
+			strings.Contains(resource.Properties.ReadWrite, common.ReadWrite_W) {
+			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("write permission not support %s and %s value type for resource '%s'", common.ValueTypeBinary, common.ValueTypeObject, resource.Name), nil)
+		}
 		// deviceResource name should not duplicated
 		if dupCheck[resource.Name] {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("device resource %s is duplicated", resource.Name), nil)

--- a/dtos/deviceprofile_test.go
+++ b/dtos/deviceprofile_test.go
@@ -94,6 +94,12 @@ func TestDeviceProfileDTOValidation(t *testing.T) {
 		mismatchedResource.DeviceCommands[0].ResourceOperations, ResourceOperation{DeviceResource: "missMatchedResource"})
 	invalidReadWrite := profileData()
 	invalidReadWrite.DeviceResources[0].Properties.ReadWrite = common.ReadWrite_R
+	binaryWithWritePermission := profileData()
+	binaryWithWritePermission.DeviceResources[0].Properties.ValueType = common.ValueTypeBinary
+	binaryWithWritePermission.DeviceResources[0].Properties.ReadWrite = common.ReadWrite_RW
+	objectWithWritePermission := profileData()
+	objectWithWritePermission.DeviceResources[0].Properties.ValueType = common.ValueTypeObject
+	objectWithWritePermission.DeviceResources[0].Properties.ReadWrite = common.ReadWrite_W
 
 	tests := []struct {
 		name        string
@@ -105,6 +111,8 @@ func TestDeviceProfileDTOValidation(t *testing.T) {
 		{"duplicated device command", duplicatedDeviceCommand, true},
 		{"mismatched resource", mismatchedResource, true},
 		{"invalid ReadWrite permission", invalidReadWrite, true},
+		{"write permission not support Binary value type", binaryWithWritePermission, true},
+		{"write permission not support Object value type", objectWithWritePermission, true},
 	}
 
 	for _, tt := range tests {

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -81,6 +81,11 @@ func (e *Event) AddBinaryReading(resourceName string, binaryValue []byte, mediaT
 	e.Readings = append(e.Readings, NewBinaryReading(e.ProfileName, e.DeviceName, resourceName, binaryValue, mediaType))
 }
 
+// AddObjectReading adds a object reading to the Event
+func (e *Event) AddObjectReading(resourceName string, objectValue interface{}) {
+	e.Readings = append(e.Readings, NewObjectReading(e.ProfileName, e.DeviceName, resourceName, objectValue))
+}
+
 // ToXML provides a XML representation of the Event as a string
 func (e *Event) ToXML() (string, error) {
 	eventXml, err := xml.Marshal(e)

--- a/dtos/event_test.go
+++ b/dtos/event_test.go
@@ -179,3 +179,30 @@ func TestEvent_AddBinaryReading(t *testing.T) {
 	assert.Equal(t, expectedValue, actual.BinaryValue)
 	assert.NotZero(t, actual.Origin)
 }
+
+func TestEvent_AddObjectReading(t *testing.T) {
+	expectedDeviceName := TestDeviceName
+	expectedProfileName := TestDeviceProfileName
+	expectedSourceName := TestSourceName
+	expectedResourceName := TestDeviceResourceName
+	expectedValueType := common.ValueTypeObject
+	expectedValue := map[string]interface{}{
+		"Attr1": "yyz",
+		"Attr2": -45,
+		"Attr3": []interface{}{255, 1, 0},
+	}
+	expectedReadingsCount := 1
+
+	target := NewEvent(expectedProfileName, expectedDeviceName, expectedSourceName)
+	target.AddObjectReading(expectedResourceName, expectedValue)
+
+	require.Equal(t, expectedReadingsCount, len(target.Readings))
+	actual := target.Readings[0]
+	assert.NotEmpty(t, actual.Id)
+	assert.Equal(t, expectedProfileName, actual.ProfileName)
+	assert.Equal(t, expectedDeviceName, actual.DeviceName)
+	assert.Equal(t, expectedResourceName, actual.ResourceName)
+	assert.Equal(t, expectedValueType, actual.ValueType)
+	assert.Equal(t, expectedValue, actual.ObjectValue)
+	assert.NotZero(t, actual.Origin)
+}

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -203,3 +203,25 @@ func TestNewBinaryReading(t *testing.T) {
 	assert.Equal(t, expectedBinaryValue, actual.BinaryValue)
 	assert.NotZero(t, actual.Origin)
 }
+
+func TestNewObjectReading(t *testing.T) {
+	expectedDeviceName := TestDeviceName
+	expectedProfileName := TestDeviceProfileName
+	expectedResourceName := TestDeviceResourceName
+	expectedValueType := common.ValueTypeObject
+	expectedValue := map[string]interface{}{
+		"Attr1": "yyz",
+		"Attr2": -45,
+		"Attr3": []interface{}{255, 1, 0},
+	}
+
+	actual := NewObjectReading(expectedProfileName, expectedDeviceName, expectedResourceName, expectedValue)
+
+	assert.NotEmpty(t, actual.Id)
+	assert.Equal(t, expectedProfileName, actual.ProfileName)
+	assert.Equal(t, expectedDeviceName, actual.DeviceName)
+	assert.Equal(t, expectedResourceName, actual.ResourceName)
+	assert.Equal(t, expectedValueType, actual.ValueType)
+	assert.Equal(t, expectedValue, actual.ObjectValue)
+	assert.NotZero(t, actual.Origin)
+}

--- a/models/reading.go
+++ b/models/reading.go
@@ -34,14 +34,23 @@ type SimpleReading struct {
 	Value       string
 }
 
+// ObjectReading and its properties are defined in the APIv2 specification:
+// https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/ObjectReading
+// Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
+type ObjectReading struct {
+	BaseReading `json:",inline"`
+	ObjectValue interface{}
+}
+
 // Reading is an abstract interface to be implemented by BinaryReading/SimpleReading
 type Reading interface {
 	GetBaseReading() BaseReading
 }
 
-// Implement GetBaseReading() method in order for BinaryReading and SimpleReading structs to implement the
+// Implement GetBaseReading() method in order for BinaryReading and SimpleReading, ObjectReading structs to implement the
 // abstract Reading interface and then be used as a Reading.
 // Also, the Reading interface can access the BaseReading fields.
 // This is Golang's way to implement inheritance.
 func (b BinaryReading) GetBaseReading() BaseReading { return b.BaseReading }
 func (s SimpleReading) GetBaseReading() BaseReading { return s.BaseReading }
+func (o ObjectReading) GetBaseReading() BaseReading { return o.BaseReading }


### PR DESCRIPTION
Add a new valueType "Object" and ObjectReading with an "objectValue" field in interface data type.

Closes #665

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) 
  <link to docs PR>

## Testing Instructions
1. Modify core-data and device simple to use specified core-contracts
2. Execute read command and the reading should contain Object value type like :
```
"readings": [
 {
  "id": "a8c52c7e-394b-46e1-bf2c-cda9b9e52c56",
  "origin": 1633336444179642000,
  "deviceName": "Simple-Device01",
  "resourceName": "Counter",
  "profileName": "Simple-Device",
  "valueType": "Object",
  "objectValue": {
    "f1": "ABC",
    "f2": 123
  }
 }
]
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->