### PR TITLE
refactor!: Use true/false for command parameters to be more consistent

### DIFF
--- a/clients/http/command.go
+++ b/clients/http/command.go
@@ -55,10 +55,10 @@ func (client *CommandClient) DeviceCoreCommandsByDeviceName(ctx context.Context,
 }
 
 // IssueGetCommandByName issues the specified read command referenced by the command name to the device/sensor that is also referenced by name.
-func (client *CommandClient) IssueGetCommandByName(ctx context.Context, deviceName string, commandName string, dsPushEvent string, dsReturnEvent string) (res *responses.EventResponse, err errors.EdgeX) {
+func (client *CommandClient) IssueGetCommandByName(ctx context.Context, deviceName string, commandName string, dsPushEvent bool, dsReturnEvent bool) (res *responses.EventResponse, err errors.EdgeX) {
 	requestParams := url.Values{}
-	requestParams.Set(common.PushEvent, dsPushEvent)
-	requestParams.Set(common.ReturnEvent, dsReturnEvent)
+	requestParams.Set(common.PushEvent, strconv.FormatBool(dsPushEvent))
+	requestParams.Set(common.ReturnEvent, strconv.FormatBool(dsReturnEvent))
 	requestPath := path.Join(common.ApiDeviceRoute, common.Name, deviceName, commandName)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams)
 	if err != nil {

--- a/clients/http/command_test.go
+++ b/clients/http/command_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"strconv"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -47,7 +48,11 @@ func TestIssueGetCommandByName(t *testing.T) {
 	ts := newTestServer(http.MethodGet, path, &responses.EventResponse{})
 	defer ts.Close()
 	client := NewCommandClient(ts.URL)
-	res, err := client.IssueGetCommandByName(context.Background(), deviceName, cmdName, common.ValueYes, common.ValueNo)
+	pushEvent, err := strconv.ParseBool(common.ValueTrue)
+	require.NoError(t, err)
+	notReturnEvent, err := strconv.ParseBool(common.ValueFalse)
+	require.NoError(t, err)
+	res, err := client.IssueGetCommandByName(context.Background(), deviceName, cmdName, pushEvent, notReturnEvent)
 	require.NoError(t, err)
 	require.IsType(t, &responses.EventResponse{}, res)
 }

--- a/clients/interfaces/command.go
+++ b/clients/interfaces/command.go
@@ -23,9 +23,9 @@ type CommandClient interface {
 	// DeviceCoreCommandsByDeviceName returns all commands associated with the specified device name.
 	DeviceCoreCommandsByDeviceName(ctx context.Context, deviceName string) (responses.DeviceCoreCommandResponse, errors.EdgeX)
 	// IssueGetCommandByName issues the specified read command referenced by the command name to the device/sensor that is also referenced by name.
-	// dsPushEvent: If set to yes, a successful GET will result in an event being pushed to the EdgeX system. Default value is no.
-	// dsReturnEvent: If set to no, there will be no Event returned in the http response. Default value is yes.
-	IssueGetCommandByName(ctx context.Context, deviceName string, commandName string, dsPushEvent string, dsReturnEvent string) (*responses.EventResponse, errors.EdgeX)
+	// dsPushEvent: If set to true, a successful GET will result in an event being pushed to the EdgeX system. Default value is false.
+	// dsReturnEvent: If set to false, there will be no Event returned in the http response. Default value is true.
+	IssueGetCommandByName(ctx context.Context, deviceName string, commandName string, dsPushEvent bool, dsReturnEvent bool) (*responses.EventResponse, errors.EdgeX)
 	// IssueGetCommandByNameWithQueryParams issues the specified read command by deviceName and commandName with additional query parameters.
 	IssueGetCommandByNameWithQueryParams(ctx context.Context, deviceName string, commandName string, queryParams map[string]string) (*responses.EventResponse, errors.EdgeX)
 	// IssueSetCommandByName issues the specified write command referenced by the command name to the device/sensor that is also referenced by name.

--- a/common/constants.go
+++ b/common/constants.go
@@ -190,8 +190,6 @@ const (
 	DefaultOffset  = 0
 	DefaultLimit   = 20
 	CommaSeparator = ","
-	ValueYes       = "yes"
-	ValueNo        = "no"
 	ValueTrue      = "true"
 	ValueFalse     = "false"
 )


### PR DESCRIPTION
BREAKING CHANGE:
- ds-pushevent and ds-returnevent to use true/false instead of yes/no

close #780

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/917

## Testing Instructions
<!-- How can the reviewers test your change? -->
build core-command and device-virtual docker images based on the changes and run docker-compose.yml
The following commands work as expected:
- `curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=true`
- `curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=false`
- `curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=true`
- `curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=false`
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->