### PR TITLE
feat: Add multiple profile basic info DTO

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -35,6 +35,7 @@ const (
 
 	ApiDeviceProfileRoute                       = ApiBase + "/deviceprofile"
 	ApiDeviceProfileBasicInfoRoute              = ApiDeviceProfileRoute + "/basicinfo"
+	ApiAllDeviceProfileBasicInfoRoute           = ApiDeviceProfileBasicInfoRoute + "/" + All
 	ApiDeviceProfileDeviceCommandRoute          = ApiDeviceProfileRoute + "/" + DeviceCommand
 	ApiDeviceProfileResourceRoute               = ApiDeviceProfileRoute + "/" + Resource
 	ApiDeviceProfileUploadFileRoute             = ApiDeviceProfileRoute + "/uploadfile"

--- a/dtos/deviceprofile.go
+++ b/dtos/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -91,6 +91,18 @@ func FromDeviceProfileModelToDTO(deviceProfile models.DeviceProfile) DeviceProfi
 		},
 		DeviceResources: FromDeviceResourceModelsToDTOs(deviceProfile.DeviceResources),
 		DeviceCommands:  FromDeviceCommandModelsToDTOs(deviceProfile.DeviceCommands),
+	}
+}
+
+// FromDeviceProfileModelToBasicInfoDTO transforms the DeviceProfile Model to the DeviceProfileBasicInfo DTO
+func FromDeviceProfileModelToBasicInfoDTO(deviceProfile models.DeviceProfile) DeviceProfileBasicInfo {
+	return DeviceProfileBasicInfo{
+		Id:           deviceProfile.Id,
+		Name:         deviceProfile.Name,
+		Description:  deviceProfile.Description,
+		Manufacturer: deviceProfile.Manufacturer,
+		Model:        deviceProfile.Model,
+		Labels:       deviceProfile.Labels,
 	}
 }
 

--- a/dtos/deviceprofile_test.go
+++ b/dtos/deviceprofile_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021-2023 IOTech Ltd
+// Copyright (C) 2021-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -88,6 +88,11 @@ func profileData() DeviceProfile {
 func TestFromDeviceProfileModelToDTO(t *testing.T) {
 	result := FromDeviceProfileModelToDTO(testDeviceProfile)
 	assert.Equal(t, profileData(), result, "FromDeviceProfileModelToDTO did not result in expected device profile DTO.")
+}
+
+func TestFromDeviceProfileModelToBasicInfoDTO(t *testing.T) {
+	result := FromDeviceProfileModelToBasicInfoDTO(testDeviceProfile)
+	assert.Equal(t, profileData().DeviceProfileBasicInfo, result, "FromDeviceProfileModelToBasicInfoDTO did not result in expected device profile basic info DTO.")
 }
 
 func TestDeviceProfileDTOValidation(t *testing.T) {

--- a/dtos/responses/deviceprofile.go
+++ b/dtos/responses/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -33,5 +33,18 @@ func NewMultiDeviceProfilesResponse(requestId string, message string, statusCode
 	return MultiDeviceProfilesResponse{
 		BaseWithTotalCountResponse: common.NewBaseWithTotalCountResponse(requestId, message, statusCode, totalCount),
 		Profiles:                   deviceProfiles,
+	}
+}
+
+// MultiDeviceProfileBasicInfoResponse defines the Response Content for GET multiple DeviceProfileBasicInfo DTOs.
+type MultiDeviceProfileBasicInfoResponse struct {
+	common.BaseWithTotalCountResponse `json:",inline"`
+	Profiles                          []dtos.DeviceProfileBasicInfo `json:"profiles"`
+}
+
+func NewMultiDeviceProfileBasicInfosResponse(requestId string, message string, statusCode int, totalCount uint32, deviceProfileBasicInfos []dtos.DeviceProfileBasicInfo) MultiDeviceProfileBasicInfoResponse {
+	return MultiDeviceProfileBasicInfoResponse{
+		BaseWithTotalCountResponse: common.NewBaseWithTotalCountResponse(requestId, message, statusCode, totalCount),
+		Profiles:                   deviceProfileBasicInfos,
 	}
 }

--- a/dtos/responses/deviceprofile_test.go
+++ b/dtos/responses/deviceprofile_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,4 +42,22 @@ func TestNewMultiDeviceProfilesResponse(t *testing.T) {
 	assert.Equal(t, expectedMessage, actual.Message)
 	assert.Equal(t, expectedTotalCount, actual.TotalCount)
 	assert.Equal(t, expectedDeviceProfiles, actual.Profiles)
+}
+
+func TestNewMultiDeviceProfileBasicInfosResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedDeviceProfileBasicInfos := []dtos.DeviceProfileBasicInfo{
+		{Name: "test device profile1"},
+		{Name: "test device profile2"},
+	}
+	expectedTotalCount := uint32(2)
+	actual := NewMultiDeviceProfileBasicInfosResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedTotalCount, expectedDeviceProfileBasicInfos)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedTotalCount, actual.TotalCount)
+	assert.Equal(t, expectedDeviceProfileBasicInfos, actual.Profiles)
 }


### PR DESCRIPTION
Add multiple profile basic info DTO for /api/v3/deviceprofile/basicinfo/all API

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) update the swagger doc
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- core-data and metadata
- upload profiles
- test the API


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->