### PR TITLE
feat: Add new Properties field to Device DTO and Model

### DIFF
--- a/dtos/device.go
+++ b/dtos/device.go
@@ -27,6 +27,7 @@ type Device struct {
 	AutoEvents     []AutoEvent                   `json:"autoEvents,omitempty" validate:"dive"`
 	Protocols      map[string]ProtocolProperties `json:"protocols" validate:"required,gt=0"`
 	Tags           map[string]any                `json:"tags,omitempty"`
+	Properties     map[string]any                `json:"properties,omitempty"`
 }
 
 // UpdateDevice and its properties are defined in the APIv2 specification:
@@ -47,6 +48,7 @@ type UpdateDevice struct {
 	Protocols      map[string]ProtocolProperties `json:"protocols" validate:"omitempty,gt=0"`
 	Notify         *bool                         `json:"notify"`
 	Tags           map[string]any                `json:"tags"`
+	Properties     map[string]any                `json:"properties"`
 }
 
 // ToDeviceModel transforms the Device DTO to the Device Model
@@ -66,6 +68,7 @@ func ToDeviceModel(dto Device) models.Device {
 	d.AutoEvents = ToAutoEventModels(dto.AutoEvents)
 	d.Protocols = ToProtocolModels(dto.Protocols)
 	d.Tags = dto.Tags
+	d.Properties = dto.Properties
 	return d
 }
 
@@ -87,6 +90,7 @@ func FromDeviceModelToDTO(d models.Device) Device {
 	dto.AutoEvents = FromAutoEventModelsToDTOs(d.AutoEvents)
 	dto.Protocols = FromProtocolModelsToDTOs(d.Protocols)
 	dto.Tags = d.Tags
+	dto.Properties = d.Properties
 	return dto
 }
 
@@ -110,6 +114,7 @@ func FromDeviceModelToUpdateDTO(d models.Device) UpdateDevice {
 		Labels:         d.Labels,
 		Notify:         &d.Notify,
 		Tags:           d.Tags,
+		Properties:     d.Properties,
 	}
 	return dto
 }

--- a/dtos/device_test.go
+++ b/dtos/device_test.go
@@ -27,4 +27,5 @@ func TestFromDeviceModelToUpdateDTO(t *testing.T) {
 	assert.Equal(t, model.ProfileName, *dto.ProfileName)
 	assert.Equal(t, model.Location, dto.Location)
 	assert.Equal(t, model.Tags, dto.Tags)
+	assert.Equal(t, model.Properties, dto.Properties)
 }

--- a/dtos/requests/device.go
+++ b/dtos/requests/device.go
@@ -128,6 +128,12 @@ func ReplaceDeviceModelFieldsWithDTO(device *models.Device, patch dtos.UpdateDev
 	if patch.Notify != nil {
 		device.Notify = *patch.Notify
 	}
+	if patch.Tags != nil {
+		device.Tags = patch.Tags
+	}
+	if patch.Properties != nil {
+		device.Properties = patch.Properties
+	}
 }
 
 func NewAddDeviceRequest(dto dtos.Device) AddDeviceRequest {

--- a/dtos/requests/device_test.go
+++ b/dtos/requests/device_test.go
@@ -387,6 +387,8 @@ func TestUpdateDeviceRequest_UnmarshalJSON_NilField(t *testing.T) {
 	assert.Nil(t, req.Device.AutoEvents)
 	assert.Nil(t, req.Device.Protocols)
 	assert.Nil(t, req.Device.Notify)
+	assert.Nil(t, req.Device.Tags)
+	assert.Nil(t, req.Device.Properties)
 }
 
 func TestUpdateDeviceRequest_UnmarshalJSON_EmptySlice(t *testing.T) {

--- a/models/device.go
+++ b/models/device.go
@@ -25,6 +25,7 @@ type Device struct {
 	AutoEvents     []AutoEvent
 	Notify         bool
 	Tags           map[string]any
+	Properties     map[string]any
 }
 
 // ProtocolProperties contains the device connection information in key/value pair


### PR DESCRIPTION
Add an extendable field into Device DTO and Model: Properties map[string]any
This is useful for some devices that requires extra information. For example, a BACnet device may have properties such as DeviceInstance, Firmware, InstanceID, and ObjectName.

fixes https://github.com/edgexfoundry/go-mod-core-contracts/issues/769

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->