### PR TITLE
feat: Set Default Value for AdminState and Enhancements for Cron Scheduler

### DIFF
--- a/dtos/schedulejob.go
+++ b/dtos/schedulejob.go
@@ -6,6 +6,8 @@
 package dtos
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
@@ -17,7 +19,7 @@ type ScheduleJob struct {
 	Name        string           `json:"name" validate:"edgex-dto-none-empty-string"`
 	Definition  ScheduleDef      `json:"definition" validate:"required"`
 	Actions     []ScheduleAction `json:"actions" validate:"required,gt=0,dive"`
-	AdminState  string           `json:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
+	AdminState  string           `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	Labels      []string         `json:"labels,omitempty"`
 	Properties  map[string]any   `json:"properties,omitempty"`
 }
@@ -85,11 +87,11 @@ func (s *ScheduleDef) Validate() error {
 }
 
 type IntervalScheduleDef struct {
-	Interval string `json:"interval" validate:"required,edgex-dto-duration"`
+	Interval string `json:"interval,omitempty" validate:"required,edgex-dto-duration"`
 }
 
 type CronScheduleDef struct {
-	Crontab string `json:"crontab" validate:"required"`
+	Crontab string `json:"crontab,omitempty" validate:"required"`
 }
 
 type ScheduleAction struct {
@@ -100,6 +102,46 @@ type ScheduleAction struct {
 	EdgeXMessageBusAction `json:",inline" validate:"-"`
 	RESTAction            `json:",inline" validate:"-"`
 	DeviceControlAction   `json:",inline" validate:"-"`
+}
+
+func (s *ScheduleAction) UnmarshalJSON(b []byte) error {
+	type Alias ScheduleAction
+	alias := &struct {
+		Payload any `json:"payload,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	if err := json.Unmarshal(b, &alias); err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal ScheduleAction as JSON.", err)
+	}
+
+	if alias.Payload == nil {
+		return nil
+	}
+
+	switch v := alias.Payload.(type) {
+	case string:
+		// Check if payload is a base64 encoded string
+		if decoded, err := base64.StdEncoding.DecodeString(v); err == nil {
+			s.Payload = decoded
+		} else {
+			// Or just a plain string
+			s.Payload = []byte(v)
+		}
+	case map[string]any:
+		// If payload is a JSON object then marshal it
+		if encoded, err := json.Marshal(v); err == nil {
+			s.Payload = encoded
+		} else {
+			return err
+		}
+	default:
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal ScheduleAction, unsupported payload type.", nil)
+	}
+
+	return nil
 }
 
 func (s *ScheduleAction) Validate() error {
@@ -130,18 +172,18 @@ func (s *ScheduleAction) Validate() error {
 }
 
 type EdgeXMessageBusAction struct {
-	Topic string `json:"topic" validate:"required"`
+	Topic string `json:"topic,omitempty" validate:"required"`
 }
 
 type RESTAction struct {
-	Address         string `json:"address" validate:"required"`
-	Method          string `json:"method" validate:"required"`
+	Address         string `json:"address,omitempty" validate:"required"`
+	Method          string `json:"method,omitempty" validate:"required"`
 	InjectEdgeXAuth bool   `json:"injectEdgeXAuth,omitempty"`
 }
 
 type DeviceControlAction struct {
-	DeviceName string `json:"deviceName" validate:"required"`
-	SourceName string `json:"sourceName" validate:"required"`
+	DeviceName string `json:"deviceName,omitempty" validate:"required"`
+	SourceName string `json:"sourceName,omitempty" validate:"required"`
 }
 
 func ToScheduleJobModel(dto ScheduleJob) models.ScheduleJob {
@@ -150,7 +192,7 @@ func ToScheduleJobModel(dto ScheduleJob) models.ScheduleJob {
 	model.Name = dto.Name
 	model.Definition = ToScheduleDefModel(dto.Definition)
 	model.Actions = ToScheduleActionModels(dto.Actions)
-	model.AdminState = models.AdminState(dto.AdminState)
+	model.AdminState = models.AssignAdminState(dto.AdminState)
 	model.Labels = dto.Labels
 	model.Properties = dto.Properties
 

--- a/dtos/schedulejob.go
+++ b/dtos/schedulejob.go
@@ -8,6 +8,8 @@ package dtos
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
@@ -138,7 +140,7 @@ func (s *ScheduleAction) UnmarshalJSON(b []byte) error {
 			return err
 		}
 	default:
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, "Failed to unmarshal ScheduleAction, unsupported payload type.", nil)
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("Failed to unmarshal ScheduleAction, unsupported payload type: %s.", v), nil)
 	}
 
 	return nil

--- a/dtos/schedulejob_test.go
+++ b/dtos/schedulejob_test.go
@@ -207,6 +207,30 @@ func TestScheduleJob_Validate(t *testing.T) {
 	}
 }
 
+func TestScheduleAction_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     string
+		expectedErr bool
+	}{
+		{"valid Schedule Action with base64 encoding payload", `{"type":"EdgeXMessageBus","contentType":"application/json","payload":"eyJrZXkiOiAiVmFsdWUifQ==","topic":"mock-topic"}`, false},
+		{"valid Schedule Action with JSON string payload", `{"type":"EdgeXMessageBus","contentType":"application/json","payload":"{\"key\": \"Value\"}","topic":"mock-topic"}`, false},
+		{"valid Schedule Action with JSON object payload", `{"type":"EdgeXMessageBus","contentType":"application/json","payload":{"key": "Value"},"topic":"mock-topic"}`, false},
+		{"invalid Schedule Action with invalid payload", `{"type":"EdgeXMessageBus","contentType":"application/json","payload":{key: "Value"},"topic":"mock-topic"}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a ScheduleAction
+			err := a.UnmarshalJSON([]byte(tt.request))
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestToScheduleJobModel(t *testing.T) {
 	result := ToScheduleJobModel(scheduleJob)
 	assert.Equal(t, scheduleJobModel, result, "ToScheduleJobModel did not result in ScheduleJob model")

--- a/models/device.go
+++ b/models/device.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,9 +29,10 @@ type ProtocolProperties map[string]any
 // AdminState controls the range of values which constitute valid administrative states for a device
 type AdminState string
 
+// AssignAdminState provides a default value "UNLOCKED" to AdminState
 func AssignAdminState(dtoAdminState string) AdminState {
 	if dtoAdminState == "" {
-		return Unlocked
+		return AdminState(Unlocked)
 	}
 	return AdminState(dtoAdminState)
 }

--- a/models/device.go
+++ b/models/device.go
@@ -29,5 +29,12 @@ type ProtocolProperties map[string]any
 // AdminState controls the range of values which constitute valid administrative states for a device
 type AdminState string
 
+func AssignAdminState(dtoAdminState string) AdminState {
+	if dtoAdminState == "" {
+		return Unlocked
+	}
+	return AdminState(dtoAdminState)
+}
+
 // OperatingState is an indication of the operations of the device.
 type OperatingState string


### PR DESCRIPTION
closes: #915

- Make AdminState as an optional field with UNLOCKED as default value
- Enhance the models and DTOs for Cron Scheduler service

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->