### PR TITLE
fix(data): Add reading id mapping during conversion

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -287,6 +287,7 @@ func (b BaseReading) Validate() error {
 func ToReadingModel(r BaseReading) models.Reading {
 	var readingModel models.Reading
 	br := models.BaseReading{
+		Id:           r.Id,
 		Origin:       r.Origin,
 		DeviceName:   r.DeviceName,
 		ResourceName: r.ResourceName,

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var testSimpleReading = BaseReading{
+	Id:           TestUUID,
 	DeviceName:   TestDeviceName,
 	ResourceName: TestReadingName,
 	ProfileName:  TestDeviceProfileName,
@@ -31,6 +32,7 @@ func Test_ToReadingModel(t *testing.T) {
 	valid := testSimpleReading
 	expectedSimpleReading := models.SimpleReading{
 		BaseReading: models.BaseReading{
+			Id:           TestUUID,
 			DeviceName:   TestDeviceName,
 			ResourceName: TestReadingName,
 			ProfileName:  TestDeviceProfileName,

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -283,6 +283,7 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 	valid := eventRequestData()
 	s := models.SimpleReading{
 		BaseReading: models.BaseReading{
+			Id:           ExampleUUID,
 			DeviceName:   TestDeviceName,
 			ResourceName: TestDeviceResourceName,
 			ProfileName:  TestDeviceProfileName,


### PR DESCRIPTION
While converting a reading DTO to reading model, the original code base misses the reading id mapping.  As a result, the reading id will always be generated even when users provide reading id in the request. To fix this bug, this commit adds reading id mapping while converting reading DTO to reading model.

closes #673

Signed-off-by: Jude Hung <jude@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)  As this is bug fix, no doc needs to be changed.
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Modify the edgex-go's go.mod to replace the core-contracts lib
2. Run core-data
3. Add events whose readings contain valid UUID.  Query the event from database to verify that reading id is the same UUID.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->