### PR TITLE
feat: Consolidate topic keys for Commanding in one block of common constants

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -308,3 +308,16 @@ const (
 	ConfigStemDevice   = ConfigStemAll
 	ConfigStemSecurity = ConfigStemAll
 )
+
+// Constants related to topics for Commanding via MessageBus
+const (
+	CommandQueryRequestTopicKey           = "CommandQueryRequestTopic"
+	CommandQueryRequestTopicPrefixKey     = "CommandQueryRequestTopicPrefix"
+	CommandRequestTopicKey                = "CommandRequestTopic"
+	CommandRequestTopicPrefixKey          = "CommandRequestTopicPrefix"
+	DeviceCommandRequestTopicKey          = "DeviceCommandRequestTopic"
+	DeviceCommandRequestTopicPrefixKey    = "DeviceCommandRequestTopicPrefix"
+	ExternalCommandQueryResponseTopicKey  = "CommandQueryResponseTopic"
+	ExternalCommandResponseTopicPrefixKey = "CommandResponseTopicPrefix"
+	ResponseTopicPrefixKey                = "ResponseTopicPrefix"
+)


### PR DESCRIPTION

Topic constants for commanding were scattered across multiple files. This puts them in a single place.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->