### PR TITLE
fix: Fix missing AutoTriggerMissedRecords for patching schedule job

### DIFF
--- a/dtos/requests/schedulejob.go
+++ b/dtos/requests/schedulejob.go
@@ -97,6 +97,9 @@ func ReplaceScheduleJobModelFieldsWithDTO(ds *models.ScheduleJob, patch dtos.Upd
 	if patch.AdminState != nil {
 		ds.AdminState = models.AdminState(*patch.AdminState)
 	}
+	if patch.AutoTriggerMissedRecords != nil {
+		ds.AutoTriggerMissedRecords = *patch.AutoTriggerMissedRecords
+	}
 	if patch.Labels != nil {
 		ds.Labels = patch.Labels
 	}

--- a/dtos/requests/schedulejob_test.go
+++ b/dtos/requests/schedulejob_test.go
@@ -46,6 +46,7 @@ var (
 			},
 		},
 	}
+	testAutoTriggerMissedRecords = true
 )
 
 func addScheduleJobRequestData() AddScheduleJobRequest {
@@ -64,12 +65,14 @@ func updateScheduleJobData() dtos.UpdateScheduleJob {
 	definition := testScheduleDef
 	actions := testScheduleActions
 	labels := testScheduleJobLabels
+	autoTriggerMissedRecords := testAutoTriggerMissedRecords
 	return dtos.UpdateScheduleJob{
-		Id:         &id,
-		Name:       &name,
-		Definition: &definition,
-		Actions:    actions,
-		Labels:     labels,
+		Id:                       &id,
+		Name:                     &name,
+		Definition:               &definition,
+		Actions:                  actions,
+		AutoTriggerMissedRecords: &autoTriggerMissedRecords,
+		Labels:                   labels,
 	}
 }
 
@@ -262,5 +265,6 @@ func TestReplaceScheduleJobModelFieldsWithDTO(t *testing.T) {
 	expectedDef := dtos.ToScheduleDefModel(*patch.Definition)
 	assert.Equal(t, testScheduleJobName, job.Name)
 	assert.Equal(t, expectedActions, job.Actions)
+	assert.Equal(t, testAutoTriggerMissedRecords, job.AutoTriggerMissedRecords)
 	assert.Equal(t, expectedDef, job.Definition)
 }


### PR DESCRIPTION
Fix missing AutoTriggerMissedRecords for patching schedule job in ReplaceScheduleJobModelFieldsWithDTO.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->