### PR TITLE
feat: Allow reading value to be null

### DIFF
--- a/dtos/event_test.go
+++ b/dtos/event_test.go
@@ -151,7 +151,7 @@ func TestEvent_AddSimpleReading(t *testing.T) {
 		assert.Equal(t, expectedDeviceName, actual.DeviceName)
 		assert.Equal(t, expectedReadingDetails[index].resourceName, actual.ResourceName)
 		assert.Equal(t, expectedReadingDetails[index].valueType, actual.ValueType)
-		assert.Equal(t, expectedReadingDetails[index].value, actual.Value)
+		assert.Equal(t, expectedReadingDetails[index].value, *actual.Value)
 		assert.NotZero(t, actual.Origin)
 	}
 }

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var TestSimpleValue = "500"
+
 var testSimpleReading = BaseReading{
 	Id:           TestUUID,
 	DeviceName:   TestDeviceName,
@@ -26,7 +28,7 @@ var testSimpleReading = BaseReading{
 	Units:        TestUnit,
 	Tags:         testTags,
 	SimpleReading: SimpleReading{
-		Value: TestValue,
+		Value: &TestSimpleValue,
 	},
 }
 
@@ -83,7 +85,7 @@ func TestFromReadingModelToDTO(t *testing.T) {
 		Units:        TestUnit,
 		Tags:         testTags,
 		SimpleReading: SimpleReading{
-			Value: TestValue,
+			Value: &TestSimpleValue,
 		},
 	}
 
@@ -148,7 +150,7 @@ func TestNewSimpleReading(t *testing.T) {
 			assert.Equal(t, expectedDeviceName, actual.DeviceName)
 			assert.Equal(t, expectedResourceName, actual.ResourceName)
 			assert.Equal(t, tt.expectedValueType, actual.ValueType)
-			assert.Equal(t, tt.expectedValue, actual.Value)
+			assert.Equal(t, tt.expectedValue, *actual.Value)
 			assert.NotZero(t, actual.Origin)
 		})
 	}
@@ -194,6 +196,60 @@ func TestNewSimpleReadingError(t *testing.T) {
 	}
 }
 
