### PR TITLE
feat: add injectEdgeXAuth boolean attribute to RESTAddress types

### DIFF
--- a/dtos/address.go
+++ b/dtos/address.go
@@ -50,8 +50,9 @@ func (a *Address) Validate() error {
 }
 
 type RESTAddress struct {
-	Path       string `json:"path,omitempty"`
-	HTTPMethod string `json:"httpMethod,omitempty" validate:"required,oneof='GET' 'HEAD' 'POST' 'PUT' 'PATCH' 'DELETE' 'TRACE' 'CONNECT'"`
+	Path            string `json:"path,omitempty"`
+	HTTPMethod      string `json:"httpMethod,omitempty" validate:"required,oneof='GET' 'HEAD' 'POST' 'PUT' 'PATCH' 'DELETE' 'TRACE' 'CONNECT'"`
+	InjectEdgeXAuth bool   `json:"injectEdgeXAuth,omitempty"`
 }
 
 func NewRESTAddress(host string, port int, httpMethod string) Address {
@@ -109,8 +110,9 @@ func ToAddressModel(a Address) models.Address {
 			BaseAddress: models.BaseAddress{
 				Type: a.Type, Host: a.Host, Port: a.Port,
 			},
-			Path:       a.RESTAddress.Path,
-			HTTPMethod: a.RESTAddress.HTTPMethod,
+			Path:            a.RESTAddress.Path,
+			HTTPMethod:      a.RESTAddress.HTTPMethod,
+			InjectEdgeXAuth: a.RESTAddress.InjectEdgeXAuth,
 		}
 	case common.MQTT:
 		address = models.MQTTPubAddress{
@@ -146,8 +148,9 @@ func FromAddressModelToDTO(address models.Address) Address {
 	switch a := address.(type) {
 	case models.RESTAddress:
 		dto.RESTAddress = RESTAddress{
-			Path:       a.Path,
-			HTTPMethod: a.HTTPMethod,
+			Path:            a.Path,
+			HTTPMethod:      a.HTTPMethod,
+			InjectEdgeXAuth: a.InjectEdgeXAuth,
 		}
 	case models.MQTTPubAddress:
 		dto.MQTTPubAddress = MQTTPubAddress{

--- a/dtos/address_test.go
+++ b/dtos/address_test.go
@@ -38,6 +38,17 @@ var testRESTAddress = Address{
 	},
 }
 
+var testRESTAddressWithAuthInject = Address{
+	Type: common.REST,
+	Host: testHost,
+	Port: testPort,
+	RESTAddress: RESTAddress{
+		Path:            testPath,
+		HTTPMethod:      testHTTPMethod,
+		InjectEdgeXAuth: true,
+	},
+}
+
 var testMQTTPubAddress = Address{
 	Type: common.MQTT,
 	Host: testHost,
@@ -61,6 +72,11 @@ func TestAddress_UnmarshalJSON(t *testing.T) {
 		testRESTAddress.Type, testRESTAddress.Host, testRESTAddress.Port,
 		testRESTAddress.Path, testRESTAddress.HTTPMethod,
 	)
+	restWithInjectJsonStr := fmt.Sprintf(
+		`{"type":"%s","host":"%s","port":%d,"path":"%s","httpMethod":"%s","injectEdgeXAuth":%v}`,
+		testRESTAddressWithAuthInject.Type, testRESTAddressWithAuthInject.Host, testRESTAddressWithAuthInject.Port,
+		testRESTAddressWithAuthInject.Path, testRESTAddressWithAuthInject.HTTPMethod, testRESTAddressWithAuthInject.InjectEdgeXAuth,
+	)
 	mqttJsonStr := fmt.Sprintf(
 		`{"type":"%s","host":"%s","port":%d,"Publisher":"%s","Topic":"%s"}`,
 		testMQTTPubAddress.Type, testMQTTPubAddress.Host, testMQTTPubAddress.Port,
@@ -75,6 +91,7 @@ func TestAddress_UnmarshalJSON(t *testing.T) {
 		wantErr  bool
 	}{
 		{"unmarshal RESTAddress with success", testRESTAddress, []byte(restJsonStr), false},
+		{"unmarshal RESTAddressWithAuthInject with success", testRESTAddressWithAuthInject, []byte(restWithInjectJsonStr), false},
 		{"unmarshal MQTTPubAddress with success", testMQTTPubAddress, []byte(mqttJsonStr), false},
 		{"unmarshal EmailAddress with success", testEmailAddress, []byte(emailJsonStr), false},
 		{"unmarshal invalid Address, empty data", Address{}, []byte{}, true},
@@ -163,6 +180,16 @@ func TestAddress_marshalJSON(t *testing.T) {
 		`{"type":"%s","host":"%s","port":%d,"httpMethod":"%s"}`,
 		restAddress.Type, restAddress.Host, restAddress.Port, restAddress.HTTPMethod,
 	)
+	restAddressWithAuthInject := Address{
+		Type: common.REST,
+		Host: testHost, Port: testPort,
+		RESTAddress: RESTAddress{HTTPMethod: testHTTPMethod, InjectEdgeXAuth: true},
+	}
+	expectedRESTWithAuthInjectJsonStr := fmt.Sprintf(
+		`{"type":"%s","host":"%s","port":%d,"httpMethod":"%s","injectEdgeXAuth":%v}`,
+		restAddressWithAuthInject.Type, restAddressWithAuthInject.Host, restAddressWithAuthInject.Port,
+		restAddressWithAuthInject.HTTPMethod, restAddressWithAuthInject.InjectEdgeXAuth,
+	)
 	mattAddress := Address{
 		Type: common.MQTT,
 		Host: testHost, Port: testPort,
@@ -192,6 +219,7 @@ func TestAddress_marshalJSON(t *testing.T) {
 		expectedJSONStr string
 	}{
 		{"marshal REST address", restAddress, expectedRESTJsonStr},
+		{"marshal REST address with auth inject", restAddressWithAuthInject, expectedRESTWithAuthInjectJsonStr},
 		{"marshal MQTT address", mattAddress, expectedMQTTJsonStr},
 		{"marshal Email address", emailAddress, expectedEmailJsonStr},
 	}

--- a/models/address.go
+++ b/models/address.go
@@ -70,8 +70,9 @@ type BaseAddress struct {
 // RESTAddress is a REST specific struct
 type RESTAddress struct {
 	BaseAddress
-	Path       string
-	HTTPMethod string
+	Path            string
+	HTTPMethod      string
+	InjectEdgeXAuth bool
 }
 
 func (a RESTAddress) GetBaseAddress() BaseAddress { return a.BaseAddress }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Requires update of `edgex-go` support notifications. See https://github.com/edgexfoundry/edgex-go/issues/4747#issuecomment-1911312262

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
N/A