### PR TITLE
fix: Remove redundant URL escaping from Client lib

### DIFF
--- a/clients/http/command.go
+++ b/clients/http/command.go
@@ -46,7 +46,7 @@ func (client *CommandClient) AllDeviceCoreCommands(ctx context.Context, offset i
 // DeviceCoreCommandsByDeviceName returns all commands associated with the specified device name.
 func (client *CommandClient) DeviceCoreCommandsByDeviceName(ctx context.Context, name string) (
 	res responses.DeviceCoreCommandResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiDeviceRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -59,7 +59,7 @@ func (client *CommandClient) IssueGetCommandByName(ctx context.Context, deviceNa
 	requestParams := url.Values{}
 	requestParams.Set(common.PushEvent, dsPushEvent)
 	requestParams.Set(common.ReturnEvent, dsReturnEvent)
-	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
+	requestPath := path.Join(common.ApiDeviceRoute, common.Name, deviceName, commandName)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -83,8 +83,8 @@ func (client *CommandClient) IssueGetCommandByNameWithQueryParams(ctx context.Co
 
 // IssueSetCommandByName issues the specified write command referenced by the command name to the device/sensor that is also referenced by name.
 func (client *CommandClient) IssueSetCommandByName(ctx context.Context, deviceName string, commandName string, settings map[string]string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
-	err = utils.PutRequest(ctx, &res, client.baseUrl+requestPath, settings)
+	requestPath := path.Join(common.ApiDeviceRoute, common.Name, deviceName, commandName)
+	err = utils.PutRequest(ctx, &res, client.baseUrl, requestPath, nil, settings)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -93,8 +93,8 @@ func (client *CommandClient) IssueSetCommandByName(ctx context.Context, deviceNa
 
 // IssueSetCommandByNameWithObject issues the specified write command and the settings supports object value type
 func (client *CommandClient) IssueSetCommandByNameWithObject(ctx context.Context, deviceName string, commandName string, settings map[string]interface{}) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
-	err = utils.PutRequest(ctx, &res, client.baseUrl+requestPath, settings)
+	requestPath := path.Join(common.ApiDeviceRoute, common.Name, deviceName, commandName)
+	err = utils.PutRequest(ctx, &res, client.baseUrl, requestPath, nil, settings)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/http/common.go
+++ b/clients/http/common.go
@@ -63,7 +63,7 @@ func (cc *commonClient) Version(ctx context.Context) (dtoCommon.VersionResponse,
 }
 
 func (cc *commonClient) AddSecret(ctx context.Context, request dtoCommon.SecretRequest) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, cc.baseUrl+common.ApiSecretRoute, request)
+	err = utils.PostRequestWithRawData(ctx, &res, cc.baseUrl, common.ApiSecretRoute, nil, request)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/http/device.go
+++ b/clients/http/device.go
@@ -28,7 +28,7 @@ func NewDeviceClient(baseUrl string) interfaces.DeviceClient {
 }
 
 func (dc DeviceClient) Add(ctx context.Context, reqs []requests.AddDeviceRequest) (res []dtoCommon.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, dc.baseUrl+common.ApiDeviceRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, dc.baseUrl, common.ApiDeviceRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -36,7 +36,7 @@ func (dc DeviceClient) Add(ctx context.Context, reqs []requests.AddDeviceRequest
 }
 
 func (dc DeviceClient) Update(ctx context.Context, reqs []requests.UpdateDeviceRequest) (res []dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, dc.baseUrl+common.ApiDeviceRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, dc.baseUrl, common.ApiDeviceRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -58,7 +58,7 @@ func (dc DeviceClient) AllDevices(ctx context.Context, labels []string, offset i
 }
 
 func (dc DeviceClient) DeviceNameExists(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Check, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiDeviceRoute, common.Check, common.Name, name)
 	err = utils.GetRequest(ctx, &res, dc.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -67,7 +67,7 @@ func (dc DeviceClient) DeviceNameExists(ctx context.Context, name string) (res d
 }
 
 func (dc DeviceClient) DeviceByName(ctx context.Context, name string) (res responses.DeviceResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiDeviceRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, dc.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -76,7 +76,7 @@ func (dc DeviceClient) DeviceByName(ctx context.Context, name string) (res respo
 }
 
 func (dc DeviceClient) DeleteDeviceByName(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiDeviceRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, dc.baseUrl, path)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -85,7 +85,7 @@ func (dc DeviceClient) DeleteDeviceByName(ctx context.Context, name string) (res
 }
 
 func (dc DeviceClient) DevicesByProfileName(ctx context.Context, name string, offset int, limit int) (res responses.MultiDevicesResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceRoute, common.Profile, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiDeviceRoute, common.Profile, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -97,7 +97,7 @@ func (dc DeviceClient) DevicesByProfileName(ctx context.Context, name string, of
 }
 
 func (dc DeviceClient) DevicesByServiceName(ctx context.Context, name string, offset int, limit int) (res responses.MultiDevicesResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceRoute, common.Service, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiDeviceRoute, common.Service, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))

--- a/clients/http/deviceprofile.go
+++ b/clients/http/deviceprofile.go
@@ -40,7 +40,7 @@ func NewDeviceProfileClient(baseUrl string) interfaces.DeviceProfileClient {
 // Add adds new device profile
 func (client *DeviceProfileClient) Add(ctx context.Context, reqs []requests.DeviceProfileRequest) ([]dtoCommon.BaseWithIdResponse, errors.EdgeX) {
 	var responses []dtoCommon.BaseWithIdResponse
-	err := utils.PostRequestWithRawData(ctx, &responses, client.baseUrl+common.ApiDeviceProfileRoute, reqs)
+	err := utils.PostRequestWithRawData(ctx, &responses, client.baseUrl, common.ApiDeviceProfileRoute, nil, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -50,7 +50,7 @@ func (client *DeviceProfileClient) Add(ctx context.Context, reqs []requests.Devi
 // Update updates device profile
 func (client *DeviceProfileClient) Update(ctx context.Context, reqs []requests.DeviceProfileRequest) ([]dtoCommon.BaseResponse, errors.EdgeX) {
 	var responses []dtoCommon.BaseResponse
-	err := utils.PutRequest(ctx, &responses, client.baseUrl+common.ApiDeviceProfileRoute, reqs)
+	err := utils.PutRequest(ctx, &responses, client.baseUrl, common.ApiDeviceProfileRoute, nil, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -60,7 +60,7 @@ func (client *DeviceProfileClient) Update(ctx context.Context, reqs []requests.D
 // AddByYaml adds new device profile by uploading a yaml file
 func (client *DeviceProfileClient) AddByYaml(ctx context.Context, yamlFilePath string) (dtoCommon.BaseWithIdResponse, errors.EdgeX) {
 	var responses dtoCommon.BaseWithIdResponse
-	err := utils.PostByFileRequest(ctx, &responses, client.baseUrl+common.ApiDeviceProfileUploadFileRoute, yamlFilePath)
+	err := utils.PostByFileRequest(ctx, &responses, client.baseUrl, common.ApiDeviceProfileUploadFileRoute, yamlFilePath)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -70,7 +70,7 @@ func (client *DeviceProfileClient) AddByYaml(ctx context.Context, yamlFilePath s
 // UpdateByYaml updates device profile by uploading a yaml file
 func (client *DeviceProfileClient) UpdateByYaml(ctx context.Context, yamlFilePath string) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var responses dtoCommon.BaseResponse
-	err := utils.PutByFileRequest(ctx, &responses, client.baseUrl+common.ApiDeviceProfileUploadFileRoute, yamlFilePath)
+	err := utils.PutByFileRequest(ctx, &responses, client.baseUrl, common.ApiDeviceProfileUploadFileRoute, yamlFilePath)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -80,7 +80,7 @@ func (client *DeviceProfileClient) UpdateByYaml(ctx context.Context, yamlFilePat
 // DeleteByName deletes the device profile by name
 func (client *DeviceProfileClient) DeleteByName(ctx context.Context, name string) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Name, name)
 	err := utils.DeleteRequest(ctx, &response, client.baseUrl, requestPath)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
@@ -90,7 +90,7 @@ func (client *DeviceProfileClient) DeleteByName(ctx context.Context, name string
 
 // DeviceProfileByName queries the device profile by name
 func (client *DeviceProfileClient) DeviceProfileByName(ctx context.Context, name string) (res responses.DeviceProfileResponse, edgexError errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Name, name)
 	err := utils.GetRequest(ctx, &res, client.baseUrl, requestPath, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -115,7 +115,7 @@ func (client *DeviceProfileClient) AllDeviceProfiles(ctx context.Context, labels
 
 // DeviceProfilesByModel queries the device profiles with offset, limit and model
 func (client *DeviceProfileClient) DeviceProfilesByModel(ctx context.Context, model string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Model, url.QueryEscape(model))
+	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Model, model)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -128,7 +128,7 @@ func (client *DeviceProfileClient) DeviceProfilesByModel(ctx context.Context, mo
 
 // DeviceProfilesByManufacturer queries the device profiles with offset, limit and manufacturer
 func (client *DeviceProfileClient) DeviceProfilesByManufacturer(ctx context.Context, manufacturer string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Manufacturer, url.QueryEscape(manufacturer))
+	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Manufacturer, manufacturer)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -141,7 +141,7 @@ func (client *DeviceProfileClient) DeviceProfilesByManufacturer(ctx context.Cont
 
 // DeviceProfilesByManufacturerAndModel queries the device profiles with offset, limit, manufacturer and model
 func (client *DeviceProfileClient) DeviceProfilesByManufacturerAndModel(ctx context.Context, manufacturer string, model string, offset int, limit int) (res responses.MultiDeviceProfilesResponse, edgexError errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Manufacturer, url.QueryEscape(manufacturer), common.Model, url.QueryEscape(model))
+	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Manufacturer, manufacturer, common.Model, model)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -159,7 +159,7 @@ func (client *DeviceProfileClient) DeviceResourceByProfileNameAndResourceName(ct
 	if exists {
 		return res, nil
 	}
-	requestPath := path.Join(common.ApiDeviceResourceRoute, common.Profile, url.QueryEscape(profileName), common.Resource, url.QueryEscape(resourceName))
+	requestPath := path.Join(common.ApiDeviceResourceRoute, common.Profile, profileName, common.Resource, resourceName)
 	err := utils.GetRequest(ctx, &res, client.baseUrl, requestPath, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -190,7 +190,7 @@ func (client *DeviceProfileClient) CleanResourcesCache() {
 // UpdateDeviceProfileBasicInfo updates existing profile's basic info
 func (client *DeviceProfileClient) UpdateDeviceProfileBasicInfo(ctx context.Context, reqs []requests.DeviceProfileBasicInfoRequest) ([]dtoCommon.BaseResponse, errors.EdgeX) {
 	var responses []dtoCommon.BaseResponse
-	err := utils.PatchRequest(ctx, &responses, client.baseUrl+common.ApiDeviceProfileBasicInfoRoute, reqs)
+	err := utils.PatchRequest(ctx, &responses, client.baseUrl, common.ApiDeviceProfileBasicInfoRoute, nil, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -200,7 +200,7 @@ func (client *DeviceProfileClient) UpdateDeviceProfileBasicInfo(ctx context.Cont
 // AddDeviceProfileResource adds new device resource to an existing profile
 func (client *DeviceProfileClient) AddDeviceProfileResource(ctx context.Context, reqs []requests.AddDeviceResourceRequest) ([]dtoCommon.BaseResponse, errors.EdgeX) {
 	var responses []dtoCommon.BaseResponse
-	err := utils.PostRequestWithRawData(ctx, &responses, client.baseUrl+common.ApiDeviceProfileResourceRoute, reqs)
+	err := utils.PostRequestWithRawData(ctx, &responses, client.baseUrl, common.ApiDeviceProfileResourceRoute, nil, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -210,7 +210,7 @@ func (client *DeviceProfileClient) AddDeviceProfileResource(ctx context.Context,
 // UpdateDeviceProfileResource updates existing device resource
 func (client *DeviceProfileClient) UpdateDeviceProfileResource(ctx context.Context, reqs []requests.UpdateDeviceResourceRequest) ([]dtoCommon.BaseResponse, errors.EdgeX) {
 	var responses []dtoCommon.BaseResponse
-	err := utils.PatchRequest(ctx, &responses, client.baseUrl+common.ApiDeviceProfileResourceRoute, reqs)
+	err := utils.PatchRequest(ctx, &responses, client.baseUrl, common.ApiDeviceProfileResourceRoute, nil, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -231,7 +231,7 @@ func (client *DeviceProfileClient) DeleteDeviceResourceByName(ctx context.Contex
 // AddDeviceProfileDeviceCommand adds new device command to an existing profile
 func (client *DeviceProfileClient) AddDeviceProfileDeviceCommand(ctx context.Context, reqs []requests.AddDeviceCommandRequest) ([]dtoCommon.BaseResponse, errors.EdgeX) {
 	var responses []dtoCommon.BaseResponse
-	err := utils.PostRequestWithRawData(ctx, &responses, client.baseUrl+common.ApiDeviceProfileDeviceCommandRoute, reqs)
+	err := utils.PostRequestWithRawData(ctx, &responses, client.baseUrl, common.ApiDeviceProfileDeviceCommandRoute, nil, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -241,7 +241,7 @@ func (client *DeviceProfileClient) AddDeviceProfileDeviceCommand(ctx context.Con
 // UpdateDeviceProfileDeviceCommand updates existing device command
 func (client *DeviceProfileClient) UpdateDeviceProfileDeviceCommand(ctx context.Context, reqs []requests.UpdateDeviceCommandRequest) ([]dtoCommon.BaseResponse, errors.EdgeX) {
 	var responses []dtoCommon.BaseResponse
-	err := utils.PatchRequest(ctx, &responses, client.baseUrl+common.ApiDeviceProfileDeviceCommandRoute, reqs)
+	err := utils.PatchRequest(ctx, &responses, client.baseUrl, common.ApiDeviceProfileDeviceCommandRoute, nil, reqs)
 	if err != nil {
 		return responses, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/http/deviceservice.go
+++ b/clients/http/deviceservice.go
@@ -29,7 +29,7 @@ func NewDeviceServiceClient(baseUrl string) interfaces.DeviceServiceClient {
 
 func (dsc DeviceServiceClient) Add(ctx context.Context, reqs []requests.AddDeviceServiceRequest) (
 	res []dtoCommon.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, dsc.baseUrl+common.ApiDeviceServiceRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, dsc.baseUrl, common.ApiDeviceServiceRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -38,7 +38,7 @@ func (dsc DeviceServiceClient) Add(ctx context.Context, reqs []requests.AddDevic
 
 func (dsc DeviceServiceClient) Update(ctx context.Context, reqs []requests.UpdateDeviceServiceRequest) (
 	res []dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, dsc.baseUrl+common.ApiDeviceServiceRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, dsc.baseUrl, common.ApiDeviceServiceRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -62,7 +62,7 @@ func (dsc DeviceServiceClient) AllDeviceServices(ctx context.Context, labels []s
 
 func (dsc DeviceServiceClient) DeviceServiceByName(ctx context.Context, name string) (
 	res responses.DeviceServiceResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceServiceRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiDeviceServiceRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, dsc.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -72,7 +72,7 @@ func (dsc DeviceServiceClient) DeviceServiceByName(ctx context.Context, name str
 
 func (dsc DeviceServiceClient) DeleteByName(ctx context.Context, name string) (
 	res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceServiceRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiDeviceServiceRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, dsc.baseUrl, path)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/deviceservicecallback.go
+++ b/clients/http/deviceservicecallback.go
@@ -30,7 +30,7 @@ func NewDeviceServiceCallbackClient(baseUrl string) interfaces.DeviceServiceCall
 
 func (client *deviceServiceCallbackClient) AddDeviceCallback(ctx context.Context, request requests.AddDeviceRequest) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl+common.ApiDeviceCallbackRoute, request)
+	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl, common.ApiDeviceCallbackRoute, nil, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -39,7 +39,7 @@ func (client *deviceServiceCallbackClient) AddDeviceCallback(ctx context.Context
 
 func (client *deviceServiceCallbackClient) ValidateDeviceCallback(ctx context.Context, request requests.AddDeviceRequest) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl+common.ApiDeviceValidationRoute, request)
+	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl, common.ApiDeviceValidationRoute, nil, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -48,7 +48,7 @@ func (client *deviceServiceCallbackClient) ValidateDeviceCallback(ctx context.Co
 
 func (client *deviceServiceCallbackClient) UpdateDeviceCallback(ctx context.Context, request requests.UpdateDeviceRequest) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+common.ApiDeviceCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl, common.ApiDeviceCallbackRoute, nil, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -67,7 +67,7 @@ func (client *deviceServiceCallbackClient) DeleteDeviceCallback(ctx context.Cont
 
 func (client *deviceServiceCallbackClient) UpdateDeviceProfileCallback(ctx context.Context, request requests.DeviceProfileRequest) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+common.ApiProfileCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl, common.ApiProfileCallbackRoute, nil, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -76,7 +76,7 @@ func (client *deviceServiceCallbackClient) UpdateDeviceProfileCallback(ctx conte
 
 func (client *deviceServiceCallbackClient) AddProvisionWatcherCallback(ctx context.Context, request requests.AddProvisionWatcherRequest) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl+common.ApiWatcherCallbackRoute, request)
+	err := utils.PostRequestWithRawData(ctx, &response, client.baseUrl, common.ApiWatcherCallbackRoute, nil, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -85,7 +85,7 @@ func (client *deviceServiceCallbackClient) AddProvisionWatcherCallback(ctx conte
 
 func (client *deviceServiceCallbackClient) UpdateProvisionWatcherCallback(ctx context.Context, request requests.UpdateProvisionWatcherRequest) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+common.ApiWatcherCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl, common.ApiWatcherCallbackRoute, nil, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -104,7 +104,7 @@ func (client *deviceServiceCallbackClient) DeleteProvisionWatcherCallback(ctx co
 
 func (client *deviceServiceCallbackClient) UpdateDeviceServiceCallback(ctx context.Context, request requests.UpdateDeviceServiceRequest) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	err := utils.PutRequest(ctx, &response, client.baseUrl+common.ApiServiceCallbackRoute, request)
+	err := utils.PutRequest(ctx, &response, client.baseUrl, common.ApiServiceCallbackRoute, nil, request)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/http/deviceservicecommand.go
+++ b/clients/http/deviceservicecommand.go
@@ -30,7 +30,7 @@ func NewDeviceServiceCommandClient() interfaces.DeviceServiceCommandClient {
 
 // GetCommand sends HTTP request to execute the Get command
 func (client *deviceServiceCommandClient) GetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string) (*responses.EventResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
+	requestPath := path.Join(common.ApiDeviceRoute, common.Name, deviceName, commandName)
 	params, err := url.ParseQuery(queryParams)
 	if err != nil {
 		return nil, errors.NewCommonEdgeXWrapper(err)
@@ -60,8 +60,12 @@ func (client *deviceServiceCommandClient) GetCommand(ctx context.Context, baseUr
 // SetCommand sends HTTP request to execute the Set command
 func (client *deviceServiceCommandClient) SetCommand(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]string) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
-	err := utils.PutRequest(ctx, &response, baseUrl+requestPath+"?"+queryParams, settings)
+	requestPath := path.Join(common.ApiDeviceRoute, common.Name, deviceName, commandName)
+	params, err := url.ParseQuery(queryParams)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	err = utils.PutRequest(ctx, &response, baseUrl, requestPath, params, settings)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -71,8 +75,12 @@ func (client *deviceServiceCommandClient) SetCommand(ctx context.Context, baseUr
 // SetCommandWithObject invokes device service's set command API and the settings supports object value type
 func (client *deviceServiceCommandClient) SetCommandWithObject(ctx context.Context, baseUrl string, deviceName string, commandName string, queryParams string, settings map[string]interface{}) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	requestPath := path.Join(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
-	err := utils.PutRequest(ctx, &response, baseUrl+requestPath+"?"+queryParams, settings)
+	requestPath := path.Join(common.ApiDeviceRoute, common.Name, deviceName, commandName)
+	params, err := url.ParseQuery(queryParams)
+	if err != nil {
+		return response, errors.NewCommonEdgeXWrapper(err)
+	}
+	err = utils.PutRequest(ctx, &response, baseUrl, requestPath, params, settings)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/http/event.go
+++ b/clients/http/event.go
@@ -33,7 +33,7 @@ func NewEventClient(baseUrl string) interfaces.EventClient {
 
 func (ec *eventClient) Add(ctx context.Context, req requests.AddEventRequest) (
 	dtoCommon.BaseWithIdResponse, errors.EdgeX) {
-	path := path.Join(common.ApiEventRoute, url.QueryEscape(req.Event.ProfileName), url.QueryEscape(req.Event.DeviceName), url.QueryEscape(req.Event.SourceName))
+	path := path.Join(common.ApiEventRoute, req.Event.ProfileName, req.Event.DeviceName, req.Event.SourceName)
 	var br dtoCommon.BaseWithIdResponse
 
 	bytes, encoding, err := req.Encode()
@@ -41,7 +41,7 @@ func (ec *eventClient) Add(ctx context.Context, req requests.AddEventRequest) (
 		return br, errors.NewCommonEdgeXWrapper(err)
 	}
 
-	err = utils.PostRequest(ctx, &br, ec.baseUrl+path, bytes, encoding)
+	err = utils.PostRequest(ctx, &br, ec.baseUrl, path, bytes, encoding)
 	if err != nil {
 		return br, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -70,7 +70,7 @@ func (ec *eventClient) EventCount(ctx context.Context) (dtoCommon.CountResponse,
 }
 
 func (ec *eventClient) EventCountByDeviceName(ctx context.Context, name string) (dtoCommon.CountResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiEventCountRoute, common.Device, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiEventCountRoute, common.Device, common.Name, name)
 	res := dtoCommon.CountResponse{}
 	err := utils.GetRequest(ctx, &res, ec.baseUrl, requestPath, nil)
 	if err != nil {
@@ -81,7 +81,7 @@ func (ec *eventClient) EventCountByDeviceName(ctx context.Context, name string) 
 
 func (ec *eventClient) EventsByDeviceName(ctx context.Context, name string, offset, limit int) (
 	responses.MultiEventsResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiEventRoute, common.Device, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiEventRoute, common.Device, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -94,7 +94,7 @@ func (ec *eventClient) EventsByDeviceName(ctx context.Context, name string, offs
 }
 
 func (ec *eventClient) DeleteByDeviceName(ctx context.Context, name string) (dtoCommon.BaseResponse, errors.EdgeX) {
-	path := path.Join(common.ApiEventRoute, common.Device, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiEventRoute, common.Device, common.Name, name)
 	res := dtoCommon.BaseResponse{}
 	err := utils.DeleteRequest(ctx, &res, ec.baseUrl, path)
 	if err != nil {

--- a/clients/http/interval.go
+++ b/clients/http/interval.go
@@ -34,7 +34,7 @@ func NewIntervalClient(baseUrl string) interfaces.IntervalClient {
 // Add adds new intervals
 func (client IntervalClient) Add(ctx context.Context, reqs []requests.AddIntervalRequest) (
 	res []dtoCommon.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl+common.ApiIntervalRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl, common.ApiIntervalRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -44,7 +44,7 @@ func (client IntervalClient) Add(ctx context.Context, reqs []requests.AddInterva
 // Update updates intervals
 func (client IntervalClient) Update(ctx context.Context, reqs []requests.UpdateIntervalRequest) (
 	res []dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, client.baseUrl+common.ApiIntervalRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, client.baseUrl, common.ApiIntervalRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -67,7 +67,7 @@ func (client IntervalClient) AllIntervals(ctx context.Context, offset int, limit
 // IntervalByName query the interval by name
 func (client IntervalClient) IntervalByName(ctx context.Context, name string) (
 	res responses.IntervalResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiIntervalRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -78,7 +78,7 @@ func (client IntervalClient) IntervalByName(ctx context.Context, name string) (
 // DeleteIntervalByName delete the interval by name
 func (client IntervalClient) DeleteIntervalByName(ctx context.Context, name string) (
 	res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiIntervalRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/intervalaction.go
+++ b/clients/http/intervalaction.go
@@ -34,7 +34,7 @@ func NewIntervalActionClient(baseUrl string) interfaces.IntervalActionClient {
 // Add adds new intervalActions
 func (client IntervalActionClient) Add(ctx context.Context, reqs []requests.AddIntervalActionRequest) (
 	res []dtoCommon.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl+common.ApiIntervalActionRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl, common.ApiIntervalActionRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -44,7 +44,7 @@ func (client IntervalActionClient) Add(ctx context.Context, reqs []requests.AddI
 // Update updates intervalActions
 func (client IntervalActionClient) Update(ctx context.Context, reqs []requests.UpdateIntervalActionRequest) (
 	res []dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, client.baseUrl+common.ApiIntervalActionRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, client.baseUrl, common.ApiIntervalActionRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -67,7 +67,7 @@ func (client IntervalActionClient) AllIntervalActions(ctx context.Context, offse
 // IntervalActionByName query the intervalAction by name
 func (client IntervalActionClient) IntervalActionByName(ctx context.Context, name string) (
 	res responses.IntervalActionResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalActionRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiIntervalActionRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -78,7 +78,7 @@ func (client IntervalActionClient) IntervalActionByName(ctx context.Context, nam
 // DeleteIntervalActionByName delete the intervalAction by name
 func (client IntervalActionClient) DeleteIntervalActionByName(ctx context.Context, name string) (
 	res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalActionRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiIntervalActionRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/notification.go
+++ b/clients/http/notification.go
@@ -33,7 +33,7 @@ func NewNotificationClient(baseUrl string) interfaces.NotificationClient {
 
 // SendNotification sends new notifications.
 func (client *NotificationClient) SendNotification(ctx context.Context, reqs []requests.AddNotificationRequest) (res []dtoCommon.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl+common.ApiNotificationRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl, common.ApiNotificationRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -42,7 +42,7 @@ func (client *NotificationClient) SendNotification(ctx context.Context, reqs []r
 
 // NotificationById query notification by id.
 func (client *NotificationClient) NotificationById(ctx context.Context, id string) (res responses.NotificationResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiNotificationRoute, common.Id, url.QueryEscape(id))
+	path := path.Join(common.ApiNotificationRoute, common.Id, id)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -52,7 +52,7 @@ func (client *NotificationClient) NotificationById(ctx context.Context, id strin
 
 // DeleteNotificationById deletes a notification by id.
 func (client *NotificationClient) DeleteNotificationById(ctx context.Context, id string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiNotificationRoute, common.Id, url.QueryEscape(id))
+	path := path.Join(common.ApiNotificationRoute, common.Id, id)
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -62,7 +62,7 @@ func (client *NotificationClient) DeleteNotificationById(ctx context.Context, id
 
 // NotificationsByCategory queries notifications with category, offset and limit
 func (client *NotificationClient) NotificationsByCategory(ctx context.Context, category string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiNotificationRoute, common.Category, url.QueryEscape(category))
+	requestPath := path.Join(common.ApiNotificationRoute, common.Category, category)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -75,7 +75,7 @@ func (client *NotificationClient) NotificationsByCategory(ctx context.Context, c
 
 // NotificationsByLabel queries notifications with label, offset and limit
 func (client *NotificationClient) NotificationsByLabel(ctx context.Context, label string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiNotificationRoute, common.Label, url.QueryEscape(label))
+	requestPath := path.Join(common.ApiNotificationRoute, common.Label, label)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -88,7 +88,7 @@ func (client *NotificationClient) NotificationsByLabel(ctx context.Context, labe
 
 // NotificationsByStatus queries notifications with status, offset and limit
 func (client *NotificationClient) NotificationsByStatus(ctx context.Context, status string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiNotificationRoute, common.Status, url.QueryEscape(status))
+	requestPath := path.Join(common.ApiNotificationRoute, common.Status, status)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -114,7 +114,7 @@ func (client *NotificationClient) NotificationsByTimeRange(ctx context.Context, 
 
 // NotificationsBySubscriptionName query notifications with subscriptionName, offset and limit
 func (client *NotificationClient) NotificationsBySubscriptionName(ctx context.Context, subscriptionName string, offset int, limit int) (res responses.MultiNotificationsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiNotificationRoute, common.Subscription, common.Name, url.QueryEscape(subscriptionName))
+	requestPath := path.Join(common.ApiNotificationRoute, common.Subscription, common.Name, subscriptionName)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))

--- a/clients/http/provisionwatcher.go
+++ b/clients/http/provisionwatcher.go
@@ -33,7 +33,7 @@ func NewProvisionWatcherClient(baseUrl string) interfaces.ProvisionWatcherClient
 }
 
 func (pwc ProvisionWatcherClient) Add(ctx context.Context, reqs []requests.AddProvisionWatcherRequest) (res []dtoCommon.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, pwc.baseUrl+common.ApiProvisionWatcherRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, pwc.baseUrl, common.ApiProvisionWatcherRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -42,7 +42,7 @@ func (pwc ProvisionWatcherClient) Add(ctx context.Context, reqs []requests.AddPr
 }
 
 func (pwc ProvisionWatcherClient) Update(ctx context.Context, reqs []requests.UpdateProvisionWatcherRequest) (res []dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, pwc.baseUrl+common.ApiProvisionWatcherRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, pwc.baseUrl, common.ApiProvisionWatcherRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -66,7 +66,7 @@ func (pwc ProvisionWatcherClient) AllProvisionWatchers(ctx context.Context, labe
 }
 
 func (pwc ProvisionWatcherClient) ProvisionWatcherByName(ctx context.Context, name string) (res responses.ProvisionWatcherResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiProvisionWatcherRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiProvisionWatcherRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, pwc.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -76,7 +76,7 @@ func (pwc ProvisionWatcherClient) ProvisionWatcherByName(ctx context.Context, na
 }
 
 func (pwc ProvisionWatcherClient) DeleteProvisionWatcherByName(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiProvisionWatcherRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiProvisionWatcherRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, pwc.baseUrl, path)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -86,7 +86,7 @@ func (pwc ProvisionWatcherClient) DeleteProvisionWatcherByName(ctx context.Conte
 }
 
 func (pwc ProvisionWatcherClient) ProvisionWatchersByProfileName(ctx context.Context, name string, offset int, limit int) (res responses.MultiProvisionWatchersResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiProvisionWatcherRoute, common.Profile, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiProvisionWatcherRoute, common.Profile, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -99,7 +99,7 @@ func (pwc ProvisionWatcherClient) ProvisionWatchersByProfileName(ctx context.Con
 }
 
 func (pwc ProvisionWatcherClient) ProvisionWatchersByServiceName(ctx context.Context, name string, offset int, limit int) (res responses.MultiProvisionWatchersResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiProvisionWatcherRoute, common.Service, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiProvisionWatcherRoute, common.Service, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))

--- a/clients/http/reading.go
+++ b/clients/http/reading.go
@@ -52,7 +52,7 @@ func (rc readingClient) ReadingCount(ctx context.Context) (dtoCommon.CountRespon
 }
 
 func (rc readingClient) ReadingCountByDeviceName(ctx context.Context, name string) (dtoCommon.CountResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiReadingCountRoute, common.Device, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiReadingCountRoute, common.Device, common.Name, name)
 	res := dtoCommon.CountResponse{}
 	err := utils.GetRequest(ctx, &res, rc.baseUrl, requestPath, nil)
 	if err != nil {
@@ -62,7 +62,7 @@ func (rc readingClient) ReadingCountByDeviceName(ctx context.Context, name strin
 }
 
 func (rc readingClient) ReadingsByDeviceName(ctx context.Context, name string, offset, limit int) (responses.MultiReadingsResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -75,7 +75,7 @@ func (rc readingClient) ReadingsByDeviceName(ctx context.Context, name string, o
 }
 
 func (rc readingClient) ReadingsByResourceName(ctx context.Context, name string, offset, limit int) (responses.MultiReadingsResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiReadingRoute, common.ResourceName, url.QueryEscape(name))
+	requestPath := path.Join(common.ApiReadingRoute, common.ResourceName, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -102,7 +102,7 @@ func (rc readingClient) ReadingsByTimeRange(ctx context.Context, start, end, off
 
 // ReadingsByResourceNameAndTimeRange returns readings by resource name and specified time range. Readings are sorted in descending order of origin time.
 func (rc readingClient) ReadingsByResourceNameAndTimeRange(ctx context.Context, name string, start, end, offset, limit int) (responses.MultiReadingsResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiReadingRoute, common.ResourceName, url.QueryEscape(name), common.Start, strconv.Itoa(start), common.End, strconv.Itoa(end))
+	requestPath := path.Join(common.ApiReadingRoute, common.ResourceName, name, common.Start, strconv.Itoa(start), common.End, strconv.Itoa(end))
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -115,7 +115,7 @@ func (rc readingClient) ReadingsByResourceNameAndTimeRange(ctx context.Context, 
 }
 
 func (rc readingClient) ReadingsByDeviceNameAndResourceName(ctx context.Context, deviceName, resourceName string, offset, limit int) (responses.MultiReadingsResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, url.QueryEscape(deviceName), common.ResourceName, url.QueryEscape(resourceName))
+	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, deviceName, common.ResourceName, resourceName)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -129,7 +129,7 @@ func (rc readingClient) ReadingsByDeviceNameAndResourceName(ctx context.Context,
 }
 
 func (rc readingClient) ReadingsByDeviceNameAndResourceNameAndTimeRange(ctx context.Context, deviceName, resourceName string, start, end, offset, limit int) (responses.MultiReadingsResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, url.QueryEscape(deviceName), common.ResourceName, url.QueryEscape(resourceName), common.Start, strconv.Itoa(start), common.End, strconv.Itoa(end))
+	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, deviceName, common.ResourceName, resourceName, common.Start, strconv.Itoa(start), common.End, strconv.Itoa(end))
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -142,7 +142,7 @@ func (rc readingClient) ReadingsByDeviceNameAndResourceNameAndTimeRange(ctx cont
 }
 
 func (rc readingClient) ReadingsByDeviceNameAndResourceNamesAndTimeRange(ctx context.Context, deviceName string, resourceNames []string, start, end, offset, limit int) (responses.MultiReadingsResponse, errors.EdgeX) {
-	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, url.QueryEscape(deviceName), common.Start, strconv.Itoa(start), common.End, strconv.Itoa(end))
+	requestPath := path.Join(common.ApiReadingRoute, common.Device, common.Name, deviceName, common.Start, strconv.Itoa(start), common.End, strconv.Itoa(end))
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))

--- a/clients/http/subscription.go
+++ b/clients/http/subscription.go
@@ -33,7 +33,7 @@ func NewSubscriptionClient(baseUrl string) interfaces.SubscriptionClient {
 
 // Add adds new subscriptions.
 func (client *SubscriptionClient) Add(ctx context.Context, reqs []requests.AddSubscriptionRequest) (res []dtoCommon.BaseWithIdResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl+common.ApiSubscriptionRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, client.baseUrl, common.ApiSubscriptionRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -42,7 +42,7 @@ func (client *SubscriptionClient) Add(ctx context.Context, reqs []requests.AddSu
 
 // Update updates subscriptions.
 func (client *SubscriptionClient) Update(ctx context.Context, reqs []requests.UpdateSubscriptionRequest) (res []dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PatchRequest(ctx, &res, client.baseUrl+common.ApiSubscriptionRoute, reqs)
+	err = utils.PatchRequest(ctx, &res, client.baseUrl, common.ApiSubscriptionRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -63,7 +63,7 @@ func (client *SubscriptionClient) AllSubscriptions(ctx context.Context, offset i
 
 // SubscriptionsByCategory queries subscriptions with category, offset and limit
 func (client *SubscriptionClient) SubscriptionsByCategory(ctx context.Context, category string, offset int, limit int) (res responses.MultiSubscriptionsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiSubscriptionRoute, common.Category, url.QueryEscape(category))
+	requestPath := path.Join(common.ApiSubscriptionRoute, common.Category, category)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -76,7 +76,7 @@ func (client *SubscriptionClient) SubscriptionsByCategory(ctx context.Context, c
 
 // SubscriptionsByLabel queries subscriptions with label, offset and limit
 func (client *SubscriptionClient) SubscriptionsByLabel(ctx context.Context, label string, offset int, limit int) (res responses.MultiSubscriptionsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiSubscriptionRoute, common.Label, url.QueryEscape(label))
+	requestPath := path.Join(common.ApiSubscriptionRoute, common.Label, label)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -89,7 +89,7 @@ func (client *SubscriptionClient) SubscriptionsByLabel(ctx context.Context, labe
 
 // SubscriptionsByReceiver queries subscriptions with receiver, offset and limit
 func (client *SubscriptionClient) SubscriptionsByReceiver(ctx context.Context, receiver string, offset int, limit int) (res responses.MultiSubscriptionsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiSubscriptionRoute, common.Receiver, url.QueryEscape(receiver))
+	requestPath := path.Join(common.ApiSubscriptionRoute, common.Receiver, receiver)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -102,7 +102,7 @@ func (client *SubscriptionClient) SubscriptionsByReceiver(ctx context.Context, r
 
 // SubscriptionByName query subscription by name.
 func (client *SubscriptionClient) SubscriptionByName(ctx context.Context, name string) (res responses.SubscriptionResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiSubscriptionRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiSubscriptionRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -112,7 +112,7 @@ func (client *SubscriptionClient) SubscriptionByName(ctx context.Context, name s
 
 // DeleteSubscriptionByName deletes a subscription by name.
 func (client *SubscriptionClient) DeleteSubscriptionByName(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiSubscriptionRoute, common.Name, url.QueryEscape(name))
+	path := path.Join(common.ApiSubscriptionRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/system.go
+++ b/clients/http/system.go
@@ -62,7 +62,7 @@ func (smc *SystemManagementClient) GetConfig(ctx context.Context, services []str
 }
 
 func (smc *SystemManagementClient) DoOperation(ctx context.Context, reqs []requests.OperationRequest) (res []dtoCommon.BaseResponse, err errors.EdgeX) {
-	err = utils.PostRequestWithRawData(ctx, &res, smc.baseUrl+common.ApiOperationRoute, reqs)
+	err = utils.PostRequestWithRawData(ctx, &res, smc.baseUrl, common.ApiOperationRoute, nil, reqs)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/http/transmission.go
+++ b/clients/http/transmission.go
@@ -32,7 +32,7 @@ func NewTransmissionClient(baseUrl string) interfaces.TransmissionClient {
 
 // TransmissionById query transmission by id.
 func (client *TransmissionClient) TransmissionById(ctx context.Context, id string) (res responses.TransmissionResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiTransmissionRoute, common.Id, url.QueryEscape(id))
+	path := path.Join(common.ApiTransmissionRoute, common.Id, id)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -67,7 +67,7 @@ func (client *TransmissionClient) AllTransmissions(ctx context.Context, offset i
 
 // TransmissionsByStatus queries transmissions with status, offset and limit
 func (client *TransmissionClient) TransmissionsByStatus(ctx context.Context, status string, offset int, limit int) (res responses.MultiTransmissionsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiTransmissionRoute, common.Status, url.QueryEscape(status))
+	requestPath := path.Join(common.ApiTransmissionRoute, common.Status, status)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -90,7 +90,7 @@ func (client *TransmissionClient) DeleteProcessedTransmissionsByAge(ctx context.
 
 // TransmissionsBySubscriptionName query transmissions with subscriptionName, offset and limit
 func (client *TransmissionClient) TransmissionsBySubscriptionName(ctx context.Context, subscriptionName string, offset int, limit int) (res responses.MultiTransmissionsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiTransmissionRoute, common.Subscription, common.Name, url.QueryEscape(subscriptionName))
+	requestPath := path.Join(common.ApiTransmissionRoute, common.Subscription, common.Name, subscriptionName)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -103,7 +103,7 @@ func (client *TransmissionClient) TransmissionsBySubscriptionName(ctx context.Co
 
 // TransmissionsByNotificationId query transmissions with notification id, offset and limit
 func (client *TransmissionClient) TransmissionsByNotificationId(ctx context.Context, id string, offset int, limit int) (res responses.MultiTransmissionsResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiTransmissionRoute, common.Notification, common.Id, url.QueryEscape(id))
+	requestPath := path.Join(common.ApiTransmissionRoute, common.Notification, common.Id, id)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))

--- a/clients/http/utils/request.go
+++ b/clients/http/utils/request.go
@@ -88,11 +88,11 @@ func GetRequestWithBodyRawData(ctx context.Context, returnValuePointer interface
 func PostRequest(
 	ctx context.Context,
 	returnValuePointer interface{},
-	url string,
+	baseUrl string, requestPath string,
 	data []byte,
 	encoding string) errors.EdgeX {
 
-	req, err := createRequestWithEncodedData(ctx, http.MethodPost, url, data, encoding)
+	req, err := createRequestWithEncodedData(ctx, http.MethodPost, baseUrl, requestPath, data, encoding)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -111,10 +111,11 @@ func PostRequest(
 func PostRequestWithRawData(
 	ctx context.Context,
 	returnValuePointer interface{},
-	url string,
+	baseUrl string, requestPath string,
+	requestParams url.Values,
 	data interface{}) errors.EdgeX {
 
-	req, err := createRequestWithRawData(ctx, http.MethodPost, url, data)
+	req, err := createRequestWithRawData(ctx, http.MethodPost, baseUrl, requestPath, requestParams, data)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -133,10 +134,11 @@ func PostRequestWithRawData(
 func PutRequest(
 	ctx context.Context,
 	returnValuePointer interface{},
-	url string,
+	baseUrl string, requestPath string,
+	requestParams url.Values,
 	data interface{}) errors.EdgeX {
 
-	req, err := createRequestWithRawData(ctx, http.MethodPut, url, data)
+	req, err := createRequestWithRawData(ctx, http.MethodPut, baseUrl, requestPath, requestParams, data)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -155,10 +157,11 @@ func PutRequest(
 func PatchRequest(
 	ctx context.Context,
 	returnValuePointer interface{},
-	url string,
+	baseUrl string, requestPath string,
+	requestParams url.Values,
 	data interface{}) errors.EdgeX {
 
-	req, err := createRequestWithRawData(ctx, http.MethodPatch, url, data)
+	req, err := createRequestWithRawData(ctx, http.MethodPatch, baseUrl, requestPath, requestParams, data)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -177,10 +180,10 @@ func PatchRequest(
 func PostByFileRequest(
 	ctx context.Context,
 	returnValuePointer interface{},
-	url string,
+	baseUrl string, requestPath string,
 	filePath string) errors.EdgeX {
 
-	req, err := createRequestFromFilePath(ctx, http.MethodPost, url, filePath)
+	req, err := createRequestFromFilePath(ctx, http.MethodPost, baseUrl, requestPath, filePath)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -199,10 +202,10 @@ func PostByFileRequest(
 func PutByFileRequest(
 	ctx context.Context,
 	returnValuePointer interface{},
-	url string,
+	baseUrl string, requestPath string,
 	filePath string) errors.EdgeX {
 
-	req, err := createRequestFromFilePath(ctx, http.MethodPut, url, filePath)
+	req, err := createRequestFromFilePath(ctx, http.MethodPut, baseUrl, requestPath, filePath)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}

--- a/clients/interfaces/mocks/CommandClient.go
+++ b/clients/interfaces/mocks/CommandClient.go
@@ -90,6 +90,31 @@ func (_m *CommandClient) IssueGetCommandByName(ctx context.Context, deviceName s
 	return r0, r1
 }
 
+// IssueGetCommandByNameWithQueryParams provides a mock function with given fields: ctx, deviceName, commandName, queryParams
+func (_m *CommandClient) IssueGetCommandByNameWithQueryParams(ctx context.Context, deviceName string, commandName string, queryParams map[string]string) (*responses.EventResponse, errors.EdgeX) {
+	ret := _m.Called(ctx, deviceName, commandName, queryParams)
+
+	var r0 *responses.EventResponse
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]string) *responses.EventResponse); ok {
+		r0 = rf(ctx, deviceName, commandName, queryParams)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*responses.EventResponse)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, map[string]string) errors.EdgeX); ok {
+		r1 = rf(ctx, deviceName, commandName, queryParams)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // IssueSetCommandByName provides a mock function with given fields: ctx, deviceName, commandName, settings
 func (_m *CommandClient) IssueSetCommandByName(ctx context.Context, deviceName string, commandName string, settings map[string]string) (common.BaseResponse, errors.EdgeX) {
 	ret := _m.Called(ctx, deviceName, commandName, settings)


### PR DESCRIPTION
- Remove redundant URL escaping from Client lib
- Refactor the HTTP request creating func

Close #730

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **not impact the test**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact the doc**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run go-mod-core-contract unit test
2. Deploy EdgeX
3. Deploy simple device service
4. Test Set and Get command to verify the general function works.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->