### PR TITLE
feat: Add Client API to Pass Get Command Parameters in the Payload

### DIFF
--- a/clients/http/command.go
+++ b/clients/http/command.go
@@ -67,6 +67,19 @@ func (client *CommandClient) IssueGetCommandByName(ctx context.Context, deviceNa
 	return res, nil
 }
 
+// IssueGetCommandByNameWithObject issues the specified read command and pass the parameters in the payload
+func (client *CommandClient) IssueGetCommandByNameWithObject(ctx context.Context, deviceName string, commandName string, dsPushEvent string, dsReturnEvent string, parameters map[string]interface{}) (res *responses.EventResponse, err errors.EdgeX) {
+	requestParams := url.Values{}
+	requestParams.Set(common.PushEvent, dsPushEvent)
+	requestParams.Set(common.ReturnEvent, dsReturnEvent)
+	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
+	err = utils.GetRequestWithBodyRawData(ctx, &res, client.baseUrl, requestPath, requestParams, parameters)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}
+
 // IssueSetCommandByName issues the specified write command referenced by the command name to the device/sensor that is also referenced by name.
 func (client *CommandClient) IssueSetCommandByName(ctx context.Context, deviceName string, commandName string, settings map[string]string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
 	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))

--- a/clients/http/command_test.go
+++ b/clients/http/command_test.go
@@ -50,7 +50,23 @@ func TestIssueGetCommandByName(t *testing.T) {
 	require.IsType(t, &responses.EventResponse{}, res)
 }
 
