### PR TITLE
feat: Use URL escape for DTO name field

### DIFF
--- a/clients/http/command.go
+++ b/clients/http/command.go
@@ -9,7 +9,6 @@ package http
 import (
 	"context"
 	"net/url"
-	"path"
 	"strconv"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http/utils"
@@ -49,7 +48,7 @@ func (client *CommandClient) AllDeviceCoreCommands(ctx context.Context, offset i
 // DeviceCoreCommandsByDeviceName returns all commands associated with the specified device name.
 func (client *CommandClient) DeviceCoreCommandsByDeviceName(ctx context.Context, name string) (
 	res responses.DeviceCoreCommandResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/command_test.go
+++ b/clients/http/command_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http/utils"
 	"net/http"
 	"net/http/httptest"
-	"path"
 	"strconv"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestQueryDeviceCoreCommands(t *testing.T) {
 
 func TestQueryDeviceCoreCommandsByDeviceName(t *testing.T) {
 	deviceName := "Simple-Device01"
-	path := path.Join(common.ApiDeviceRoute, common.Name, deviceName)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, deviceName)
 	ts := newTestServer(http.MethodGet, path, responses.DeviceCoreCommandResponse{})
 	defer ts.Close()
 	client := NewCommandClient(ts.URL, NewNullAuthenticationInjector())

--- a/clients/http/device.go
+++ b/clients/http/device.go
@@ -9,7 +9,6 @@ package http
 import (
 	"context"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 
@@ -66,7 +65,7 @@ func (dc DeviceClient) AllDevices(ctx context.Context, labels []string, offset i
 }
 
 func (dc DeviceClient) DeviceNameExists(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Check, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Check, common.Name, name)
 	err = utils.GetRequest(ctx, &res, dc.baseUrl, path, nil, dc.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -75,7 +74,7 @@ func (dc DeviceClient) DeviceNameExists(ctx context.Context, name string) (res d
 }
 
 func (dc DeviceClient) DeviceByName(ctx context.Context, name string) (res responses.DeviceResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, dc.baseUrl, path, nil, dc.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -84,7 +83,7 @@ func (dc DeviceClient) DeviceByName(ctx context.Context, name string) (res respo
 }
 
 func (dc DeviceClient) DeleteDeviceByName(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, dc.baseUrl, path, dc.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -93,7 +92,7 @@ func (dc DeviceClient) DeleteDeviceByName(ctx context.Context, name string) (res
 }
 
 func (dc DeviceClient) DevicesByProfileName(ctx context.Context, name string, offset int, limit int) (res responses.MultiDevicesResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceRoute, common.Profile, common.Name, name)
+	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Profile, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -105,7 +104,7 @@ func (dc DeviceClient) DevicesByProfileName(ctx context.Context, name string, of
 }
 
 func (dc DeviceClient) DevicesByServiceName(ctx context.Context, name string, offset int, limit int) (res responses.MultiDevicesResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceRoute, common.Service, common.Name, name)
+	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceRoute, common.Service, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))

--- a/clients/http/deviceprofile.go
+++ b/clients/http/deviceprofile.go
@@ -83,7 +83,7 @@ func (client *DeviceProfileClient) UpdateByYaml(ctx context.Context, yamlFilePat
 // DeleteByName deletes the device profile by name
 func (client *DeviceProfileClient) DeleteByName(ctx context.Context, name string) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Name, name)
+	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceProfileRoute, common.Name, name)
 	err := utils.DeleteRequest(ctx, &response, client.baseUrl, requestPath, client.authInjector)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)
@@ -93,7 +93,7 @@ func (client *DeviceProfileClient) DeleteByName(ctx context.Context, name string
 
 // DeviceProfileByName queries the device profile by name
 func (client *DeviceProfileClient) DeviceProfileByName(ctx context.Context, name string) (res responses.DeviceProfileResponse, edgexError errors.EdgeX) {
-	requestPath := path.Join(common.ApiDeviceProfileRoute, common.Name, name)
+	requestPath := utils.EscapeAndJoinPath(common.ApiDeviceProfileRoute, common.Name, name)
 	err := utils.GetRequest(ctx, &res, client.baseUrl, requestPath, nil, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/deviceservice.go
+++ b/clients/http/deviceservice.go
@@ -9,7 +9,6 @@ package http
 import (
 	"context"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 
@@ -70,7 +69,7 @@ func (dsc DeviceServiceClient) AllDeviceServices(ctx context.Context, labels []s
 
 func (dsc DeviceServiceClient) DeviceServiceByName(ctx context.Context, name string) (
 	res responses.DeviceServiceResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceServiceRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceServiceRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, dsc.baseUrl, path, nil, dsc.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -80,7 +79,7 @@ func (dsc DeviceServiceClient) DeviceServiceByName(ctx context.Context, name str
 
 func (dsc DeviceServiceClient) DeleteByName(ctx context.Context, name string) (
 	res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiDeviceServiceRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiDeviceServiceRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, dsc.baseUrl, path, dsc.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/deviceservicecallback.go
+++ b/clients/http/deviceservicecallback.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2022 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 // Copyright (C) 2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -97,7 +97,7 @@ func (client *deviceServiceCallbackClient) UpdateProvisionWatcherCallback(ctx co
 
 func (client *deviceServiceCallbackClient) DeleteProvisionWatcherCallback(ctx context.Context, name string) (dtoCommon.BaseResponse, errors.EdgeX) {
 	var response dtoCommon.BaseResponse
-	requestPath := path.Join(common.ApiWatcherCallbackRoute, common.Name, name)
+	requestPath := utils.EscapeAndJoinPath(common.ApiWatcherCallbackRoute, common.Name, name)
 	err := utils.DeleteRequest(ctx, &response, client.baseUrl, requestPath, client.authInjector)
 	if err != nil {
 		return response, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/interval.go
+++ b/clients/http/interval.go
@@ -9,7 +9,6 @@ package http
 import (
 	"context"
 	"net/url"
-	"path"
 	"strconv"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http/utils"
@@ -70,7 +69,7 @@ func (client IntervalClient) AllIntervals(ctx context.Context, offset int, limit
 // IntervalByName query the interval by name
 func (client IntervalClient) IntervalByName(ctx context.Context, name string) (
 	res responses.IntervalResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiIntervalRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -81,7 +80,7 @@ func (client IntervalClient) IntervalByName(ctx context.Context, name string) (
 // DeleteIntervalByName delete the interval by name
 func (client IntervalClient) DeleteIntervalByName(ctx context.Context, name string) (
 	res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiIntervalRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/intervalaction.go
+++ b/clients/http/intervalaction.go
@@ -9,7 +9,6 @@ package http
 import (
 	"context"
 	"net/url"
-	"path"
 	"strconv"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/http/utils"
@@ -70,7 +69,7 @@ func (client IntervalActionClient) AllIntervalActions(ctx context.Context, offse
 // IntervalActionByName query the intervalAction by name
 func (client IntervalActionClient) IntervalActionByName(ctx context.Context, name string) (
 	res responses.IntervalActionResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalActionRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiIntervalActionRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -81,7 +80,7 @@ func (client IntervalActionClient) IntervalActionByName(ctx context.Context, nam
 // DeleteIntervalActionByName delete the intervalAction by name
 func (client IntervalActionClient) DeleteIntervalActionByName(ctx context.Context, name string) (
 	res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiIntervalActionRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiIntervalActionRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/clients/http/provisionwatcher.go
+++ b/clients/http/provisionwatcher.go
@@ -9,7 +9,6 @@ package http
 import (
 	"context"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 
@@ -69,7 +68,7 @@ func (pwc ProvisionWatcherClient) AllProvisionWatchers(ctx context.Context, labe
 }
 
 func (pwc ProvisionWatcherClient) ProvisionWatcherByName(ctx context.Context, name string) (res responses.ProvisionWatcherResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiProvisionWatcherRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiProvisionWatcherRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, pwc.baseUrl, path, nil, pwc.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -79,7 +78,7 @@ func (pwc ProvisionWatcherClient) ProvisionWatcherByName(ctx context.Context, na
 }
 
 func (pwc ProvisionWatcherClient) DeleteProvisionWatcherByName(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiProvisionWatcherRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiProvisionWatcherRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, pwc.baseUrl, path, pwc.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -89,7 +88,7 @@ func (pwc ProvisionWatcherClient) DeleteProvisionWatcherByName(ctx context.Conte
 }
 
 func (pwc ProvisionWatcherClient) ProvisionWatchersByProfileName(ctx context.Context, name string, offset int, limit int) (res responses.MultiProvisionWatchersResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiProvisionWatcherRoute, common.Profile, common.Name, name)
+	requestPath := utils.EscapeAndJoinPath(common.ApiProvisionWatcherRoute, common.Profile, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))
@@ -102,7 +101,7 @@ func (pwc ProvisionWatcherClient) ProvisionWatchersByProfileName(ctx context.Con
 }
 
 func (pwc ProvisionWatcherClient) ProvisionWatchersByServiceName(ctx context.Context, name string, offset int, limit int) (res responses.MultiProvisionWatchersResponse, err errors.EdgeX) {
-	requestPath := path.Join(common.ApiProvisionWatcherRoute, common.Service, common.Name, name)
+	requestPath := utils.EscapeAndJoinPath(common.ApiProvisionWatcherRoute, common.Service, common.Name, name)
 	requestParams := url.Values{}
 	requestParams.Set(common.Offset, strconv.Itoa(offset))
 	requestParams.Set(common.Limit, strconv.Itoa(limit))

--- a/clients/http/subscription.go
+++ b/clients/http/subscription.go
@@ -105,7 +105,7 @@ func (client *SubscriptionClient) SubscriptionsByReceiver(ctx context.Context, r
 
 // SubscriptionByName query subscription by name.
 func (client *SubscriptionClient) SubscriptionByName(ctx context.Context, name string) (res responses.SubscriptionResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiSubscriptionRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiSubscriptionRoute, common.Name, name)
 	err = utils.GetRequest(ctx, &res, client.baseUrl, path, nil, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
@@ -115,7 +115,7 @@ func (client *SubscriptionClient) SubscriptionByName(ctx context.Context, name s
 
 // DeleteSubscriptionByName deletes a subscription by name.
 func (client *SubscriptionClient) DeleteSubscriptionByName(ctx context.Context, name string) (res dtoCommon.BaseResponse, err errors.EdgeX) {
-	path := path.Join(common.ApiSubscriptionRoute, common.Name, name)
+	path := utils.EscapeAndJoinPath(common.ApiSubscriptionRoute, common.Name, name)
 	err = utils.DeleteRequest(ctx, &res, client.baseUrl, path, client.authInjector)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)

--- a/common/utils.go
+++ b/common/utils.go
@@ -44,8 +44,9 @@ func BuildTopic(parts ...string) string {
 // URLEncode encodes the input string with additional common character support
 func URLEncode(s string) string {
 	res := url.PathEscape(s)
+	res = strings.Replace(res, "+", "%2B", -1) // MQTT topic reserved char
 	res = strings.Replace(res, "-", "%2D", -1)
-	res = strings.Replace(res, ".", "%2E", -1)
+	res = strings.Replace(res, ".", "%2E", -1) // RegexCmd and Redis topic reserved char
 	res = strings.Replace(res, "_", "%5F", -1)
 	res = strings.Replace(res, "~", "%7E", -1)
 

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -9,26 +9,27 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestURLEncode(t *testing.T) {
 	tests := []struct {
-		name             string
-		input            string
-		output           string
-		EqualsURLPackage bool
+		name   string
+		input  string
+		output string
 	}{
-		{"valid", "^[this]+{is}?test:string*#", "%5E%5Bthis%5D+%7Bis%7D%3Ftest:string%2A%23", true},
-		{"valid - special character", "this-is_test.string~", "this%2Dis%5Ftest%2Estring%7E", false},
+		{"valid", "^[this]+{is}?test:string*#", "%5E%5Bthis%5D%2B%7Bis%7D%3Ftest:string%2A%23"},
+		{"valid - special character", "this-is_test.string~哈囉世界< >/!#%^*()+,`@$&", "this%2Dis%5Ftest%2Estring%7E%E5%93%88%E5%9B%89%E4%B8%96%E7%95%8C%3C%20%3E%2F%21%23%25%5E%2A%28%29%2B%2C%60@$&"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := URLEncode(tt.input)
-			require.Equal(t, tt.output, res)
-			if tt.EqualsURLPackage {
-				require.Equal(t, url.PathEscape(tt.input), res)
-			}
+			assert.Equal(t, tt.output, res)
+
+			unescaped, err := url.PathUnescape(tt.output)
+			require.NoError(t, err)
+			assert.Equal(t, tt.input, unescaped)
 		})
 	}
 }

--- a/dtos/corecommand.go
+++ b/dtos/corecommand.go
@@ -6,8 +6,8 @@
 package dtos
 
 type DeviceCoreCommand struct {
-	DeviceName   string        `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	ProfileName  string        `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	DeviceName   string        `json:"deviceName" validate:"required,edgex-dto-none-empty-string"`
+	ProfileName  string        `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	CoreCommands []CoreCommand `json:"coreCommands,omitempty" validate:"dive"`
 }
 

--- a/dtos/device.go
+++ b/dtos/device.go
@@ -12,14 +12,14 @@ import (
 type Device struct {
 	DBTimestamp    `json:",inline"`
 	Id             string                        `json:"id,omitempty" yaml:"id,omitempty" validate:"omitempty,uuid"`
-	Name           string                        `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name           string                        `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string"`
 	Description    string                        `json:"description,omitempty" yaml:"description,omitempty"`
 	AdminState     string                        `json:"adminState" yaml:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	OperatingState string                        `json:"operatingState" yaml:"operatingState" validate:"oneof='UP' 'DOWN' 'UNKNOWN'"`
 	Labels         []string                      `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Location       interface{}                   `json:"location,omitempty" yaml:"location,omitempty"`
-	ServiceName    string                        `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ProfileName    string                        `json:"profileName" yaml:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ServiceName    string                        `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string"`
+	ProfileName    string                        `json:"profileName" yaml:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	AutoEvents     []AutoEvent                   `json:"autoEvents,omitempty" yaml:"autoEvents,omitempty" validate:"dive"`
 	Protocols      map[string]ProtocolProperties `json:"protocols" yaml:"protocols" validate:"required,gt=0"`
 	Tags           map[string]any                `json:"tags,omitempty" yaml:"tags,omitempty"`
@@ -28,12 +28,12 @@ type Device struct {
 
 type UpdateDevice struct {
 	Id             *string                       `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name           *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name           *string                       `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
 	Description    *string                       `json:"description" validate:"omitempty"`
 	AdminState     *string                       `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	OperatingState *string                       `json:"operatingState" validate:"omitempty,oneof='UP' 'DOWN' 'UNKNOWN'"`
-	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ProfileName    *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string"`
+	ProfileName    *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string"`
 	Labels         []string                      `json:"labels"`
 	Location       interface{}                   `json:"location"`
 	AutoEvents     []AutoEvent                   `json:"autoEvents" validate:"dive"`

--- a/dtos/deviceprofilebasicinfo.go
+++ b/dtos/deviceprofilebasicinfo.go
@@ -7,7 +7,7 @@ package dtos
 
 type DeviceProfileBasicInfo struct {
 	Id           string   `json:"id" validate:"omitempty,uuid"`
-	Name         string   `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name         string   `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string"`
 	Manufacturer string   `json:"manufacturer" yaml:"manufacturer"`
 	Description  string   `json:"description" yaml:"description"`
 	Model        string   `json:"model" yaml:"model"`
@@ -16,7 +16,7 @@ type DeviceProfileBasicInfo struct {
 
 type UpdateDeviceProfileBasicInfo struct {
 	Id           *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name         *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name         *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
 	Manufacturer *string  `json:"manufacturer"`
 	Description  *string  `json:"description"`
 	Model        *string  `json:"model"`

--- a/dtos/deviceservice.go
+++ b/dtos/deviceservice.go
@@ -12,7 +12,7 @@ import (
 type DeviceService struct {
 	DBTimestamp `json:",inline"`
 	Id          string   `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name        string   `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name        string   `json:"name" validate:"required,edgex-dto-none-empty-string"`
 	Description string   `json:"description,omitempty"`
 	Labels      []string `json:"labels,omitempty"`
 	BaseAddress string   `json:"baseAddress" validate:"required,uri"`
@@ -21,7 +21,7 @@ type DeviceService struct {
 
 type UpdateDeviceService struct {
 	Id          *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name        *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name        *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
 	Description *string  `json:"description"`
 	BaseAddress *string  `json:"baseAddress" validate:"omitempty,uri"`
 	Labels      []string `json:"labels"`

--- a/dtos/discovereddevice.go
+++ b/dtos/discovereddevice.go
@@ -8,14 +8,14 @@ package dtos
 import "github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 
 type DiscoveredDevice struct {
-	ProfileName string         `json:"profileName" yaml:"profileName" validate:"len=0|edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName string         `json:"profileName" yaml:"profileName" validate:"len=0|edgex-dto-none-empty-string"`
 	AdminState  string         `json:"adminState" yaml:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents  []AutoEvent    `json:"autoEvents,omitempty" yaml:"autoEvents,omitempty" validate:"dive"`
 	Properties  map[string]any `json:"properties,omitempty" yaml:"properties,omitempty"`
 }
 
 type UpdateDiscoveredDevice struct {
-	ProfileName *string        `json:"profileName" validate:"omitempty,len=0|edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName *string        `json:"profileName" validate:"omitempty,len=0|edgex-dto-none-empty-string"`
 	AdminState  *string        `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents  []AutoEvent    `json:"autoEvents" validate:"dive"`
 	Properties  map[string]any `json:"properties"`

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -18,8 +18,8 @@ import (
 type Event struct {
 	common.Versionable `json:",inline"`
 	Id                 string        `json:"id" validate:"required,uuid"`
-	DeviceName         string        `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
-	ProfileName        string        `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	DeviceName         string        `json:"deviceName" validate:"required,edgex-dto-none-empty-string"`
+	ProfileName        string        `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	SourceName         string        `json:"sourceName" validate:"required"`
 	Origin             int64         `json:"origin" validate:"required"`
 	Readings           []BaseReading `json:"readings" validate:"gt=0,dive,required"`

--- a/dtos/interval.go
+++ b/dtos/interval.go
@@ -12,7 +12,7 @@ import (
 type Interval struct {
 	DBTimestamp `json:",inline"`
 	Id          string `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name        string `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name        string `json:"name" validate:"edgex-dto-none-empty-string"`
 	Start       string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	End         string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	Interval    string `json:"interval" validate:"required,edgex-dto-duration"`
@@ -25,7 +25,7 @@ func NewInterval(name, interval string) Interval {
 
 type UpdateInterval struct {
 	Id       *string `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name     *string `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name     *string `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
 	Start    *string `json:"start" validate:"omitempty,edgex-dto-interval-datetime"`
 	End      *string `json:"end" validate:"omitempty,edgex-dto-interval-datetime"`
 	Interval *string `json:"interval" validate:"omitempty,edgex-dto-duration"`

--- a/dtos/intervalaction.go
+++ b/dtos/intervalaction.go
@@ -12,8 +12,8 @@ import (
 type IntervalAction struct {
 	DBTimestamp  `json:",inline"`
 	Id           string  `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name         string  `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	IntervalName string  `json:"intervalName" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name         string  `json:"name" validate:"edgex-dto-none-empty-string"`
+	IntervalName string  `json:"intervalName" validate:"edgex-dto-none-empty-string"`
 	Address      Address `json:"address" validate:"required"`
 	Content      string  `json:"content,omitempty"`
 	ContentType  string  `json:"contentType,omitempty"`
@@ -33,8 +33,8 @@ func NewIntervalAction(name string, intervalName string, address Address) Interv
 
 type UpdateIntervalAction struct {
 	Id           *string  `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name         *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	IntervalName *string  `json:"intervalName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name         *string  `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
+	IntervalName *string  `json:"intervalName" validate:"omitempty,edgex-dto-none-empty-string"`
 	Content      *string  `json:"content"`
 	ContentType  *string  `json:"contentType"`
 	Address      *Address `json:"address"`

--- a/dtos/provisionwatcher.go
+++ b/dtos/provisionwatcher.go
@@ -12,8 +12,8 @@ import (
 type ProvisionWatcher struct {
 	DBTimestamp         `json:",inline"`
 	Id                  string              `json:"id,omitempty" yaml:"id,omitempty" validate:"omitempty,uuid"`
-	Name                string              `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ServiceName         string              `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name                string              `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string"`
+	ServiceName         string              `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string"`
 	Labels              []string            `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Identifiers         map[string]string   `json:"identifiers" yaml:"identifiers" validate:"gt=0,dive,keys,required,endkeys,required"`
 	BlockingIdentifiers map[string][]string `json:"blockingIdentifiers,omitempty" yaml:"blockingIdentifiers,omitempty"`
@@ -23,8 +23,8 @@ type ProvisionWatcher struct {
 
 type UpdateProvisionWatcher struct {
 	Id                  *string                `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name                *string                `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
-	ServiceName         *string                `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name                *string                `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
+	ServiceName         *string                `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string"`
 	Labels              []string               `json:"labels"`
 	Identifiers         map[string]string      `json:"identifiers" validate:"omitempty,gt=0,dive,keys,required,endkeys,required"`
 	BlockingIdentifiers map[string][]string    `json:"blockingIdentifiers"`

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -23,9 +23,9 @@ import (
 type BaseReading struct {
 	Id            string `json:"id,omitempty"`
 	Origin        int64  `json:"origin" validate:"required"`
-	DeviceName    string `json:"deviceName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	DeviceName    string `json:"deviceName" validate:"required,edgex-dto-none-empty-string"`
 	ResourceName  string `json:"resourceName" validate:"required"`
-	ProfileName   string `json:"profileName" validate:"required,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName   string `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	ValueType     string `json:"valueType" validate:"required,edgex-dto-value-type"`
 	Units         string `json:"units,omitempty"`
 	Tags          Tags   `json:"tags,omitempty"`

--- a/dtos/requests/device_test.go
+++ b/dtos/requests/device_test.go
@@ -151,7 +151,7 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 		{"Valid AddDeviceRequest with service name containing unreserved chars", serviceNameWithUnreservedChars, false},
 	}
 
-	// Following tests verify if name fields containing reserved characters should be detected with an error
+	// Following tests verify if name fields containing reserved characters should not be detected with an error
 	for _, n := range namesWithReservedChar {
 		deviceNameWithReservedChar := testAddDevice
 		deviceNameWithReservedChar.Device.Name = n
@@ -161,9 +161,9 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 		serviceNameWithReservedChar.Device.ServiceName = n
 
 		testsForNameFields = append(testsForNameFields,
-			testForNameField{"Invalid AddDeviceRequest with device name containing reserved char", deviceNameWithReservedChar, true},
-			testForNameField{"Invalid AddDeviceRequest with device name containing reserved char", profileNameWithReservedChar, true},
-			testForNameField{"Invalid AddDeviceRequest with device name containing reserved char", serviceNameWithReservedChar, true},
+			testForNameField{"Valid AddDeviceRequest with device name containing reserved char", deviceNameWithReservedChar, false},
+			testForNameField{"Valid AddDeviceRequest with device name containing reserved char", profileNameWithReservedChar, false},
+			testForNameField{"Valid AddDeviceRequest with device name containing reserved char", serviceNameWithReservedChar, false},
 		)
 	}
 

--- a/dtos/requests/devicecommand.go
+++ b/dtos/requests/devicecommand.go
@@ -18,7 +18,7 @@ import (
 // AddDeviceCommandRequest defines the Request Content for POST DeviceCommand DTO.
 type AddDeviceCommandRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
-	ProfileName           string             `json:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName           string             `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	DeviceCommand         dtos.DeviceCommand `json:"deviceCommand"`
 }
 
@@ -51,7 +51,7 @@ func (dc *AddDeviceCommandRequest) UnmarshalJSON(b []byte) error {
 // UpdateDeviceCommandRequest defines the Request Content for PATCH DeviceCommand DTO.
 type UpdateDeviceCommandRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
-	ProfileName           string                   `json:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName           string                   `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	DeviceCommand         dtos.UpdateDeviceCommand `json:"deviceCommand"`
 }
 

--- a/dtos/requests/deviceprofile_test.go
+++ b/dtos/requests/deviceprofile_test.go
@@ -147,13 +147,13 @@ func TestDeviceProfileRequest_Validate(t *testing.T) {
 	err := profileNameWithUnreservedChars.Validate()
 	assert.NoError(t, err, fmt.Sprintf("DeviceProfileRequest with profile name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
 
-	// Following tests verify if profile name containing reserved characters should be detected with an error
+	// Following tests verify if profile name containing reserved characters should not be detected with an error
 	for _, n := range namesWithReservedChar {
 		profileNameWithReservedChar := profileData()
 		profileNameWithReservedChar.Profile.Name = n
 
 		err := profileNameWithReservedChar.Validate()
-		assert.Error(t, err, fmt.Sprintf("DeviceProfileRequest with profile name containing reserved char %s should return error during validation", n))
+		assert.NoError(t, err, fmt.Sprintf("DeviceProfileRequest with profile name containing reserved char %s should not return error during validation", n))
 	}
 }
 

--- a/dtos/requests/deviceresource.go
+++ b/dtos/requests/deviceresource.go
@@ -18,7 +18,7 @@ import (
 // AddDeviceResourceRequest defines the Request Content for POST DeviceResource DTO.
 type AddDeviceResourceRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
-	ProfileName           string              `json:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName           string              `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	Resource              dtos.DeviceResource `json:"resource"`
 }
 
@@ -50,7 +50,7 @@ func (dr *AddDeviceResourceRequest) UnmarshalJSON(b []byte) error {
 // UpdateDeviceResourceRequest defines the Request Content for PATCH DeviceResource DTO.
 type UpdateDeviceResourceRequest struct {
 	dtoCommon.BaseRequest `json:",inline"`
-	ProfileName           string                    `json:"profileName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	ProfileName           string                    `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
 	Resource              dtos.UpdateDeviceResource `json:"resource"`
 }
 

--- a/dtos/requests/deviceservice_test.go
+++ b/dtos/requests/deviceservice_test.go
@@ -98,13 +98,13 @@ func TestAddDeviceServiceRequest_Validate(t *testing.T) {
 	err := serviceNameWithUnreservedChars.Validate()
 	assert.NoError(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
 
-	// Following tests verify if service name containing reserved characters should be detected with an error
+	// Following tests verify if service name containing reserved characters should be detected without an error
 	for _, n := range namesWithReservedChar {
 		serviceNameWithReservedChar := testAddDeviceService
 		serviceNameWithReservedChar.Service.Name = n
 
 		err := serviceNameWithReservedChar.Validate()
-		assert.Error(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
+		assert.NoError(t, err, fmt.Sprintf("AddDeviceServiceRequest with service name containing reserved char %s should nout return error during validation", n))
 	}
 }
 
@@ -253,13 +253,13 @@ func TestUpdateDeviceServiceRequest_Validate(t *testing.T) {
 	err := serviceNameWithUnreservedChars.Validate()
 	assert.NoError(t, err, fmt.Sprintf("UpdateDeviceServiceRequest with service name containing unreserved chars %s should pass validation", nameWithUnreservedChars))
 
-	// Following tests verify if service name containing reserved characters should be detected with an error
+	// Following tests verify if service name containing reserved characters should not be detected with an error
 	for i, n := range namesWithReservedChar {
 		serviceNameWithReservedChar := testUpdateDeviceService
 		serviceNameWithReservedChar.Service.Name = &namesWithReservedChar[i]
 
 		err := serviceNameWithReservedChar.Validate()
-		assert.Error(t, err, fmt.Sprintf("UpdateDeviceServiceRequest with service name containing reserved char %s should return error during validation", n))
+		assert.NoError(t, err, fmt.Sprintf("UpdateDeviceServiceRequest with service name containing reserved char %s should not return error during validation", n))
 	}
 }
 

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -170,12 +170,12 @@ func TestAddEventRequest_Validate(t *testing.T) {
 		readingProfileNameWithReservedChar.Event.Readings[0].ProfileName = n
 
 		testsForNameFields = append(testsForNameFields,
-			testForNameField{"Invalid AddEventRequest with device name containing reserved char", deviceNameWithReservedChar, true},
-			testForNameField{"Invalid AddEventRequest with profile name containing reserved char", profileNameWithReservedChar, true},
+			testForNameField{"Valid AddEventRequest with device name containing reserved char", deviceNameWithReservedChar, false},
+			testForNameField{"Valid AddEventRequest with profile name containing reserved char", profileNameWithReservedChar, false},
 			testForNameField{"Valid AddEventRequest with source name containing reserved char", sourceNameWithReservedChar, false},
-			testForNameField{"Invalid AddEventRequest with reading device name containing reserved char", readingDeviceNameWithReservedChar, true},
+			testForNameField{"Valid AddEventRequest with reading device name containing reserved char", readingDeviceNameWithReservedChar, false},
 			testForNameField{"Valid AddEventRequest with reading resource name containing reserved char", readingResourceNameWithReservedChar, false},
-			testForNameField{"Invalid AddEventRequest with reading profile name containing reserved char", readingProfileNameWithReservedChar, true},
+			testForNameField{"Valid AddEventRequest with reading profile name containing reserved char", readingProfileNameWithReservedChar, false},
 		)
 	}
 

--- a/dtos/requests/interval_test.go
+++ b/dtos/requests/interval_test.go
@@ -87,7 +87,7 @@ func TestAddIntervalRequest_Validate(t *testing.T) {
 		{"valid AddIntervalRequest", valid, false},
 		{"valid AddIntervalRequest, no Request Id", noReqId, false},
 		{"valid AddIntervalRequest, interval name containing unreserved chars", intervalNameWithUnreservedChars, false},
-		{"invalid AddIntervalRequest, interval name containing reserved chars", intervalNameWithReservedChars, true},
+		{"valid AddIntervalRequest, interval name containing reserved chars", intervalNameWithReservedChars, false},
 		{"invalid AddIntervalRequest, Request Id is not an uuid", invalidReqId, true},
 		{"invalid AddIntervalRequest, no IntervalName", noIntervalName, true},
 		{"invalid AddIntervalRequest, invalid frequency", invalidFrequency, true},

--- a/dtos/requests/intervalaction_test.go
+++ b/dtos/requests/intervalaction_test.go
@@ -90,7 +90,7 @@ func TestAddIntervalActionRequest_Validate(t *testing.T) {
 		{"valid AddIntervalActionRequest", valid, false},
 		{"valid AddIntervalActionRequest, no Request Id", noReqId, false},
 		{"valid AddIntervalActionRequest, interval name containing unreserved chars", intervalNameWithUnreservedChars, false},
-		{"invalid AddIntervalActionRequest, interval name containing reserved chars", intervalNameWithReservedChars, true},
+		{"valid AddIntervalActionRequest, interval name containing reserved chars", intervalNameWithReservedChars, false},
 		{"invalid AddIntervalActionRequest, Request Id is not an uuid", invalidReqId, true},
 		{"invalid AddIntervalActionRequest, no IntervalActionName", noIntervalActionName, true},
 		{"invalid AddIntervalActionRequest, no IntervalActionName", noIntervalName, true},

--- a/dtos/requests/provisionwatcher_test.go
+++ b/dtos/requests/provisionwatcher_test.go
@@ -125,7 +125,7 @@ func TestAddProvisionWatcherRequest_Validate(t *testing.T) {
 		{"valid AddProvisionWatcherRequest, no Request Id", noReqId, false},
 		{"invalid AddProvisionWatcherRequest, Request Id is not an uuid", invalidReqId, true},
 		{"invalid AddProvisionWatcherRequest, no ProvisionWatcherName", noProvisionWatcherName, true},
-		{"invalid AddProvisionWatcherRequest, ProvisionWatcherName with reserved chars", provisionWatcherNameWithReservedChar, true},
+		{"valid AddProvisionWatcherRequest, ProvisionWatcherName with reserved chars", provisionWatcherNameWithReservedChar, false},
 		{"invalid AddProvisionWatcherRequest, no Identifiers", noIdentifiers, true},
 		{"invalid AddProvisionWatcherRequest, missing Identifiers key", missingIdentifiersKey, true},
 		{"invalid AddProvisionWatcherRequest, missing Identifiers value", missingIdentifiersValue, true},
@@ -226,8 +226,8 @@ func TestUpdateProvisionWatcherRequest_Validate(t *testing.T) {
 	nameAndEmptyId.ProvisionWatcher.Id = &whiteSpace
 	invalidEmptyName := valid
 	invalidEmptyName.ProvisionWatcher.Name = &whiteSpace
-	invalidReservedName := valid
-	invalidReservedName.ProvisionWatcher.Name = &namesWithReservedChar[0]
+	reservedName := valid
+	reservedName.ProvisionWatcher.Name = &namesWithReservedChar[0]
 	// no id and name
 	noIdAndName := valid
 	noIdAndName.ProvisionWatcher.Id = nil
@@ -271,7 +271,7 @@ func TestUpdateProvisionWatcherRequest_Validate(t *testing.T) {
 		{"valid, only name", validOnlyName, false},
 		{"valid, name and empty Id", nameAndEmptyId, false},
 		{"invalid, empty name", invalidEmptyName, true},
-		{"invalid, name with reserved chars", invalidReservedName, true},
+		{"valid, name with reserved chars", reservedName, false},
 
 		{"invalid, no Id and name", noIdAndName, true},
 

--- a/dtos/requests/subscription_test.go
+++ b/dtos/requests/subscription_test.go
@@ -119,7 +119,7 @@ func TestAddSubscriptionRequest_Validate(t *testing.T) {
 		{"valid, no labels specified", noLabels, false},
 		{"invalid, request ID is not an UUID", invalidReqId, true},
 		{"invalid, no subscription name", noSubscriptionName, true},
-		{"invalid, subscription name containing reserved chars", subscriptionNameWithReservedChars, true},
+		{"valid, subscription name containing reserved chars", subscriptionNameWithReservedChars, false},
 		{"invalid, no channels specified", noChannel, true},
 		{"invalid, email address is invalid", invalidEmailAddress, true},
 		{"invalid, unsupported channel type", unsupportedChannelType, true},

--- a/dtos/subscription.go
+++ b/dtos/subscription.go
@@ -12,7 +12,7 @@ import (
 type Subscription struct {
 	DBTimestamp    `json:",inline"`
 	Id             string    `json:"id,omitempty" validate:"omitempty,uuid"`
-	Name           string    `json:"name" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name           string    `json:"name" validate:"required,edgex-dto-none-empty-string"`
 	Channels       []Address `json:"channels" validate:"required,gt=0,dive"`
 	Receiver       string    `json:"receiver" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Categories     []string  `json:"categories,omitempty" validate:"required_without=Labels,omitempty,gt=0,dive,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
@@ -25,7 +25,7 @@ type Subscription struct {
 
 type UpdateSubscription struct {
 	Id             *string   `json:"id" validate:"required_without=Name,edgex-dto-uuid"`
-	Name           *string   `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	Name           *string   `json:"name" validate:"required_without=Id,edgex-dto-none-empty-string"`
 	Channels       []Address `json:"channels" validate:"omitempty,gt=0,dive"`
 	Receiver       *string   `json:"receiver" validate:"omitempty,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Categories     []string  `json:"categories" validate:"omitempty,dive,gt=0,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`

--- a/dtos/transmission.go
+++ b/dtos/transmission.go
@@ -14,7 +14,7 @@ type Transmission struct {
 	Id               string               `json:"id,omitempty" validate:"omitempty,uuid"`
 	Channel          Address              `json:"channel" validate:"required"`
 	NotificationId   string               `json:"notificationId" validate:"required"`
-	SubscriptionName string               `json:"subscriptionName" validate:"required,edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
+	SubscriptionName string               `json:"subscriptionName" validate:"required,edgex-dto-none-empty-string"`
 	Records          []TransmissionRecord `json:"records,omitempty"`
 	ResendCount      int                  `json:"resendCount,omitempty"`
 	Status           string               `json:"status" validate:"required,oneof='ACKNOWLEDGED' 'FAILED' 'SENT' 'ESCALATED' 'RESENDING'"`


### PR DESCRIPTION
Use URL escape for DTO name field, including
- device name
- profile name
- service name
- interval and interval action name
- provision watcher name
- subscription name

Close #850

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [v] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [v] I am not introducing a new dependency (add notes below if you are)
- [v] I have added unit tests for the new feature or bug fix (if not, why?)
- [v] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Test core metadata API to verify the deviceName or serviceName accept URL escape.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->