### PR TITLE
feat!: add 'discoveredDevice' for discovered device fields

### DIFF
--- a/dtos/discovereddevice.go
+++ b/dtos/discovereddevice.go
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dtos
+
+import "github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+
+type DiscoveredDevice struct {
+	ProfileName string         `json:"profileName" yaml:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ServiceName string         `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	AdminState  string         `json:"adminState" yaml:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
+	AutoEvents  []AutoEvent    `json:"autoEvents,omitempty" yaml:"autoEvents,omitempty" validate:"dive"`
+	Properties  map[string]any `json:"properties,omitempty" yaml:"properties,omitempty"`
+}
+
+type UpdateDiscoveredDevice struct {
+	ProfileName *string        `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ServiceName *string        `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	AdminState  *string        `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
+	AutoEvents  []AutoEvent    `json:"autoEvents" validate:"dive"`
+	Properties  map[string]any `json:"properties"`
+}
+
+func ToDiscoveredDeviceModel(dto DiscoveredDevice) models.DiscoveredDevice {
+	return models.DiscoveredDevice{
+		ProfileName: dto.ProfileName,
+		ServiceName: dto.ServiceName,
+		AdminState:  models.AdminState(dto.AdminState),
+		AutoEvents:  ToAutoEventModels(dto.AutoEvents),
+		Properties:  dto.Properties,
+	}
+}
+
+func FromDiscoveredDeviceModelToDTO(d models.DiscoveredDevice) DiscoveredDevice {
+	return DiscoveredDevice{
+		ProfileName: d.ProfileName,
+		ServiceName: d.ServiceName,
+		AdminState:  string(d.AdminState),
+		AutoEvents:  FromAutoEventModelsToDTOs(d.AutoEvents),
+		Properties:  d.Properties,
+	}
+}
+
+func FromDiscoveredDeviceModelToUpdateDTO(d models.DiscoveredDevice) UpdateDiscoveredDevice {
+	adminState := string(d.AdminState)
+	return UpdateDiscoveredDevice{
+		ProfileName: &d.ProfileName,
+		ServiceName: &d.ServiceName,
+		AdminState:  &adminState,
+		AutoEvents:  FromAutoEventModelsToDTOs(d.AutoEvents),
+		Properties:  d.Properties,
+	}
+}

--- a/dtos/provisionwatcher.go
+++ b/dtos/provisionwatcher.go
@@ -18,26 +18,20 @@ type ProvisionWatcher struct {
 	Labels              []string            `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Identifiers         map[string]string   `json:"identifiers" yaml:"identifiers" validate:"gt=0,dive,keys,required,endkeys,required"`
 	BlockingIdentifiers map[string][]string `json:"blockingIdentifiers,omitempty" yaml:"blockingIdentifiers,omitempty"`
-	ProfileName         string              `json:"profileName" yaml:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ServiceName         string              `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState          string              `json:"adminState" yaml:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
-	AutoEvents          []AutoEvent         `json:"autoEvents,omitempty" yaml:"autoEvents,omitempty" validate:"dive"`
-	Properties          map[string]any      `json:"properties,omitempty" yaml:"properties,omitempty"`
+	DiscoveredDevice    DiscoveredDevice    `json:"discoveredDevice" yaml:"discoveredDevice" validate:"dive"`
 }
 
 // UpdateProvisionWatcher and its properties are defined in the APIv2 specification:
 // https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.1.0#/UpdateProvisionWatcher
 type UpdateProvisionWatcher struct {
-	Id                  *string             `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name                *string             `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	Labels              []string            `json:"labels"`
-	Identifiers         map[string]string   `json:"identifiers" validate:"omitempty,gt=0,dive,keys,required,endkeys,required"`
-	BlockingIdentifiers map[string][]string `json:"blockingIdentifiers"`
-	ProfileName         *string             `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ServiceName         *string             `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	AdminState          *string             `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
-	AutoEvents          []AutoEvent         `json:"autoEvents" validate:"dive"`
-	Properties          map[string]any      `json:"properties"`
+	Id                  *string                `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
+	Name                *string                `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Labels              []string               `json:"labels"`
+	Identifiers         map[string]string      `json:"identifiers" validate:"omitempty,gt=0,dive,keys,required,endkeys,required"`
+	BlockingIdentifiers map[string][]string    `json:"blockingIdentifiers"`
+	AdminState          *string                `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
+	DiscoveredDevice    UpdateDiscoveredDevice `json:"discoveredDevice"`
 }
 
 // ToProvisionWatcherModel transforms the ProvisionWatcher DTO to the ProvisionWatcher model