-func TestIssueIssueSetCommandByName(t *testing.T) {
+func TestIssueGetCommandByNameWithObject(t *testing.T) {
+	deviceName := "Simple-Device01"
+	cmdName := "SwitchButton"
+	parameters := map[string]interface{}{
+		"kind":  "button",
+		"value": "on",
+	}
+	path := path.Join(common.ApiDeviceRoute, common.Name, deviceName, cmdName)
+	ts := newTestServer(http.MethodGet, path, &responses.EventResponse{})
+	defer ts.Close()
+	client := NewCommandClient(ts.URL)
+	res, err := client.IssueGetCommandByNameWithObject(context.Background(), deviceName, cmdName, common.ValueYes, common.ValueNo, parameters)
+	require.NoError(t, err)
+	require.IsType(t, &responses.EventResponse{}, res)
+}
+
+func TestIssueSetCommandByName(t *testing.T) {
 	deviceName := "Simple-Device01"
 	cmdName := "SwitchButton"
 	settings := map[string]string{
@@ -65,7 +81,7 @@ func TestIssueIssueSetCommandByName(t *testing.T) {
 	require.IsType(t, dtoCommon.BaseResponse{}, res)
 }
 
-func TestIssueIssueSetCommandByNameWithObject(t *testing.T) {
+func TestIssueSetCommandByNameWithObject(t *testing.T) {
 	deviceName := "Simple-Device01"
 	cmdName := "SwitchButton"
 	settings := map[string]interface{}{

--- a/clients/http/deviceservicecommand_test.go
+++ b/clients/http/deviceservicecommand_test.go
@@ -54,6 +54,23 @@ func TestGetCommand(t *testing.T) {
 	assert.Equal(t, expectedResponse, *res)
 }
 
+func TestGetCommandWithObject(t *testing.T) {
+	requestId := uuid.New().String()
+	expectedResponse := responses.NewEventResponse(requestId, "", http.StatusOK, testEventDTO)
+	ts := newTestServer(http.MethodGet, common.ApiDeviceRoute+"/"+common.Name+"/"+TestDeviceName+"/"+TestCommandName, expectedResponse)
+	defer ts.Close()
+	parameters := map[string]interface{}{
+		"kind":  "button",
+		"value": "on",
+	}
+
+	client := NewDeviceServiceCommandClient()
+	res, err := client.GetCommandWithObject(context.Background(), ts.URL, TestDeviceName, TestCommandName, "ds-returnevent=yes", parameters)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedResponse, *res)
+}
+
 func TestSetCommand(t *testing.T) {
 	requestId := uuid.New().String()
 	expectedResponse := dtoCommon.NewBaseResponse(requestId, "", http.StatusOK)

--- a/clients/http/utils/request.go
+++ b/clients/http/utils/request.go
@@ -38,8 +38,8 @@ func GetRequest(ctx context.Context, returnValuePointer interface{}, baseUrl str
 }
 
 // GetRequestAndReturnBinaryRes makes the get request and return the binary response and content type(i.e., application/json, application/cbor, ... )
-func GetRequestAndReturnBinaryRes(ctx context.Context, baseUrl string, requestPath string, requestParams url.Values) (res []byte, contentType string, edgeXerr errors.EdgeX) {
-	req, edgeXerr := createRequest(ctx, http.MethodGet, baseUrl, requestPath, requestParams)
+func GetRequestAndReturnBinaryRes(ctx context.Context, baseUrl string, requestPath string, requestParams url.Values, data interface{}) (res []byte, contentType string, edgeXerr errors.EdgeX) {
+	req, edgeXerr := createRequestWithRawDataAndParams(ctx, http.MethodGet, baseUrl, requestPath, requestParams, data)
 	if edgeXerr != nil {
 		return nil, "", errors.NewCommonEdgeXWrapper(edgeXerr)
 	}

--- a/clients/interfaces/command.go
+++ b/clients/interfaces/command.go
@@ -26,6 +26,8 @@ type CommandClient interface {
 	// dsPushEvent: If set to yes, a successful GET will result in an event being pushed to the EdgeX system. Default value is no.
 	// dsReturnEvent: If set to no, there will be no Event returned in the http response. Default value is yes.
 	IssueGetCommandByName(ctx context.Context, deviceName string, commandName string, dsPushEvent string, dsReturnEvent string) (*responses.EventResponse, errors.EdgeX)
+	// IssueGetCommandByNameWithObject issues the specified read command and pass the parameters in the payload
+	IssueGetCommandByNameWithObject(ctx context.Context, deviceName string, commandName string, dsPushEvent string, dsReturnEvent string, parameters map[string]interface{}) (*responses.EventResponse, errors.EdgeX)
 	// IssueSetCommandByName issues the specified write command referenced by the command name to the device/sensor that is also referenced by name.
 	IssueSetCommandByName(ctx context.Context, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX)
 	// IssueSetCommandByNameWithObject issues the specified write command and the settings supports object value type

--- a/clients/interfaces/deviceservicecommand.go
+++ b/clients/interfaces/deviceservicecommand.go
@@ -17,6 +17,8 @@ import (
 type DeviceServiceCommandClient interface {
 	// GetCommand invokes device service's command API for issuing get(read) command
 	GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string) (*responses.EventResponse, errors.EdgeX)
+	// GetCommandWithObject invokes device service's get command API and pass the parameters in the payload
+	GetCommandWithObject(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, parameters map[string]interface{}) (*responses.EventResponse, errors.EdgeX)
 	// SetCommand invokes device service's command API for issuing set(write) command
 	SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]string) (common.BaseResponse, errors.EdgeX)
 	// SetCommandWithObject invokes device service's set command API and the settings supports object value type

--- a/clients/interfaces/mocks/DeviceServiceCommandClient.go
+++ b/clients/interfaces/mocks/DeviceServiceCommandClient.go
@@ -44,6 +44,31 @@ func (_m *DeviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl st
 	return r0, r1
 }
 
+// GetCommandWithObject provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, queryParams, settings
+func (_m *DeviceServiceCommandClient) GetCommandWithObject(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]interface{}) (*responses.EventResponse, errors.EdgeX) {
+	ret := _m.Called(ctx, baseUrl, deviceName, commandName, queryParams, settings)
+
+	var r0 *responses.EventResponse
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, map[string]interface{}) *responses.EventResponse); ok {
+		r0 = rf(ctx, baseUrl, deviceName, commandName, queryParams, settings)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*responses.EventResponse)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, map[string]interface{}) errors.EdgeX); ok {
+		r1 = rf(ctx, baseUrl, deviceName, commandName, queryParams, settings)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // SetCommand provides a mock function with given fields: ctx, baseUrl, deviceName, commandName, queryParams, settings
 func (_m *DeviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
 	ret := _m.Called(ctx, baseUrl, deviceName, commandName, queryParams, settings)


### PR DESCRIPTION
Since we need to pass the parameters in the payload from core-command to Device Services, so we add new client APIs to pass the payload in the HTTP Get request.

Closes #677

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-go/...

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-service and device-simple
2. Execute Get command API with payload
3. Debug the protocol driver should receive the payload which is the attributes of the commandRequest.

https://github.com/edgexfoundry/device-sdk-go/blob/1be87f15213c05ab1957194b5dea87ff4eff74a4/pkg/models/commandrequest.go#L15

For example, the payload is:
```
{
    "foo":"123",
    "bar":{
        "foobar":"456"
    }
}
```
The commandRequest should be
```
{
	DeviceResourceName: "testResource"
	Attributes :  {
                "foo":"123",
                "bar":{
                   "foobar":"456"
                           }
               }
	Type : "..."
}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->