### PR TITLE
feat(EventClient): add DeleteById to interface

### DIFF
--- a/clients/http/event.go
+++ b/clients/http/event.go
@@ -132,3 +132,13 @@ func (ec *eventClient) DeleteByAge(ctx context.Context, age int) (dtoCommon.Base
 	}
 	return res, nil
 }
+
+func (ec *eventClient) DeleteById(ctx context.Context, id string) (dtoCommon.BaseResponse, errors.EdgeX) {
+	path := path.Join(common.ApiEventRoute, common.Id, id)
+	res := dtoCommon.BaseResponse{}
+	err := utils.DeleteRequest(ctx, &res, ec.baseUrl, path, ec.authInjector)
+	if err != nil {
+		return res, errors.NewCommonEdgeXWrapper(err)
+	}
+	return res, nil
+}

--- a/clients/http/event_test.go
+++ b/clients/http/event_test.go
@@ -116,3 +116,15 @@ func TestDeleteEventsByAge(t *testing.T) {
 	require.NoError(t, err)
 	assert.IsType(t, dtoCommon.BaseResponse{}, res)
 }
+
+func TestDeleteEventById(t *testing.T) {
+	id := "1234-5678-90fa-keid"
+	path := path.Join(common.ApiEventRoute, common.Id, id)
+	ts := newTestServer(http.MethodDelete, path, dtoCommon.BaseResponse{})
+	defer ts.Close()
+
+	client := NewEventClient(ts.URL, NewNullAuthenticationInjector(), false)
+	res, err := client.DeleteById(context.Background(), id)
+	require.NoError(t, err)
+	assert.IsType(t, dtoCommon.BaseResponse{}, res)
+}

--- a/clients/interfaces/event.go
+++ b/clients/interfaces/event.go
@@ -40,4 +40,6 @@ type EventClient interface {
 	EventsByTimeRange(ctx context.Context, start, end, offset, limit int) (responses.MultiEventsResponse, errors.EdgeX)
 	// DeleteByAge deletes events that are older than the given age. Age is supposed in milliseconds from created timestamp.
 	DeleteByAge(ctx context.Context, age int) (common.BaseResponse, errors.EdgeX)
+	// DeleteById deletes an event by its id
+	DeleteById(ctx context.Context, id string) (common.BaseResponse, errors.EdgeX)
 }

--- a/clients/interfaces/mocks/EventClient.go
+++ b/clients/interfaces/mocks/EventClient.go
@@ -99,6 +99,32 @@ func (_m *EventClient) DeleteByAge(ctx context.Context, age int) (common.BaseRes
 	return r0, r1
 }
 
+// DeleteById provides a mock function with given fields: ctx, id
+func (_m *EventClient) DeleteById(ctx context.Context, id string) (common.BaseResponse, errors.EdgeX) {
+	ret := _m.Called(ctx, id)
+
+	var r0 common.BaseResponse
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(context.Context, string) (common.BaseResponse, errors.EdgeX)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) common.BaseResponse); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Get(0).(common.BaseResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) errors.EdgeX); ok {
+		r1 = rf(ctx, id)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // DeleteByDeviceName provides a mock function with given fields: ctx, name
 func (_m *EventClient) DeleteByDeviceName(ctx context.Context, name string) (common.BaseResponse, errors.EdgeX) {
 	ret := _m.Called(ctx, name)


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->
Closes #868 

<!--If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md-->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  No docs change necessary

## Testing Instructions
1. Update app-functions-sdk-go with updated version of go-mod-core-contracts (using `replace`, for example)
2. From a new application service, import the new version of app-functions-sdk-go (using `replace`, for example) and use `interfaces.EventClient` the same as before. `DeleteById(ctx, id)` will be available.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
N/A