### PR TITLE
feat: Add SimpleReading value validation to prevent type mismatch

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -8,12 +8,14 @@ package dtos
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	edgexErrors "github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
@@ -281,6 +283,9 @@ func (b BaseReading) Validate() error {
 		if err := common.Validate(simpleReading); err != nil {
 			return err
 		}
+		if err := ValidateValue(b.ValueType, simpleReading.Value); err != nil {
+			return edgexErrors.NewCommonEdgeX(edgexErrors.KindContractInvalid, fmt.Sprintf("The value does not match the %v valueType", b.ValueType), nil)
+		}
 	}
 
 	return nil
@@ -357,4 +362,87 @@ func FromReadingModelToDTO(reading models.Reading) BaseReading {
 	}
 
 	return baseReading
+}
+
+// ValidateValue used to check whether the value and valueType are matched
+func ValidateValue(valueType string, value string) error {
+	if strings.Contains(valueType, "Array") {
+		return parseArrayValue(valueType, value)
+	} else {
+		return parseSimpleValue(valueType, value)
+	}
+}
+
+func parseSimpleValue(valueType string, value string) (err error) {
+	switch valueType {
+	case common.ValueTypeBool:
+		_, err = strconv.ParseBool(value)
+
+	case common.ValueTypeUint8:
+		_, err = strconv.ParseUint(value, 10, 8)
+	case common.ValueTypeUint16:
+		_, err = strconv.ParseUint(value, 10, 16)
+	case common.ValueTypeUint32:
+		_, err = strconv.ParseUint(value, 10, 32)
+	case common.ValueTypeUint64:
+		_, err = strconv.ParseUint(value, 10, 64)
+
+	case common.ValueTypeInt8:
+		_, err = strconv.ParseInt(value, 10, 8)
+	case common.ValueTypeInt16:
+		_, err = strconv.ParseInt(value, 10, 16)
+	case common.ValueTypeInt32:
+		_, err = strconv.ParseInt(value, 10, 32)
+	case common.ValueTypeInt64:
+		_, err = strconv.ParseInt(value, 10, 64)
+
+	case common.ValueTypeFloat32:
+		_, err = strconv.ParseFloat(value, 32)
+	case common.ValueTypeFloat64:
+		_, err = strconv.ParseFloat(value, 64)
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseArrayValue(valueType string, value string) (err error) {
+	arrayValue := strings.Split(value[1:len(value)-1], ", ") // trim "[" and "]"
+
+	for _, v := range arrayValue {
+		switch valueType {
+		case common.ValueTypeBoolArray:
+			err = parseSimpleValue(common.ValueTypeBool, v)
+
+		case common.ValueTypeUint8Array:
+			err = parseSimpleValue(common.ValueTypeUint8, v)
+		case common.ValueTypeUint16Array:
+			err = parseSimpleValue(common.ValueTypeUint16, v)
+		case common.ValueTypeUint32Array:
+			err = parseSimpleValue(common.ValueTypeUint32, v)
+		case common.ValueTypeUint64Array:
+			err = parseSimpleValue(common.ValueTypeUint64, v)
+
+		case common.ValueTypeInt8Array:
+			err = parseSimpleValue(common.ValueTypeInt8, v)
+		case common.ValueTypeInt16Array:
+			err = parseSimpleValue(common.ValueTypeInt16, v)
+		case common.ValueTypeInt32Array:
+			err = parseSimpleValue(common.ValueTypeInt32, v)
+		case common.ValueTypeInt64Array:
+			err = parseSimpleValue(common.ValueTypeInt64, v)
+
+		case common.ValueTypeFloat32Array:
+			err = parseSimpleValue(common.ValueTypeFloat32, v)
+		case common.ValueTypeFloat64Array:
+			err = parseSimpleValue(common.ValueTypeFloat64, v)
+
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -231,3 +231,80 @@ func TestNewObjectReading(t *testing.T) {
 	assert.Equal(t, expectedValue, actual.ObjectValue)
 	assert.NotZero(t, actual.Origin)
 }
+
+func TestValidateValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		valueType string
+		value     string
+	}{
+		{"Simple Boolean (true)", common.ValueTypeBool, "True"},
+		{"Simple String", common.ValueTypeString, "hello world"},
+		{"Simple Uint8", common.ValueTypeUint8, "123"},
+		{"Simple Uint16", common.ValueTypeUint16, "12345"},
+		{"Simple Uint32", common.ValueTypeUint32, "1234567890"},
+		{"Simple uint64", common.ValueTypeUint64, "1234567890987654321"},
+		{"Simple int8", common.ValueTypeInt8, "-123"},
+		{"Simple int16", common.ValueTypeInt16, "-12345"},
+		{"Simple int32", common.ValueTypeInt32, "-1234567890"},
+		{"Simple int64", common.ValueTypeInt64, "-1234567890987654321"},
+		{"Simple Float32", common.ValueTypeFloat32, "123.456"},
+		{"Simple Float64", common.ValueTypeFloat64, "123456789.0987654321"},
+		{"Simple Boolean Array", common.ValueTypeBoolArray, "[true, false]"},
+		{"Simple String Array", common.ValueTypeStringArray, "[\"hello\", \"world\"]"},
+		{"Simple Uint8 Array", common.ValueTypeUint8Array, "[123, 21]"},
+		{"Simple Uint16 Array", common.ValueTypeUint16Array, "[12345, 4321]"},
+		{"Simple Uint32 Array", common.ValueTypeUint32Array, "[1234567890, 87654321]"},
+		{"Simple Uint64 Array", common.ValueTypeUint64Array, "[1234567890987654321, 10987654321]"},
+		{"Simple Int8 Array", common.ValueTypeInt8Array, "[-123, 123]"},
+		{"Simple Int16 Array", common.ValueTypeInt16Array, "[-12345, 12345]"},
+		{"Simple Int32 Array", common.ValueTypeInt32Array, "[-1234567890, 1234567890]"},
+		{"Simple Int64 Array", common.ValueTypeInt64Array, "[-1234567890987654321, 1234567890987654321]"},
+		{"Simple Float32 Array", common.ValueTypeFloat32Array, "[123.456, -654.321]"},
+		{"Simple Float64 Array", common.ValueTypeFloat64Array, "[123456789.0987654321, -987654321.123456789]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateValue(tt.valueType, tt.value)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateValueError(t *testing.T) {
+	invalidValue := "invalid"
+	tests := []struct {
+		name      string
+		valueType string
+	}{
+		{"Invalid Simple Boolean (true)", common.ValueTypeBool},
+		{"Invalid Simple Uint8", common.ValueTypeUint8},
+		{"Invalid Simple Uint16", common.ValueTypeUint16},
+		{"Invalid Simple Uint32", common.ValueTypeUint32},
+		{"Invalid Simple uint64", common.ValueTypeUint64},
+		{"Invalid Simple int8", common.ValueTypeInt8},
+		{"Invalid Simple int16", common.ValueTypeInt16},
+		{"Invalid Simple int32", common.ValueTypeInt32},
+		{"Invalid Simple int64", common.ValueTypeInt64},
+		{"Invalid Simple Float32", common.ValueTypeFloat32},
+		{"Invalid Simple Float64", common.ValueTypeFloat64},
+		{"Invalid Simple Boolean Array", common.ValueTypeBoolArray},
+		{"Invalid Simple Uint8 Array", common.ValueTypeUint8Array},
+		{"Invalid Simple Uint16 Array", common.ValueTypeUint16Array},
+		{"Invalid Simple Uint32 Array", common.ValueTypeUint32Array},
+		{"Invalid Simple Uint64 Array", common.ValueTypeUint64Array},
+		{"Invalid Simple Int8 Array", common.ValueTypeInt8Array},
+		{"Invalid Simple Int16 Array", common.ValueTypeInt16Array},
+		{"Invalid Simple Int32 Array", common.ValueTypeInt32Array},
+		{"Invalid Simple Int64 Array", common.ValueTypeInt64Array},
+		{"Invalid Simple Float32 Array", common.ValueTypeFloat32Array},
+		{"Invalid Simple Float64 Array", common.ValueTypeFloat64Array},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateValue(tt.valueType, invalidValue)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
close #737

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)NA, just add a validation to check value and type
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Build core-data from this branch and run with other edgex services
2. Create a event having mismatched value and valueType
3. verify the response

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->