### PR TITLE
fix: Fix wrong intervalAction field assignment

### DIFF
--- a/dtos/requests/const_test.go
+++ b/dtos/requests/const_test.go
@@ -47,6 +47,7 @@ const (
 	TestPublisher          = "testPublisher"
 	TestTarget             = "testTarget"
 	TestTopic              = "testTopic"
+	TestContent            = "test content"
 
 	TestServiceName = "TestService"
 	TestActionName  = "stop"

--- a/dtos/requests/intervalaction.go
+++ b/dtos/requests/intervalaction.go
@@ -118,7 +118,7 @@ func ReplaceIntervalActionModelFieldsWithDTO(action *models.IntervalAction, patc
 		action.Content = *patch.Content
 	}
 	if patch.ContentType != nil {
-		action.ContentType = *patch.Content
+		action.ContentType = *patch.ContentType
 	}
 	if patch.AdminState != nil {
 		action.AdminState = models.AdminState(*patch.AdminState)

--- a/dtos/requests/intervalaction_test.go
+++ b/dtos/requests/intervalaction_test.go
@@ -38,11 +38,15 @@ func updateIntervalActionData() dtos.UpdateIntervalAction {
 	testId := ExampleUUID
 	testName := TestIntervalActionName
 	testIntervalName := TestIntervalName
+	testContent := TestContent
+	testContentType := common.ContentTypeText
 
 	dto := dtos.UpdateIntervalAction{}
 	dto.Id = &testId
 	dto.Name = &testName
 	dto.IntervalName = &testIntervalName
+	dto.Content = &testContent
+	dto.ContentType = &testContentType
 	address := dtos.NewRESTAddress(TestHost, TestPort, TestHTTPMethod)
 	dto.Address = &address
 	return dto
@@ -266,5 +270,7 @@ func TestReplaceIntervalActionModelFieldsWithDTO(t *testing.T) {
 	expectedAddress := dtos.ToAddressModel(*patch.Address)
 	assert.Equal(t, TestIntervalActionName, interval.Name)
 	assert.Equal(t, TestIntervalName, interval.IntervalName)
+	assert.Equal(t, TestContent, interval.Content)
+	assert.Equal(t, common.ContentTypeText, interval.ContentType)
 	assert.Equal(t, expectedAddress, interval.Address)
 }


### PR DESCRIPTION
Closes #682

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact the doc**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run the unit test to check whether the value is changed as expected.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->