### PR TITLE
fix: Adding the missed PATCH method in REST Address DTO

### DIFF
--- a/dtos/address.go
+++ b/dtos/address.go
@@ -54,7 +54,7 @@ func (a *Address) Validate() error {
 
 type RESTAddress struct {
 	Path       string `json:"path,omitempty"`
-	HTTPMethod string `json:"httpMethod,omitempty" validate:"required,oneof='GET' 'HEAD' 'POST' 'PUT' 'DELETE' 'TRACE' 'CONNECT'"`
+	HTTPMethod string `json:"httpMethod,omitempty" validate:"required,oneof='GET' 'HEAD' 'POST' 'PUT' 'PATCH' 'DELETE' 'TRACE' 'CONNECT'"`
 }
 
 func NewRESTAddress(host string, port int, httpMethod string) Address {

--- a/dtos/address_test.go
+++ b/dtos/address_test.go
@@ -8,6 +8,7 @@ package dtos
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
@@ -98,6 +99,8 @@ func TestAddress_UnmarshalJSON(t *testing.T) {
 
 func TestAddress_Validate(t *testing.T) {
 	validRest := testRESTAddress
+	validRestPatch := testRESTAddress
+	validRestPatch.HTTPMethod = http.MethodPatch
 	noRestHttpMethod := testRESTAddress
 	noRestHttpMethod.HTTPMethod = ""
 
@@ -117,6 +120,7 @@ func TestAddress_Validate(t *testing.T) {
 		expectError bool
 	}{
 		{"valid RESTAddress", validRest, false},
+		{"valid RESTAddress, PATCH http method", validRestPatch, false},
 		{"invalid RESTAddress, no HTTP method", noRestHttpMethod, true},
 		{"valid MQTTPubAddress", validMQTT, false},
 		{"invalid MQTTPubAddress, no MQTT publisher", noMQTTPublisher, true},


### PR DESCRIPTION
Adding the PATCH method to Address DTO validate tag

Fix #685

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact the doc**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Fork the branch and run the unit test.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->