+func TestNewSimpleReadingWithNilValue(t *testing.T) {
+	expectedDeviceName := TestDeviceName
+	expectedProfileName := TestDeviceProfileName
+	expectedResourceName := TestDeviceResourceName
+
+	var nilValue *string = nil
+
+	tests := []struct {
+		name              string
+		expectedValueType string
+		value             any
+		expectedValue     any
+	}{
+		{"Simple Boolean", common.ValueTypeBool, nil, nilValue},
+		{"Simple String", common.ValueTypeString, nil, nilValue},
+		{"Simple Uint8", common.ValueTypeUint8, nil, nilValue},
+		{"Simple Uint16", common.ValueTypeUint16, nil, nilValue},
+		{"Simple Uint32", common.ValueTypeUint32, nil, nilValue},
+		{"Simple uint64", common.ValueTypeUint64, nil, nilValue},
+		{"Simple int8", common.ValueTypeInt8, nil, nilValue},
+		{"Simple int16", common.ValueTypeInt16, nil, nilValue},
+		{"Simple int32", common.ValueTypeInt32, nil, nilValue},
+		{"Simple int64", common.ValueTypeInt64, nil, nilValue},
+		{"Simple Float32", common.ValueTypeFloat32, nil, nilValue},
+		{"Simple Float64", common.ValueTypeFloat64, nil, nilValue},
+		{"Simple Boolean Array", common.ValueTypeBoolArray, nil, nilValue},
+		{"Simple String Array", common.ValueTypeStringArray, nil, nilValue},
+		{"Simple Uint8 Array", common.ValueTypeUint8Array, nil, nilValue},
+		{"Simple Uint16 Array", common.ValueTypeUint16Array, nil, nilValue},
+		{"Simple Uint32 Array", common.ValueTypeUint32Array, nil, nilValue},
+		{"Simple Uint64 Array", common.ValueTypeUint64Array, nil, nilValue},
+		{"Simple Int8 Array", common.ValueTypeInt8Array, nil, nilValue},
+		{"Simple Int16 Array", common.ValueTypeInt16Array, nil, nilValue},
+		{"Simple Int32 Array", common.ValueTypeInt32Array, nil, nilValue},
+		{"Simple Int64 Array", common.ValueTypeInt64Array, nil, nilValue},
+		{"Simple Float32 Array", common.ValueTypeFloat32Array, nil, nilValue},
+		{"Simple Float64 Array", common.ValueTypeFloat64Array, nil, nilValue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := NewSimpleReading(expectedProfileName, expectedDeviceName, expectedResourceName, tt.expectedValueType, tt.value)
+			require.NoError(t, err)
+			assert.NotEmpty(t, actual.Id)
+			assert.Equal(t, expectedProfileName, actual.ProfileName)
+			assert.Equal(t, expectedDeviceName, actual.DeviceName)
+			assert.Equal(t, expectedResourceName, actual.ResourceName)
+			assert.Equal(t, tt.expectedValueType, actual.ValueType)
+			assert.Equal(t, tt.expectedValue, actual.Value)
+			assert.NotZero(t, actual.Origin)
+		})
+	}
+}
+
 func TestNewBinaryReading(t *testing.T) {
 	expectedDeviceName := TestDeviceName
 	expectedProfileName := TestDeviceProfileName
@@ -201,6 +257,26 @@ func TestNewBinaryReading(t *testing.T) {
 
 	expectedValueType := common.ValueTypeBinary
 	expectedBinaryValue := []byte("hello word, any one out there?")
+	expectedMediaType := "application/text"
+
+	actual := NewBinaryReading(expectedProfileName, expectedDeviceName, expectedResourceName, expectedBinaryValue, expectedMediaType)
+
+	assert.NotEmpty(t, actual.Id)
+	assert.Equal(t, expectedProfileName, actual.ProfileName)
+	assert.Equal(t, expectedDeviceName, actual.DeviceName)
+	assert.Equal(t, expectedResourceName, actual.ResourceName)
+	assert.Equal(t, expectedValueType, actual.ValueType)
+	assert.Equal(t, expectedBinaryValue, actual.BinaryValue)
+	assert.NotZero(t, actual.Origin)
+}
+
+func TestNewBinaryReadingWithNilValue(t *testing.T) {
+	expectedDeviceName := TestDeviceName
+	expectedProfileName := TestDeviceProfileName
+	expectedResourceName := TestDeviceResourceName
+
+	expectedValueType := common.ValueTypeBinary
+	var expectedBinaryValue []byte = nil
 	expectedMediaType := "application/text"
 
 	actual := NewBinaryReading(expectedProfileName, expectedDeviceName, expectedResourceName, expectedBinaryValue, expectedMediaType)
@@ -252,6 +328,24 @@ func TestNewObjectReadingWithArray(t *testing.T) {
 	}}
 
 	actual := NewObjectReadingWithArray(expectedProfileName, expectedDeviceName, expectedResourceName, expectedValue)
+
+	assert.NotEmpty(t, actual.Id)
+	assert.Equal(t, expectedProfileName, actual.ProfileName)
+	assert.Equal(t, expectedDeviceName, actual.DeviceName)
+	assert.Equal(t, expectedResourceName, actual.ResourceName)
+	assert.Equal(t, expectedValueType, actual.ValueType)
+	assert.Equal(t, expectedValue, actual.ObjectValue)
+	assert.NotZero(t, actual.Origin)
+}
+
+func TestNewObjectReadingWithNilValue(t *testing.T) {
+	expectedDeviceName := TestDeviceName
+	expectedProfileName := TestDeviceProfileName
+	expectedResourceName := TestDeviceResourceName
+	expectedValueType := common.ValueTypeObject
+	var expectedValue any = nil
+
+	actual := NewObjectReading(expectedProfileName, expectedDeviceName, expectedResourceName, expectedValue)
 
 	assert.NotEmpty(t, actual.Id)
 	assert.Equal(t, expectedProfileName, actual.ProfileName)

--- a/dtos/requests/event.go
+++ b/dtos/requests/event.go
@@ -42,6 +42,9 @@ func (a AddEventRequest) Validate() error {
 	// Otherwise error will occur as only one of them exists
 	// Therefore, need to validate the nested BinaryReading and SimpleReading struct here
 	for _, r := range a.Event.Readings {
+		if r.Value == nil {
+			continue // since we support nil value, skip checking
+		}
 		if err := r.Validate(); err != nil {
 			return err
 		}

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -77,7 +77,7 @@ func TestAddEventRequest_Validate(t *testing.T) {
 	invalidReadingInvalidValueType.Event.Readings[0].ValueType = "BadType"
 
 	invalidSimpleReadingNoValue := eventRequestData()
-	invalidSimpleReadingNoValue.Event.Readings[0].SimpleReading.Value = ""
+	invalidSimpleReadingNoValue.Event.Readings[0].SimpleReading.Value = &emptyString
 
 	invalidBinaryReadingNoValue := eventRequestData()
 	invalidBinaryReadingNoValue.Event.Readings[0].ValueType = common.ValueTypeBinary


### PR DESCRIPTION
Allow reading value to be null

closes: #931

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run device simple and test nil value.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->