### PR TITLE
feat!: Using url.PathEscape for http client request path

### DIFF
--- a/clients/http/command.go
+++ b/clients/http/command.go
@@ -76,7 +76,7 @@ func (client *CommandClient) IssueGetCommandByNameWithQueryParams(ctx context.Co
 		requestParams.Set(k, v)
 	}
 
-	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, url.QueryEscape(deviceName), url.QueryEscape(commandName))
+	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, deviceName, commandName)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, requestPath, requestParams, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/command_test.go
+++ b/clients/http/command_test.go
@@ -8,6 +8,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http/utils"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -44,7 +45,7 @@ func TestQueryDeviceCoreCommandsByDeviceName(t *testing.T) {
 func TestIssueGetCommandByName(t *testing.T) {
 	deviceName := "Simple-Device01"
 	cmdName := "SwitchButton"
-	path := path.Join(common.ApiDeviceRoute, common.Name, deviceName, cmdName)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, deviceName, cmdName)
 	ts := newTestServer(http.MethodGet, path, &responses.EventResponse{})
 	defer ts.Close()
 	client := NewCommandClient(ts.URL, NewNullAuthenticationInjector())
@@ -87,7 +88,7 @@ func TestIssueIssueSetCommandByName(t *testing.T) {
 	settings := map[string]string{
 		"SwitchButton": "true",
 	}
-	path := path.Join(common.ApiDeviceRoute, common.Name, deviceName, cmdName)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, deviceName, cmdName)
 	ts := newTestServer(http.MethodPut, path, dtoCommon.BaseResponse{})
 	defer ts.Close()
 	client := NewCommandClient(ts.URL, NewNullAuthenticationInjector())
@@ -105,7 +106,7 @@ func TestIssueIssueSetCommandByNameWithObject(t *testing.T) {
 			"value": "on",
 		},
 	}
-	path := path.Join(common.ApiDeviceRoute, common.Name, deviceName, cmdName)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, deviceName, cmdName)
 	ts := newTestServer(http.MethodPut, path, dtoCommon.BaseResponse{})
 	defer ts.Close()
 	client := NewCommandClient(ts.URL, NewNullAuthenticationInjector())

--- a/clients/http/deviceprofile.go
+++ b/clients/http/deviceprofile.go
@@ -223,7 +223,7 @@ func (client *DeviceProfileClient) UpdateDeviceProfileResource(ctx context.Conte
 // DeleteDeviceResourceByName deletes device resource by name
 func (client *DeviceProfileClient) DeleteDeviceResourceByName(ctx context.Context, profileName string, resourceName string) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceProfileRoute, common.Name, url.QueryEscape(profileName), common.Resource, url.QueryEscape(resourceName))
+	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceProfileRoute, common.Name, profileName, common.Resource, resourceName)
 	err := utils.DeleteRequest(ctx, &response, client.baseUrl, requestPath, client.authInjector)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
@@ -254,7 +254,7 @@ func (client *DeviceProfileClient) UpdateDeviceProfileDeviceCommand(ctx context.
 // DeleteDeviceCommandByName deletes device command by name
 func (client *DeviceProfileClient) DeleteDeviceCommandByName(ctx context.Context, profileName string, commandName string) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceProfileRoute, common.Name, url.QueryEscape(profileName), common.DeviceCommand, url.QueryEscape(commandName))
+	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceProfileRoute, common.Name, profileName, common.DeviceCommand, commandName)
 	err := utils.DeleteRequest(ctx, &response, client.baseUrl, requestPath, client.authInjector)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/utils/common.go
+++ b/clients/http/utils/common.go
@@ -227,7 +227,7 @@ func EscapeAndJoinPath(apiRoutePath string, pathVariables ...string) string {
 	elements := make([]string, len(pathVariables)+1)
 	elements[0] = apiRoutePath // we don't need to escape the route path like /device, /reading, ...,etc.
 	for i, e := range pathVariables {
-		elements[i+1] = url.QueryEscape(e)
+		elements[i+1] = common.URLEncode(e)
 	}
 	return path.Join(elements...)
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -43,7 +43,7 @@ func BuildTopic(parts ...string) string {
 
 // URLEncode encodes the input string with additional common character support
 func URLEncode(s string) string {
-	res := url.QueryEscape(s)
+	res := url.PathEscape(s)
 	res = strings.Replace(res, "-", "%2D", -1)
 	res = strings.Replace(res, ".", "%2E", -1)
 	res = strings.Replace(res, "_", "%5F", -1)

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -19,15 +19,15 @@ func TestURLEncode(t *testing.T) {
 		output           string
 		EqualsURLPackage bool
 	}{
-		{"valid", "^[this]+{is}?test:string*#", "%5E%5Bthis%5D%2B%7Bis%7D%3Ftest%3Astring%2A%23", true},
+		{"valid", "^[this]+{is}?test:string*#", "%5E%5Bthis%5D+%7Bis%7D%3Ftest:string%2A%23", true},
 		{"valid - special character", "this-is_test.string~", "this%2Dis%5Ftest%2Estring%7E", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := URLEncode(tt.input)
-			require.Equal(t, res, tt.output)
+			require.Equal(t, tt.output, res)
 			if tt.EqualsURLPackage {
-				require.Equal(t, url.QueryEscape(tt.input), res)
+				require.Equal(t, url.PathEscape(tt.input), res)
 			}
 		})
 	}


### PR DESCRIPTION
BREAKING CHANGE: To consist with the change for MQTT topic path encoding, use PathEscape to encode the API path because the url.QueryEscape encode the empty space to plus sign, and plus sign is invalid for publishing the MQTT message.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact 
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core services and device service to check whether the event can publish to the message bus.

This modification is based on the issue https://github.com/edgexfoundry/device-sdk-go/issues/1433

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->