### PR TITLE
feat: Allow empty profileName in Device

### DIFF
--- a/dtos/device.go
+++ b/dtos/device.go
@@ -20,7 +20,7 @@ type Device struct {
 	Labels         []string                      `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Location       interface{}                   `json:"location,omitempty" yaml:"location,omitempty"`
 	ServiceName    string                        `json:"serviceName" yaml:"serviceName" validate:"required,edgex-dto-none-empty-string"`
-	ProfileName    string                        `json:"profileName" yaml:"profileName" validate:"required,edgex-dto-none-empty-string"`
+	ProfileName    string                        `json:"profileName,omitempty" yaml:"profileName,omitempty"`
 	AutoEvents     []AutoEvent                   `json:"autoEvents,omitempty" yaml:"autoEvents,omitempty" validate:"dive"`
 	Protocols      map[string]ProtocolProperties `json:"protocols" yaml:"protocols" validate:"required"`
 	Tags           map[string]any                `json:"tags,omitempty" yaml:"tags,omitempty"`
@@ -35,7 +35,7 @@ type UpdateDevice struct {
 	AdminState     *string                       `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	OperatingState *string                       `json:"operatingState" validate:"omitempty,oneof='UP' 'DOWN' 'UNKNOWN'"`
 	ServiceName    *string                       `json:"serviceName" validate:"omitempty,edgex-dto-none-empty-string"`
-	ProfileName    *string                       `json:"profileName" validate:"omitempty,edgex-dto-none-empty-string"`
+	ProfileName    *string                       `json:"profileName" validate:"omitempty"`
 	Labels         []string                      `json:"labels"`
 	Location       interface{}                   `json:"location"`
 	AutoEvents     []AutoEvent                   `json:"autoEvents" validate:"dive"`

--- a/dtos/requests/device_test.go
+++ b/dtos/requests/device_test.go
@@ -122,7 +122,7 @@ func TestAddDeviceRequest_Validate(t *testing.T) {
 		{"invalid AddDeviceRequest, Request Id is not an uuid", invalidReqId, true},
 		{"invalid AddDeviceRequest, no DeviceName", noDeviceName, true},
 		{"invalid AddDeviceRequest, no ServiceName", noServiceName, true},
-		{"invalid AddDeviceRequest, no ProfileName", noProfileName, true},
+		{"valid AddDeviceRequest, no ProfileName", noProfileName, false},
 		{"valid AddDeviceRequest, no Protocols", noProtocols, false},
 		{"invalid AddDeviceRequest, no AutoEvent frequency", noAutoEventFrequency, true},
 		{"invalid AddDeviceRequest, no AutoEvent resource", noAutoEventResource, true},
@@ -317,8 +317,8 @@ func TestUpdateDeviceRequest_Validate(t *testing.T) {
 	// ProfileName
 	validNilProfileName := valid
 	validNilProfileName.Device.ProfileName = nil
-	invalidEmptyProfileName := valid
-	invalidEmptyProfileName.Device.ProfileName = &emptyString
+	emptyProfileName := valid
+	emptyProfileName.Device.ProfileName = &emptyString
 
 	invalidState := "invalid state"
 	invalidAdminState := valid
@@ -353,7 +353,7 @@ func TestUpdateDeviceRequest_Validate(t *testing.T) {
 		{"invalid, empty service name", invalidEmptyServiceName, true},
 
 		{"valid, nil profile name", validNilProfileName, false},
-		{"invalid, empty profile name", invalidEmptyProfileName, true},
+		{"valid, empty profile name", emptyProfileName, false},
 
 		{"invalid, invalid admin state", invalidAdminState, true},
 		{"invalid, invalid operating state", invalidOperatingState, true},


### PR DESCRIPTION
BREAKING CHANGE: Allow empty profileName in Device, and set AdminState as Locked and OperatingState as Down by default

closed #901

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->