### PR TITLE
feat!: update data type in ResourceProperties

### DIFF
--- a/dtos/deviceprofile_test.go
+++ b/dtos/deviceprofile_test.go
@@ -23,6 +23,7 @@ var testAttributes = map[string]interface{}{
 }
 var testMappings = map[string]string{"0": "off", "1": "on"}
 var testTags = map[string]any{"TestTagsKey": "TestTagsValue"}
+var testOptional = map[string]any{"isVirtual": false}
 
 var testDeviceProfile = models.DeviceProfile{
 	Name:         TestDeviceProfileName,
@@ -37,7 +38,7 @@ var testDeviceProfile = models.DeviceProfile{
 		Properties: models.ResourceProperties{
 			ValueType: common.ValueTypeInt16,
 			ReadWrite: common.ReadWrite_RW,
-			Others:    testTags,
+			Optional:  testOptional,
 		},
 		Tags: testTags,
 	}},
@@ -68,7 +69,7 @@ func profileData() DeviceProfile {
 			Properties: ResourceProperties{
 				ValueType: common.ValueTypeInt16,
 				ReadWrite: common.ReadWrite_RW,
-				Others:    testTags,
+				Optional:  testOptional,
 			},
 			Tags: testTags,
 		}},

--- a/dtos/resourceproperties.go
+++ b/dtos/resourceproperties.go
@@ -18,14 +18,14 @@ type ResourceProperties struct {
 	Minimum      string         `json:"minimum,omitempty" yaml:"minimum"`
 	Maximum      string         `json:"maximum,omitempty" yaml:"maximum"`
 	DefaultValue string         `json:"defaultValue,omitempty" yaml:"defaultValue"`
-	Mask         string         `json:"mask,omitempty" yaml:"mask"`
-	Shift        string         `json:"shift,omitempty" yaml:"shift"`
-	Scale        string         `json:"scale,omitempty" yaml:"scale"`
-	Offset       string         `json:"offset,omitempty" yaml:"offset"`
-	Base         string         `json:"base,omitempty" yaml:"base"`
+	Mask         uint64         `json:"mask,omitempty" yaml:"mask"`
+	Shift        int64          `json:"shift,omitempty" yaml:"shift"`
+	Scale        float64        `json:"scale,omitempty" yaml:"scale"`
+	Offset       float64        `json:"offset,omitempty" yaml:"offset"`
+	Base         float64        `json:"base,omitempty" yaml:"base"`
 	Assertion    string         `json:"assertion,omitempty" yaml:"assertion"`
 	MediaType    string         `json:"mediaType,omitempty" yaml:"mediaType"`
-	Others       map[string]any `json:"others,omitempty" yaml:"others"`
+	Optional     map[string]any `json:"optional,omitempty" yaml:"optional"`
 }
 
 // ToResourcePropertiesModel transforms the ResourceProperties DTO to the ResourceProperties model
@@ -44,7 +44,7 @@ func ToResourcePropertiesModel(p ResourceProperties) models.ResourceProperties {
 		Base:         p.Base,
 		Assertion:    p.Assertion,
 		MediaType:    p.MediaType,
-		Others:       p.Others,
+		Optional:     p.Optional,
 	}
 }
 
@@ -64,6 +64,6 @@ func FromResourcePropertiesModelToDTO(p models.ResourceProperties) ResourcePrope
 		Base:         p.Base,
 		Assertion:    p.Assertion,
 		MediaType:    p.MediaType,
-		Others:       p.Others,
+		Optional:     p.Optional,
 	}
 }

--- a/models/resourceproperties.go
+++ b/models/resourceproperties.go
@@ -15,12 +15,12 @@ type ResourceProperties struct {
 	Minimum      string
 	Maximum      string
 	DefaultValue string
-	Mask         string
-	Shift        string
-	Scale        string
-	Offset       string
-	Base         string
+	Mask         uint64
+	Shift        int64
+	Scale        float64
+	Offset       float64
+	Base         float64
 	Assertion    string
 	MediaType    string
-	Others       map[string]any
+	Optional     map[string]any
 }


### PR DESCRIPTION
BREAKING CHANGE: update mask,shift,base,scale,offset to numeric data type

also rename 'Others' to 'Optional' for the consistency with message broker settings.

closes #770

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->