### PR TITLE
feat: Allow Device Profile to be empty string in ProvisionWatcher

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -23,12 +23,13 @@ import (
 var val *validator.Validate
 
 const (
-	dtoDurationTag              = "edgex-dto-duration"
-	dtoUuidTag                  = "edgex-dto-uuid"
-	dtoNoneEmptyStringTag       = "edgex-dto-none-empty-string"
-	dtoValueType                = "edgex-dto-value-type"
-	dtoRFC3986UnreservedCharTag = "edgex-dto-rfc3986-unreserved-chars"
-	dtoInterDatetimeTag         = "edgex-dto-interval-datetime"
+	dtoDurationTag                     = "edgex-dto-duration"
+	dtoUuidTag                         = "edgex-dto-uuid"
+	dtoNoneEmptyStringTag              = "edgex-dto-none-empty-string"
+	dtoValueType                       = "edgex-dto-value-type"
+	dtoRFC3986UnreservedCharTag        = "edgex-dto-rfc3986-unreserved-chars"
+	emptyOrDtoRFC3986UnreservedCharTag = "len=0|" + dtoRFC3986UnreservedCharTag
+	dtoInterDatetimeTag                = "edgex-dto-interval-datetime"
 )
 
 const (
@@ -94,7 +95,7 @@ func getErrorMessage(e validator.FieldError) string {
 		msg = fmt.Sprintf("%s field needs a uuid", fieldName)
 	case dtoNoneEmptyStringTag:
 		msg = fmt.Sprintf("%s field should not be empty string", fieldName)
-	case dtoRFC3986UnreservedCharTag:
+	case dtoRFC3986UnreservedCharTag, emptyOrDtoRFC3986UnreservedCharTag:
 		msg = fmt.Sprintf("%s field only allows unreserved characters which are ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_~:;=", fieldName)
 	default:
 		msg = fmt.Sprintf("%s field validation failed on the %s tag", fieldName, tag)

--- a/dtos/discovereddevice.go
+++ b/dtos/discovereddevice.go
@@ -8,7 +8,7 @@ package dtos
 import "github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 
 type DiscoveredDevice struct {
-	ProfileName string         `json:"profileName" yaml:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName string         `json:"profileName" yaml:"profileName" validate:"len=0|edgex-dto-rfc3986-unreserved-chars"`
 	ServiceName string         `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState  string         `json:"adminState" yaml:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents  []AutoEvent    `json:"autoEvents,omitempty" yaml:"autoEvents,omitempty" validate:"dive"`
@@ -16,7 +16,7 @@ type DiscoveredDevice struct {
 }
 
 type UpdateDiscoveredDevice struct {
-	ProfileName *string        `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName *string        `json:"profileName" validate:"omitempty,len=0|edgex-dto-rfc3986-unreserved-chars"`
 	ServiceName *string        `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	AdminState  *string        `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents  []AutoEvent    `json:"autoEvents" validate:"dive"`

--- a/dtos/requests/provisionwatcher_test.go
+++ b/dtos/requests/provisionwatcher_test.go
@@ -76,7 +76,7 @@ func mockUpdateProvisionWatcher() dtos.UpdateProvisionWatcher {
 }
 
 func TestAddProvisionWatcherRequest_Validate(t *testing.T) {
-	emptyString := " "
+	whiteSpace := " "
 	emptyMap := make(map[string]string)
 	valid := testAddProvisionWatcher
 	noReqId := testAddProvisionWatcher
@@ -84,7 +84,7 @@ func TestAddProvisionWatcherRequest_Validate(t *testing.T) {
 	invalidReqId := testAddProvisionWatcher
 	invalidReqId.RequestId = "abc"
 	noProvisionWatcherName := testAddProvisionWatcher
-	noProvisionWatcherName.ProvisionWatcher.Name = emptyString
+	noProvisionWatcherName.ProvisionWatcher.Name = whiteSpace
 	provisionWatcherNameWithReservedChar := testAddProvisionWatcher
 	provisionWatcherNameWithReservedChar.ProvisionWatcher.Name = namesWithReservedChar[0]
 	noIdentifiers := testAddProvisionWatcher
@@ -98,9 +98,11 @@ func TestAddProvisionWatcherRequest_Validate(t *testing.T) {
 		"key": "",
 	}
 	noServiceName := testAddProvisionWatcher
-	noServiceName.ProvisionWatcher.DiscoveredDevice.ServiceName = emptyString
+	noServiceName.ProvisionWatcher.DiscoveredDevice.ServiceName = whiteSpace
 	noProfileName := testAddProvisionWatcher
-	noProfileName.ProvisionWatcher.DiscoveredDevice.ProfileName = emptyString
+	noProfileName.ProvisionWatcher.DiscoveredDevice.ProfileName = whiteSpace
+	emptyStringProfileName := testAddProvisionWatcher
+	emptyStringProfileName.ProvisionWatcher.DiscoveredDevice.ProfileName = ""
 	invalidFrequency := testAddProvisionWatcher
 	invalidFrequency.ProvisionWatcher.DiscoveredDevice.AutoEvents = []dtos.AutoEvent{
 		{SourceName: "TestDevice", Interval: "-1", OnChange: true},
@@ -129,6 +131,7 @@ func TestAddProvisionWatcherRequest_Validate(t *testing.T) {
 		{"invalid AddProvisionWatcherRequest, missing Identifiers value", missingIdentifiersValue, true},
 		{"invalid AddProvisionWatcherRequest, no ServiceName", noServiceName, true},
 		{"invalid AddProvisionWatcherRequest, no ProfileName", noProfileName, true},
+		{"invalid AddProvisionWatcherRequest, empty string ProfileName", emptyStringProfileName, false},
 		{"invalid AddProvisionWatcherRequest, invalid autoEvent frequency", invalidFrequency, true},
 		{"invalid AddProvisionWatcherRequest, no AutoEvent frequency", noAutoEventFrequency, true},
 		{"invalid AddProvisionWatcherRequest, no AutoEvent resource", noAutoEventResource, true},
@@ -201,7 +204,7 @@ func TestAddProvisionWatcherReqToProvisionWatcherModels(t *testing.T) {
 }
 
 func TestUpdateProvisionWatcherRequest_Validate(t *testing.T) {
-	emptyString := " "
+	whiteSpace := " "
 	emptyMap := make(map[string]string)
 	invalidUUID := "invalidUUID"
 
@@ -220,9 +223,9 @@ func TestUpdateProvisionWatcherRequest_Validate(t *testing.T) {
 	validOnlyName := valid
 	validOnlyName.ProvisionWatcher.Id = nil
 	nameAndEmptyId := valid
-	nameAndEmptyId.ProvisionWatcher.Id = &emptyString
+	nameAndEmptyId.ProvisionWatcher.Id = &whiteSpace
 	invalidEmptyName := valid
-	invalidEmptyName.ProvisionWatcher.Name = &emptyString
+	invalidEmptyName.ProvisionWatcher.Name = &whiteSpace
 	invalidReservedName := valid
 	invalidReservedName.ProvisionWatcher.Name = &namesWithReservedChar[0]
 	// no id and name
@@ -238,12 +241,15 @@ func TestUpdateProvisionWatcherRequest_Validate(t *testing.T) {
 	validNilServiceName := valid
 	validNilServiceName.ProvisionWatcher.DiscoveredDevice.ServiceName = nil
 	invalidEmptyServiceName := valid
-	invalidEmptyServiceName.ProvisionWatcher.DiscoveredDevice.ServiceName = &emptyString
+	invalidEmptyServiceName.ProvisionWatcher.DiscoveredDevice.ServiceName = &whiteSpace
 	// ProfileName
 	validNilProfileName := valid
 	validNilProfileName.ProvisionWatcher.DiscoveredDevice.ProfileName = nil
 	invalidEmptyProfileName := valid
-	invalidEmptyProfileName.ProvisionWatcher.DiscoveredDevice.ProfileName = &emptyString
+	invalidEmptyProfileName.ProvisionWatcher.DiscoveredDevice.ProfileName = &whiteSpace
+	emptyStringProfileName := valid
+	emptyString := ""
+	emptyStringProfileName.ProvisionWatcher.DiscoveredDevice.ProfileName = &emptyString
 
 	invalidState := "invalid state"
 	invalidAdminState := valid
@@ -277,6 +283,7 @@ func TestUpdateProvisionWatcherRequest_Validate(t *testing.T) {
 
 		{"valid, nil profile name", validNilProfileName, false},
 		{"invalid, empty profile name", invalidEmptyProfileName, true},
+		{"valid, empty string profile name", emptyStringProfileName, false},
 
 		{"invalid, invalid admin state", invalidAdminState, true},
 		{"invalid, invalid autoEvent frequency", invalidFrequency, true},


### PR DESCRIPTION
Update the provisionWatcher DTO to allow empty string profile

Close #830

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) 
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) will update swagger file
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run unit test

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->