### PR TITLE
feat: Specify how to authenticate outbound IntervalActions

### DIFF
--- a/dtos/intervalaction.go
+++ b/dtos/intervalaction.go
@@ -20,6 +20,7 @@ type IntervalAction struct {
 	Content      string  `json:"content,omitempty"`
 	ContentType  string  `json:"contentType,omitempty"`
 	AdminState   string  `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
+	AuthMethod   string  `json:"authMethod" validate:"oneof='' 'NONE' 'JWT'"`
 }
 
 // NewIntervalAction creates intervalAction DTO with required fields
@@ -42,6 +43,7 @@ type UpdateIntervalAction struct {
 	ContentType  *string  `json:"contentType"`
 	Address      *Address `json:"address"`
 	AdminState   *string  `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
+	AuthMethod   *string  `json:"authMethod" validate:"omitempty,oneof='' 'NONE' 'JWT'"`
 }
 
 // NewUpdateIntervalAction creates updateIntervalAction DTO with required field
@@ -59,6 +61,7 @@ func ToIntervalActionModel(dto IntervalAction) models.IntervalAction {
 	model.ContentType = dto.ContentType
 	model.Address = ToAddressModel(dto.Address)
 	model.AdminState = models.AdminState(dto.AdminState)
+	model.AuthMethod = models.AuthMethod(dto.AuthMethod)
 	return model
 }
 
@@ -73,5 +76,6 @@ func FromIntervalActionModelToDTO(model models.IntervalAction) IntervalAction {
 	dto.ContentType = model.ContentType
 	dto.Address = FromAddressModelToDTO(model.Address)
 	dto.AdminState = string(model.AdminState)
+	dto.AuthMethod = string(model.AuthMethod)
 	return dto
 }

--- a/models/intervalaction.go
+++ b/models/intervalaction.go
@@ -11,6 +11,9 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 )
 
+// AuthMethod controls the authentication method to be applied to outbound http requests for interval actions
+type AuthMethod string
+
 // IntervalAction and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-scheduler/2.x#/IntervalAction
 // Model fields are same as the DTOs documented by this swagger. Exceptions, if any, are noted below.
@@ -23,6 +26,7 @@ type IntervalAction struct {
 	ContentType  string
 	Address      Address
 	AdminState   AdminState
+	AuthMethod   AuthMethod
 }
 
 func (intervalAction *IntervalAction) UnmarshalJSON(b []byte) error {
@@ -35,6 +39,7 @@ func (intervalAction *IntervalAction) UnmarshalJSON(b []byte) error {
 		ContentType  string
 		Address      interface{}
 		AdminState   AdminState
+		AuthMethod   AuthMethod
 	}
 	if err := json.Unmarshal(b, &alias); err != nil {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal intervalAction.", err)
@@ -53,6 +58,7 @@ func (intervalAction *IntervalAction) UnmarshalJSON(b []byte) error {
 		ContentType:  alias.ContentType,
 		Address:      address,
 		AdminState:   alias.AdminState,
+		AuthMethod:   alias.AuthMethod,
 	}
 	return nil
 }


### PR DESCRIPTION
Outbound HTTP requests must be authenticated if they call EdgeX services (for example, event aging).  This commit extends the model to allow users to specify the AuthMethod of outbound HTTP requests.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->