### PR TITLE
feat: Remove DeviceProfile deviceResources validate gt=0

### DIFF
--- a/dtos/deviceprofile.go
+++ b/dtos/deviceprofile.go
@@ -24,7 +24,7 @@ type DeviceProfile struct {
 	Description     string           `json:"description" yaml:"description"`
 	Model           string           `json:"model" yaml:"model"`
 	Labels          []string         `json:"labels" yaml:"labels,flow"`
-	DeviceResources []DeviceResource `json:"deviceResources" yaml:"deviceResources" validate:"required,gt=0,dive"`
+	DeviceResources []DeviceResource `json:"deviceResources" yaml:"deviceResources" validate:"dive"`
 	DeviceCommands  []DeviceCommand  `json:"deviceCommands" yaml:"deviceCommands" validate:"dive"`
 }
 

--- a/dtos/requests/deviceprofile_test.go
+++ b/dtos/requests/deviceprofile_test.go
@@ -89,8 +89,9 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 	valid := profileData()
 	noName := profileData()
 	noName.Profile.Name = emptyString
-	noDeviceResource := profileData()
-	noDeviceResource.Profile.DeviceResources = []dtos.DeviceResource{}
+	noDeviceResourceAndDeviceCommand := profileData()
+	noDeviceResourceAndDeviceCommand.Profile.DeviceResources = []dtos.DeviceResource{}
+	noDeviceResourceAndDeviceCommand.Profile.DeviceCommands = []dtos.DeviceCommand{}
 	noDeviceResourceName := profileData()
 	noDeviceResourceName.Profile.DeviceResources[0].Name = emptyString
 	noDeviceResourcePropertyType := profileData()
@@ -103,6 +104,8 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 	invalidDeviceResourceReadWrite.Profile.DeviceResources[0].Properties.ReadWrite = "invalid"
 	validDeviceResourceReadWrite := profileData()
 	validDeviceResourceReadWrite.Profile.DeviceResources[0].Properties.ReadWrite = common.ReadWrite_WR
+	dismatchDeviceCommand := profileData()
+	dismatchDeviceCommand.Profile.DeviceResources = []dtos.DeviceResource{}
 
 	tests := []struct {
 		name          string
@@ -111,13 +114,14 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 	}{
 		{"valid DeviceProfileRequest", valid, false},
 		{"invalid DeviceProfileRequest, no name", noName, true},
-		{"invalid DeviceProfileRequest, no deviceResource", noDeviceResource, true},
+		{"valid DeviceProfileRequest, no deviceResource and no deviceCommand", noDeviceResourceAndDeviceCommand, false},
 		{"invalid DeviceProfileRequest, no deviceResource name", noDeviceResourceName, true},
 		{"invalid DeviceProfileRequest, no deviceResource property type", noDeviceResourcePropertyType, true},
 		{"invalid DeviceProfileRequest, invalid deviceResource property type", invalidDeviceResourcePropertyType, true},
 		{"invalid DeviceProfileRequest, no deviceResource property readWrite", noDeviceResourceReadWrite, true},
 		{"invalid DeviceProfileRequest, invalid deviceResource property readWrite", invalidDeviceResourcePropertyType, true},
 		{"valid DeviceProfileRequest, valid deviceResource property readWrite with value WR", validDeviceResourceReadWrite, false},
+		{"invalid DeviceProfileRequest, dismatch deviceCommand", dismatchDeviceCommand, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) NA
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
build metadata docker image based on this branch, and POST /deviceprofile with empty devcieResources and deviceCommands, also open PR for TAF tests https://github.com/edgexfoundry/edgex-taf/pull/614
