### PR TITLE
feat: Add new Properties field to ProvisionWatcher DTO and Model

### DIFF
--- a/dtos/provisionwatcher.go
+++ b/dtos/provisionwatcher.go
@@ -22,6 +22,7 @@ type ProvisionWatcher struct {
 	ServiceName         string              `json:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState          string              `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents          []AutoEvent         `json:"autoEvents,omitempty" validate:"dive"`
+	Properties          map[string]any      `json:"properties,omitempty"`
 }
 
 // UpdateProvisionWatcher and its properties are defined in the APIv2 specification:
@@ -36,6 +37,7 @@ type UpdateProvisionWatcher struct {
 	ServiceName         *string             `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState          *string             `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents          []AutoEvent         `json:"autoEvents" validate:"dive"`
+	Properties          map[string]any      `json:"properties"`
 }
 
 // ToProvisionWatcherModel transforms the ProvisionWatcher DTO to the ProvisionWatcher model
@@ -51,6 +53,7 @@ func ToProvisionWatcherModel(dto ProvisionWatcher) models.ProvisionWatcher {
 		ServiceName:         dto.ServiceName,
 		AdminState:          models.AdminState(dto.AdminState),
 		AutoEvents:          ToAutoEventModels(dto.AutoEvents),
+		Properties:          dto.Properties,
 	}
 }
 
@@ -67,6 +70,7 @@ func FromProvisionWatcherModelToDTO(pw models.ProvisionWatcher) ProvisionWatcher
 		ServiceName:         pw.ServiceName,
 		AdminState:          string(pw.AdminState),
 		AutoEvents:          FromAutoEventModelsToDTOs(pw.AutoEvents),
+		Properties:          pw.Properties,
 	}
 }
 
@@ -83,6 +87,7 @@ func FromProvisionWatcherModelToUpdateDTO(pw models.ProvisionWatcher) UpdateProv
 		Labels:              pw.Labels,
 		Identifiers:         pw.Identifiers,
 		BlockingIdentifiers: pw.BlockingIdentifiers,
+		Properties:          pw.Properties,
 	}
 	return dto
 }

--- a/dtos/provisionwatcher_test.go
+++ b/dtos/provisionwatcher_test.go
@@ -24,4 +24,5 @@ func TestFromProvisionWatcherModelToUpdateDTO(t *testing.T) {
 	assert.Equal(t, model.ProfileName, *dto.ProfileName)
 	assert.Equal(t, model.ServiceName, *dto.ServiceName)
 	assert.EqualValues(t, model.AdminState, *dto.AdminState)
+	assert.Equal(t, model.Properties, dto.Properties)
 }

--- a/dtos/requests/provisionwatcher.go
+++ b/dtos/requests/provisionwatcher.go
@@ -113,6 +113,9 @@ func ReplaceProvisionWatcherModelFieldsWithDTO(pw *models.ProvisionWatcher, patc
 	if patch.AutoEvents != nil {
 		pw.AutoEvents = dtos.ToAutoEventModels(patch.AutoEvents)
 	}
+	if patch.Properties != nil {
+		pw.Properties = patch.Properties
+	}
 }
 
 func NewAddProvisionWatcherRequest(dto dtos.ProvisionWatcher) AddProvisionWatcherRequest {

--- a/dtos/requests/provisionwatcher_test.go
+++ b/dtos/requests/provisionwatcher_test.go
@@ -301,6 +301,7 @@ func TestUpdateProvisionWatcherRequest_UnmarshalJSON_NilField(t *testing.T) {
 	assert.Nil(t, req.ProvisionWatcher.ProfileName)
 	assert.Nil(t, req.ProvisionWatcher.AdminState)
 	assert.Nil(t, req.ProvisionWatcher.AutoEvents)
+	assert.Nil(t, req.ProvisionWatcher.Properties)
 }
 
 func TestUpdateProvisionWatcherRequest_UnmarshalJSON_EmptySlice(t *testing.T) {

--- a/models/provisionwatcher.go
+++ b/models/provisionwatcher.go
@@ -19,4 +19,5 @@ type ProvisionWatcher struct {
 	ServiceName         string
 	AdminState          AdminState
 	AutoEvents          []AutoEvent
+	Properties          map[string]any
 }


### PR DESCRIPTION
Add an extendable field into ProvisionWatcher DTO and Model: `Properties map[string]any`. This is useful when certain device services requires extra information from ProvisionWatcher.  For example, assume a device service would like to generate the device name in certain format during auto discovery, the user can define a property "DeviceNameTemplate" with value as the template of device name in the ProvisionWatcher, so that the device service can pick up such property to generate the device name.

fixes https://github.com/edgexfoundry/go-mod-core-contracts/issues/772

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->