@@ -49,11 +43,8 @@ func ToProvisionWatcherModel(dto ProvisionWatcher) models.ProvisionWatcher {
 		Labels:              dto.Labels,
 		Identifiers:         dto.Identifiers,
 		BlockingIdentifiers: dto.BlockingIdentifiers,
-		ProfileName:         dto.ProfileName,
-		ServiceName:         dto.ServiceName,
 		AdminState:          models.AdminState(dto.AdminState),
-		AutoEvents:          ToAutoEventModels(dto.AutoEvents),
-		Properties:          dto.Properties,
+		DiscoveredDevice:    ToDiscoveredDeviceModel(dto.DiscoveredDevice),
 	}
 }
 
@@ -66,11 +57,8 @@ func FromProvisionWatcherModelToDTO(pw models.ProvisionWatcher) ProvisionWatcher
 		Labels:              pw.Labels,
 		Identifiers:         pw.Identifiers,
 		BlockingIdentifiers: pw.BlockingIdentifiers,
-		ProfileName:         pw.ProfileName,
-		ServiceName:         pw.ServiceName,
 		AdminState:          string(pw.AdminState),
-		AutoEvents:          FromAutoEventModelsToDTOs(pw.AutoEvents),
-		Properties:          pw.Properties,
+		DiscoveredDevice:    FromDiscoveredDeviceModelToDTO(pw.DiscoveredDevice),
 	}
 }
 
@@ -80,14 +68,11 @@ func FromProvisionWatcherModelToUpdateDTO(pw models.ProvisionWatcher) UpdateProv
 	dto := UpdateProvisionWatcher{
 		Id:                  &pw.Id,
 		Name:                &pw.Name,
-		ProfileName:         &pw.ProfileName,
-		ServiceName:         &pw.ServiceName,
-		AdminState:          &adminState,
-		AutoEvents:          FromAutoEventModelsToDTOs(pw.AutoEvents),
 		Labels:              pw.Labels,
 		Identifiers:         pw.Identifiers,
 		BlockingIdentifiers: pw.BlockingIdentifiers,
-		Properties:          pw.Properties,
+		AdminState:          &adminState,
+		DiscoveredDevice:    FromDiscoveredDeviceModelToUpdateDTO(pw.DiscoveredDevice),
 	}
 	return dto
 }

--- a/dtos/provisionwatcher_test.go
+++ b/dtos/provisionwatcher_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,8 +21,10 @@ func TestFromProvisionWatcherModelToUpdateDTO(t *testing.T) {
 	assert.Equal(t, model.Labels, dto.Labels)
 	assert.Nil(t, model.Identifiers, dto.Identifiers)
 	assert.Nil(t, model.BlockingIdentifiers, dto.BlockingIdentifiers)
-	assert.Equal(t, model.ProfileName, *dto.ProfileName)
-	assert.Equal(t, model.ServiceName, *dto.ServiceName)
 	assert.EqualValues(t, model.AdminState, *dto.AdminState)
-	assert.Equal(t, model.Properties, dto.Properties)
+	assert.Equal(t, model.DiscoveredDevice.ProfileName, *dto.DiscoveredDevice.ProfileName)
+	assert.Equal(t, model.DiscoveredDevice.ServiceName, *dto.DiscoveredDevice.ServiceName)
+	assert.EqualValues(t, model.DiscoveredDevice.AdminState, *dto.DiscoveredDevice.AdminState)
+	assert.Zero(t, model.DiscoveredDevice.AutoEvents)
+	assert.Equal(t, model.DiscoveredDevice.Properties, dto.DiscoveredDevice.Properties)
 }

