### PR TITLE
fix: use comma without a space as separator to parse array value

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -407,9 +407,10 @@ func parseSimpleValue(valueType string, value string) (err error) {
 }
 
 func parseArrayValue(valueType string, value string) (err error) {
-	arrayValue := strings.Split(value[1:len(value)-1], ", ") // trim "[" and "]"
+	arrayValue := strings.Split(value[1:len(value)-1], ",") // trim "[" and "]"
 
 	for _, v := range arrayValue {
+		v = strings.TrimSpace(v)
 		switch valueType {
 		case common.ValueTypeBoolArray:
 			err = parseSimpleValue(common.ValueTypeBool, v)

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -276,6 +276,30 @@ func TestValidateValue(t *testing.T) {
 	}
 }
 
+func TestValidateArrayValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		valueType   string
+		value       string
+		expectError bool
+	}{
+		{"Valid separator (comma followed by a space)", common.ValueTypeBoolArray, "[true, false]", false},
+		{"Valid separator (comma)", common.ValueTypeBoolArray, "[true,false]", false},
+		{"Invalid separator", common.ValueTypeBoolArray, "[true@false]", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateValue(tt.valueType, tt.value)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateValueError(t *testing.T) {
 	invalidValue := "invalid"
 	tests := []struct {


### PR DESCRIPTION
fix: #858 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
From the latest compose-builder run `make run no-secty ds-virtual`
Run `docker stop edgex-core-data`
From the latest edgex-go run `git clone --branch issue-858 git@github.com:FelixTing/go-mod-core-contracts.git`, add the following line to go.mod, and run core-data locally.
```
replace github.com/edgexfoundry/go-mod-core-contracts/v3 => ./go-mod-core-contracts
```
Create an event with array values
```
curl -X POST http://127.0.0.1:59880/api/v3/event/device-virtual/Random-UnsignedInteger-Device/Random-UnsignedInteger-Device/Uint64Array -d '
{
  "apiVersion": "v3",
  "event": {
    "apiVersion": "v3",
    "deviceName": "Random-UnsignedInteger-Device",
    "id": "7342b0dc-c2ce-4ce4-973a-25c3218703b2",
    "origin": 1694504020967572680,
    "profileName": "Random-UnsignedInteger-Device",
    "readings": [
      {
        "apiVersion": "v3",
        "deviceName": "Random-UnsignedInteger-Device",
        "id": "0345ca5b-eca5-4db9-bdaa-9685920cb12f",
        "origin": 1694504020967572680,
        "profileName": "Random-UnsignedInteger-Device",
        "resourceName": "Uint64Array",
        "value": "[1,2,3,4,5]",
        "valueType": "Uint64Array"
      }
    ],
    "sourceName": "Uint64Array"
  }
}'
```
The event should be created successfully.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->