### PR TITLE
feat: add 'Others' field in ResourceProperties

### DIFF
--- a/dtos/deviceprofile_test.go
+++ b/dtos/deviceprofile_test.go
@@ -37,6 +37,7 @@ var testDeviceProfile = models.DeviceProfile{
 		Properties: models.ResourceProperties{
 			ValueType: common.ValueTypeInt16,
 			ReadWrite: common.ReadWrite_RW,
+			Others:    testTags,
 		},
 		Tags: testTags,
 	}},
@@ -67,6 +68,7 @@ func profileData() DeviceProfile {
 			Properties: ResourceProperties{
 				ValueType: common.ValueTypeInt16,
 				ReadWrite: common.ReadWrite_RW,
+				Others:    testTags,
 			},
 			Tags: testTags,
 		}},

--- a/dtos/resourceproperties.go
+++ b/dtos/resourceproperties.go
@@ -1,28 +1,31 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package dtos
 
-import "github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+)
 
 // ResourceProperties and its properties care defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.1.0#/ResourceProperties
 type ResourceProperties struct {
-	ValueType    string `json:"valueType" yaml:"valueType" validate:"required,edgex-dto-value-type"`
-	ReadWrite    string `json:"readWrite" yaml:"readWrite" validate:"required,oneof='R' 'W' 'RW' 'WR'"`
-	Units        string `json:"units" yaml:"units"`
-	Minimum      string `json:"minimum" yaml:"minimum"`
-	Maximum      string `json:"maximum" yaml:"maximum"`
-	DefaultValue string `json:"defaultValue" yaml:"defaultValue"`
-	Mask         string `json:"mask" yaml:"mask"`
-	Shift        string `json:"shift" yaml:"shift"`
-	Scale        string `json:"scale" yaml:"scale"`
-	Offset       string `json:"offset" yaml:"offset"`
-	Base         string `json:"base" yaml:"base"`
-	Assertion    string `json:"assertion" yaml:"assertion"`
-	MediaType    string `json:"mediaType" yaml:"mediaType"`
+	ValueType    string         `json:"valueType" yaml:"valueType" validate:"required,edgex-dto-value-type"`
+	ReadWrite    string         `json:"readWrite" yaml:"readWrite" validate:"required,oneof='R' 'W' 'RW' 'WR'"`
+	Units        string         `json:"units,omitempty" yaml:"units"`
+	Minimum      string         `json:"minimum,omitempty" yaml:"minimum"`
+	Maximum      string         `json:"maximum,omitempty" yaml:"maximum"`
+	DefaultValue string         `json:"defaultValue,omitempty" yaml:"defaultValue"`
+	Mask         string         `json:"mask,omitempty" yaml:"mask"`
+	Shift        string         `json:"shift,omitempty" yaml:"shift"`
+	Scale        string         `json:"scale,omitempty" yaml:"scale"`
+	Offset       string         `json:"offset,omitempty" yaml:"offset"`
+	Base         string         `json:"base,omitempty" yaml:"base"`
+	Assertion    string         `json:"assertion,omitempty" yaml:"assertion"`
+	MediaType    string         `json:"mediaType,omitempty" yaml:"mediaType"`
+	Others       map[string]any `json:"others,omitempty" yaml:"others"`
 }
 
 // ToResourcePropertiesModel transforms the ResourceProperties DTO to the ResourceProperties model
@@ -41,6 +44,7 @@ func ToResourcePropertiesModel(p ResourceProperties) models.ResourceProperties {
 		Base:         p.Base,
 		Assertion:    p.Assertion,
 		MediaType:    p.MediaType,
+		Others:       p.Others,
 	}
 }
 
@@ -60,5 +64,6 @@ func FromResourcePropertiesModelToDTO(p models.ResourceProperties) ResourcePrope
 		Base:         p.Base,
 		Assertion:    p.Assertion,
 		MediaType:    p.MediaType,
+		Others:       p.Others,
 	}
 }

--- a/models/resourceproperties.go
+++ b/models/resourceproperties.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,4 +22,5 @@ type ResourceProperties struct {
 	Base         string
 	Assertion    string
 	MediaType    string
+	Others       map[string]any
 }


### PR DESCRIPTION
also add 'omitempty' JSON tag for non-required properties

closes #770

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->