### PR TITLE
feat!: Remove Notify out of Device DTO/Model

### DIFF
--- a/dtos/device.go
+++ b/dtos/device.go
@@ -42,7 +42,6 @@ type UpdateDevice struct {
 	Location       interface{}                   `json:"location"`
 	AutoEvents     []AutoEvent                   `json:"autoEvents" validate:"dive"`
 	Protocols      map[string]ProtocolProperties `json:"protocols" validate:"omitempty,gt=0"`
-	Notify         *bool                         `json:"notify"`
 	Tags           map[string]any                `json:"tags"`
 	Properties     map[string]any                `json:"properties"`
 }
@@ -102,7 +101,6 @@ func FromDeviceModelToUpdateDTO(d models.Device) UpdateDevice {
 		AutoEvents:     FromAutoEventModelsToDTOs(d.AutoEvents),
 		Protocols:      FromProtocolModelsToDTOs(d.Protocols),
 		Labels:         d.Labels,
-		Notify:         &d.Notify,
 		Tags:           d.Tags,
 		Properties:     d.Properties,
 	}

--- a/dtos/requests/device.go
+++ b/dtos/requests/device.go
@@ -119,9 +119,6 @@ func ReplaceDeviceModelFieldsWithDTO(device *models.Device, patch dtos.UpdateDev
 	if patch.Protocols != nil {
 		device.Protocols = dtos.ToProtocolModels(patch.Protocols)
 	}
-	if patch.Notify != nil {
-		device.Notify = *patch.Notify
-	}
 	if patch.Tags != nil {
 		device.Tags = patch.Tags
 	}

--- a/dtos/requests/device_test.go
+++ b/dtos/requests/device_test.go
@@ -379,7 +379,6 @@ func TestUpdateDeviceRequest_UnmarshalJSON_NilField(t *testing.T) {
 	assert.Nil(t, req.Device.Location)
 	assert.Nil(t, req.Device.AutoEvents)
 	assert.Nil(t, req.Device.Protocols)
-	assert.Nil(t, req.Device.Notify)
 	assert.Nil(t, req.Device.Tags)
 	assert.Nil(t, req.Device.Properties)
 }

--- a/models/device.go
+++ b/models/device.go
@@ -21,7 +21,6 @@ type Device struct {
 	ServiceName    string
 	ProfileName    string
 	AutoEvents     []AutoEvent
-	Notify         bool
 	Tags           map[string]any
 	Properties     map[string]any
 }


### PR DESCRIPTION
BREAKING CHANGE: remove Notify out of Device DTO/Model

The current Device model/DTO contains a boolean filed `notify`.  When notify is set to true, the device service managing the device will receive a notification.  Since core-metadata will publish system event message when device is created or updated, this notify is no longer needed and should be removed.

fixes #805

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->