### PR TITLE
feat!: update ProtocolProperties to have typed values

### DIFF
--- a/dtos/protocolproperties.go
+++ b/dtos/protocolproperties.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +8,7 @@ package dtos
 import "github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 
 // ProtocolProperties contains the device connection information in key/value pair
-type ProtocolProperties map[string]string
+type ProtocolProperties map[string]any
 
 // ToProtocolPropertiesModel transforms the ProtocolProperties DTO to the ProtocolProperties model
 func ToProtocolPropertiesModel(p ProtocolProperties) models.ProtocolProperties {

--- a/models/device.go
+++ b/models/device.go
@@ -26,7 +26,7 @@ type Device struct {
 }
 
 // ProtocolProperties contains the device connection information in key/value pair
-type ProtocolProperties map[string]string
+type ProtocolProperties map[string]any
 
 // AdminState controls the range of values which constitute valid administrative states for a device
 type AdminState string


### PR DESCRIPTION
BREAKING CHANGE: update ProtocolProperties type from 'map[string]string' to 'map[string]any'

closes #592

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->