### PR TITLE
feat: Reduce the character restriction of the name field

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -34,7 +34,7 @@ const (
 const (
 	// Per https://tools.ietf.org/html/rfc3986#section-2.3, unreserved characters= ALPHA / DIGIT / "-" / "." / "_" / "~"
 	// Also due to names used in topics for Redis Pub/Sub, "."are not allowed
-	rFC3986UnreservedCharsRegexString = "^[a-zA-Z0-9-_~]+$"
+	rFC3986UnreservedCharsRegexString = "^[a-zA-Z0-9-_~:;=]+$"
 	intervalDatetimeLayout            = "20060102T150405"
 	name                              = "Name"
 )
@@ -95,7 +95,7 @@ func getErrorMessage(e validator.FieldError) string {
 	case dtoNoneEmptyStringTag:
 		msg = fmt.Sprintf("%s field should not be empty string", fieldName)
 	case dtoRFC3986UnreservedCharTag:
-		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~", fieldName)
+		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~:;=", fieldName)
 	default:
 		msg = fmt.Sprintf("%s field validation failed on the %s tag", fieldName, tag)
 	}


### PR DESCRIPTION
Add characters :;= to reduce the character restriction.
Add characters :;= to reduce the character restriction.
- In BACNet protocol, the user might combine object type and property as the resourceName, for example, analog_input_0:present-value
- In OPC_UA protocol, the user might use NodeId as the resourceName, for example, ns=10;s=Hello:World

Close #750

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact the test
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact the doc
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

- Run core-metadata
- Add metadata with characters :;=

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->