--- a/dtos/requests/provisionwatcher.go
+++ b/dtos/requests/provisionwatcher.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,7 @@ type AddProvisionWatcherRequest struct {
 }
 
 // Validate satisfies the Validator interface
-func (pw AddProvisionWatcherRequest) Validate() error {
+func (pw *AddProvisionWatcherRequest) Validate() error {
 	err := common.Validate(pw)
 	return err
 }
@@ -66,7 +66,7 @@ type UpdateProvisionWatcherRequest struct {
 }
 
 // Validate satisfies the Validator interface
-func (pw UpdateProvisionWatcherRequest) Validate() error {
+func (pw *UpdateProvisionWatcherRequest) Validate() error {
 	err := common.Validate(pw)
 	return err
 }
@@ -101,20 +101,23 @@ func ReplaceProvisionWatcherModelFieldsWithDTO(pw *models.ProvisionWatcher, patc
 	if patch.BlockingIdentifiers != nil {
 		pw.BlockingIdentifiers = patch.BlockingIdentifiers
 	}
-	if patch.ProfileName != nil {
-		pw.ProfileName = *patch.ProfileName
-	}
-	if patch.ServiceName != nil {
-		pw.ServiceName = *patch.ServiceName
-	}
 	if patch.AdminState != nil {
 		pw.AdminState = models.AdminState(*patch.AdminState)
 	}
-	if patch.AutoEvents != nil {
-		pw.AutoEvents = dtos.ToAutoEventModels(patch.AutoEvents)
+	if patch.DiscoveredDevice.ProfileName != nil {
+		pw.DiscoveredDevice.ProfileName = *patch.DiscoveredDevice.ProfileName
 	}
-	if patch.Properties != nil {
-		pw.Properties = patch.Properties
+	if patch.DiscoveredDevice.ServiceName != nil {
+		pw.DiscoveredDevice.ServiceName = *patch.DiscoveredDevice.ServiceName
+	}
+	if patch.DiscoveredDevice.AdminState != nil {
+		pw.DiscoveredDevice.AdminState = models.AdminState(*patch.DiscoveredDevice.AdminState)
+	}
+	if patch.DiscoveredDevice.AutoEvents != nil {
+		pw.DiscoveredDevice.AutoEvents = dtos.ToAutoEventModels(patch.DiscoveredDevice.AutoEvents)
+	}
+	if patch.DiscoveredDevice.Properties != nil {
+		pw.DiscoveredDevice.Properties = patch.DiscoveredDevice.Properties
 	}
 }
 

--- a/models/discovereddevice.go
+++ b/models/discovereddevice.go
@@ -1,0 +1,14 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package models
+
+type DiscoveredDevice struct {
+	ProfileName string
+	ServiceName string
+	AdminState  AdminState
+	AutoEvents  []AutoEvent
+	Properties  map[string]any
+}

--- a/models/provisionwatcher.go
+++ b/models/provisionwatcher.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,9 +15,6 @@ type ProvisionWatcher struct {
 	Labels              []string
 	Identifiers         map[string]string
 	BlockingIdentifiers map[string][]string
-	ProfileName         string
-	ServiceName         string
 	AdminState          AdminState
-	AutoEvents          []AutoEvent
-	Properties          map[string]any
+	DiscoveredDevice    DiscoveredDevice
 }


### PR DESCRIPTION
BREAKING CHANGE: add 'discoveredDevice' field which includes serviceName, profileName,adminState,autoEvents and properties for discovered device

closes #813

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->