### PR TITLE
refactor: Using isNull instead of nil reading value

### DIFF
--- a/dtos/event.go
+++ b/dtos/event.go
@@ -82,6 +82,11 @@ func (e *Event) AddObjectReading(resourceName string, objectValue interface{}) {
 	e.Readings = append(e.Readings, NewObjectReading(e.ProfileName, e.DeviceName, resourceName, objectValue))
 }
 
+// AddNullReading adds a simple reading with null value to the Event
+func (e *Event) AddNullReading(resourceName string, valueType string) {
+	e.Readings = append(e.Readings, NewNullReading(e.ProfileName, e.DeviceName, resourceName, valueType))
+}
+
 // ToXML provides a XML representation of the Event as a string
 func (e *Event) ToXML() (string, error) {
 	eventXml, err := xml.Marshal(e)

--- a/dtos/event_test.go
+++ b/dtos/event_test.go
@@ -6,6 +6,7 @@
 package dtos
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -151,7 +152,7 @@ func TestEvent_AddSimpleReading(t *testing.T) {
 		assert.Equal(t, expectedDeviceName, actual.DeviceName)
 		assert.Equal(t, expectedReadingDetails[index].resourceName, actual.ResourceName)
 		assert.Equal(t, expectedReadingDetails[index].valueType, actual.ValueType)
-		assert.Equal(t, expectedReadingDetails[index].value, *actual.Value)
+		assert.Equal(t, expectedReadingDetails[index].value, actual.Value)
 		assert.NotZero(t, actual.Origin)
 	}
 }
@@ -205,4 +206,58 @@ func TestEvent_AddObjectReading(t *testing.T) {
 	assert.Equal(t, expectedValueType, actual.ValueType)
 	assert.Equal(t, expectedValue, actual.ObjectValue)
 	assert.NotZero(t, actual.Origin)
+}
+
+func TestEvent_MarshalNullReading(t *testing.T) {
+	testEvent := NewEvent(TestDeviceProfileName, TestDeviceName, TestSourceName)
+	testEvent.AddNullReading(common.ValueTypeInt8, common.ValueTypeInt8)
+	testEvent.AddNullReading(common.ValueTypeInt16, common.ValueTypeInt16)
+	testEvent.AddNullReading(common.ValueTypeInt32, common.ValueTypeInt32)
+	testEvent.AddNullReading(common.ValueTypeInt64, common.ValueTypeInt64)
+	testEvent.AddNullReading(common.ValueTypeUint8, common.ValueTypeUint8)
+	testEvent.AddNullReading(common.ValueTypeUint16, common.ValueTypeUint16)
+	testEvent.AddNullReading(common.ValueTypeUint32, common.ValueTypeUint32)
+	testEvent.AddNullReading(common.ValueTypeUint64, common.ValueTypeUint64)
+	testEvent.AddNullReading(common.ValueTypeInt8Array, common.ValueTypeInt8Array)
+	testEvent.AddNullReading(common.ValueTypeInt16Array, common.ValueTypeInt16Array)
+	testEvent.AddNullReading(common.ValueTypeInt32Array, common.ValueTypeInt32Array)
+	testEvent.AddNullReading(common.ValueTypeInt64Array, common.ValueTypeInt64Array)
+	testEvent.AddNullReading(common.ValueTypeUint8Array, common.ValueTypeUint8Array)
+	testEvent.AddNullReading(common.ValueTypeUint16Array, common.ValueTypeUint16Array)
+	testEvent.AddNullReading(common.ValueTypeUint32Array, common.ValueTypeUint32Array)
+	testEvent.AddNullReading(common.ValueTypeUint64Array, common.ValueTypeUint64Array)
+	testEvent.AddNullReading(common.ValueTypeFloat32, common.ValueTypeFloat32)
+	testEvent.AddNullReading(common.ValueTypeFloat64, common.ValueTypeFloat64)
+	testEvent.AddNullReading(common.ValueTypeFloat32Array, common.ValueTypeFloat32Array)
+	testEvent.AddNullReading(common.ValueTypeFloat64Array, common.ValueTypeFloat64Array)
+	testEvent.AddNullReading(common.ValueTypeObject, common.ValueTypeObject)
+	testEvent.AddNullReading(common.ValueTypeObjectArray, common.ValueTypeObjectArray)
+	testEvent.AddNullReading(common.ValueTypeBinary, common.ValueTypeBinary)
+
+	for _, actual := range testEvent.Readings {
+		assert.True(t, actual.isNull)
+	}
+
+	jsonEncoded, err := json.Marshal(testEvent)
+	assert.NoError(t, err)
+
+	var result Event
+	err = json.Unmarshal(jsonEncoded, &result)
+	assert.NoError(t, err)
+
+	assert.Equal(t, testEvent.DeviceName, result.DeviceName)
+	assert.Equal(t, testEvent.ProfileName, result.ProfileName)
+	assert.Equal(t, testEvent.SourceName, result.SourceName)
+	assert.Equal(t, len(testEvent.Readings), len(result.Readings))
+
+	for i, r := range result.Readings {
+		assert.Equal(t, testEvent.Readings[i].DeviceName, r.DeviceName)
+		assert.Equal(t, testEvent.Readings[i].ProfileName, r.ProfileName)
+		assert.Equal(t, testEvent.Readings[i].ResourceName, r.ResourceName)
+		assert.Equal(t, testEvent.Readings[i].ValueType, r.ValueType)
+		assert.True(t, r.isNull, "isNull should be true after marshaling")
+		assert.Empty(t, r.Value, "reading value should be empty after marshaling")
+		assert.Empty(t, r.ObjectValue, "reading objectValue should be empty after marshaling")
+		assert.Empty(t, r.BinaryValue, "reading binaryValue should be empty after marshaling")
+	}
 }

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var TestSimpleValue = "500"
-
 var testSimpleReading = BaseReading{
 	Id:           TestUUID,
 	DeviceName:   TestDeviceName,
@@ -28,7 +26,7 @@ var testSimpleReading = BaseReading{
 	Units:        TestUnit,
 	Tags:         testTags,
 	SimpleReading: SimpleReading{
-		Value: &TestSimpleValue,
+		Value: TestValue,
 	},
 }
 
@@ -45,7 +43,7 @@ func Test_ToReadingModel(t *testing.T) {
 			Units:        TestUnit,
 			Tags:         testTags,
 		},
-		Value: &TestSimpleValue,
+		Value: TestValue,
 	}
 	tests := []struct {
 		name    string
@@ -73,7 +71,7 @@ func TestFromReadingModelToDTO(t *testing.T) {
 			Units:        TestUnit,
 			Tags:         testTags,
 		},
-		Value: &TestSimpleValue,
+		Value: TestValue,
 	}
 	expectedDTO := BaseReading{
 		Id:           TestUUID,
@@ -85,7 +83,7 @@ func TestFromReadingModelToDTO(t *testing.T) {
 		Units:        TestUnit,
 		Tags:         testTags,
 		SimpleReading: SimpleReading{
-			Value: &TestSimpleValue,
+			Value: TestValue,
 		},
 	}
 
@@ -150,7 +148,7 @@ func TestNewSimpleReading(t *testing.T) {
 			assert.Equal(t, expectedDeviceName, actual.DeviceName)
 			assert.Equal(t, expectedResourceName, actual.ResourceName)
 			assert.Equal(t, tt.expectedValueType, actual.ValueType)
-			assert.Equal(t, tt.expectedValue, *actual.Value)
+			assert.Equal(t, tt.expectedValue, actual.Value)
 			assert.NotZero(t, actual.Origin)
 		})
 	}
@@ -196,55 +194,56 @@ func TestNewSimpleReadingError(t *testing.T) {
 	}
 }
 
-func TestNewSimpleReadingWithNilValue(t *testing.T) {
+func TestNullReading(t *testing.T) {
 	expectedDeviceName := TestDeviceName
 	expectedProfileName := TestDeviceProfileName
 	expectedResourceName := TestDeviceResourceName
 
-	var nilValue *string = nil
-
 	tests := []struct {
 		name              string
 		expectedValueType string
-		value             any
-		expectedValue     any
 	}{
-		{"Simple Boolean", common.ValueTypeBool, nil, nilValue},
-		{"Simple String", common.ValueTypeString, nil, nilValue},
-		{"Simple Uint8", common.ValueTypeUint8, nil, nilValue},
-		{"Simple Uint16", common.ValueTypeUint16, nil, nilValue},
-		{"Simple Uint32", common.ValueTypeUint32, nil, nilValue},
-		{"Simple uint64", common.ValueTypeUint64, nil, nilValue},
-		{"Simple int8", common.ValueTypeInt8, nil, nilValue},
-		{"Simple int16", common.ValueTypeInt16, nil, nilValue},
-		{"Simple int32", common.ValueTypeInt32, nil, nilValue},
-		{"Simple int64", common.ValueTypeInt64, nil, nilValue},
-		{"Simple Float32", common.ValueTypeFloat32, nil, nilValue},
-		{"Simple Float64", common.ValueTypeFloat64, nil, nilValue},
-		{"Simple Boolean Array", common.ValueTypeBoolArray, nil, nilValue},
-		{"Simple String Array", common.ValueTypeStringArray, nil, nilValue},
-		{"Simple Uint8 Array", common.ValueTypeUint8Array, nil, nilValue},
-		{"Simple Uint16 Array", common.ValueTypeUint16Array, nil, nilValue},
-		{"Simple Uint32 Array", common.ValueTypeUint32Array, nil, nilValue},
-		{"Simple Uint64 Array", common.ValueTypeUint64Array, nil, nilValue},
-		{"Simple Int8 Array", common.ValueTypeInt8Array, nil, nilValue},
-		{"Simple Int16 Array", common.ValueTypeInt16Array, nil, nilValue},
-		{"Simple Int32 Array", common.ValueTypeInt32Array, nil, nilValue},
-		{"Simple Int64 Array", common.ValueTypeInt64Array, nil, nilValue},
-		{"Simple Float32 Array", common.ValueTypeFloat32Array, nil, nilValue},
-		{"Simple Float64 Array", common.ValueTypeFloat64Array, nil, nilValue},
+		{"Simple Boolean", common.ValueTypeBool},
+		{"Simple String", common.ValueTypeString},
+		{"Simple Uint8", common.ValueTypeUint8},
+		{"Simple Uint16", common.ValueTypeUint16},
+		{"Simple Uint32", common.ValueTypeUint32},
+		{"Simple uint64", common.ValueTypeUint64},
+		{"Simple int8", common.ValueTypeInt8},
+		{"Simple int16", common.ValueTypeInt16},
+		{"Simple int32", common.ValueTypeInt32},
+		{"Simple int64", common.ValueTypeInt64},
+		{"Simple Float32", common.ValueTypeFloat32},
+		{"Simple Float64", common.ValueTypeFloat64},
+		{"Simple Boolean Array", common.ValueTypeBoolArray},
+		{"Simple String Array", common.ValueTypeStringArray},
+		{"Simple Uint8 Array", common.ValueTypeUint8Array},
+		{"Simple Uint16 Array", common.ValueTypeUint16Array},
+		{"Simple Uint32 Array", common.ValueTypeUint32Array},
+		{"Simple Uint64 Array", common.ValueTypeUint64Array},
+		{"Simple Int8 Array", common.ValueTypeInt8Array},
+		{"Simple Int16 Array", common.ValueTypeInt16Array},
+		{"Simple Int32 Array", common.ValueTypeInt32Array},
+		{"Simple Int64 Array", common.ValueTypeInt64Array},
+		{"Simple Float32 Array", common.ValueTypeFloat32Array},
+		{"Simple Float64 Array", common.ValueTypeFloat64Array},
+		{"Object", common.ValueTypeObject},
+		{"Object Array", common.ValueTypeObjectArray},
+		{"Binary", common.ValueTypeBinary},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := NewSimpleReading(expectedProfileName, expectedDeviceName, expectedResourceName, tt.expectedValueType, tt.value)
-			require.NoError(t, err)
+			actual := NewNullReading(expectedProfileName, expectedDeviceName, expectedResourceName, tt.expectedValueType)
 			assert.NotEmpty(t, actual.Id)
 			assert.Equal(t, expectedProfileName, actual.ProfileName)
 			assert.Equal(t, expectedDeviceName, actual.DeviceName)
 			assert.Equal(t, expectedResourceName, actual.ResourceName)
 			assert.Equal(t, tt.expectedValueType, actual.ValueType)
-			assert.Equal(t, tt.expectedValue, actual.Value)
+			assert.True(t, actual.isNull)
+			assert.Empty(t, actual.Value)
+			assert.Empty(t, actual.ObjectValue)
+			assert.Empty(t, actual.BinaryValue)
 			assert.NotZero(t, actual.Origin)
 		})
 	}

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -77,7 +77,7 @@ func TestAddEventRequest_Validate(t *testing.T) {
 	invalidReadingInvalidValueType.Event.Readings[0].ValueType = "BadType"
 
 	invalidSimpleReadingNoValue := eventRequestData()
-	invalidSimpleReadingNoValue.Event.Readings[0].SimpleReading.Value = &emptyString
+	invalidSimpleReadingNoValue.Event.Readings[0].SimpleReading.Value = emptyString
 
 	invalidBinaryReadingNoValue := eventRequestData()
 	invalidBinaryReadingNoValue.Event.Readings[0].ValueType = common.ValueTypeBinary
@@ -90,13 +90,13 @@ func TestAddEventRequest_Validate(t *testing.T) {
 	invalidBinaryReadingNoMedia.Event.Readings[0].BinaryReading.BinaryValue = []byte(TestReadingBinaryValue)
 
 	nilBinaryReadingNoMedia := eventRequestData()
-	nilBinaryReadingNoMedia.Event.Readings[0].ValueType = common.ValueTypeBinary
+	nilBinaryReadingNoMedia.Event.Readings[0] = dtos.NewNullReading(TestDeviceProfileName, TestDeviceName, TestDeviceResourceName, common.ValueTypeBinary)
 
 	nilSimpleReading := eventRequestData()
-	nilSimpleReading.Event.Readings[0].SimpleReading.Value = nil
+	nilSimpleReading.Event.Readings[0] = dtos.NewNullReading(TestDeviceProfileName, TestDeviceName, TestDeviceResourceName, common.ValueTypeUint8)
 
 	nilObjectReading := eventRequestData()
-	nilObjectReading.Event.Readings[0].ValueType = common.ValueTypeObject
+	nilObjectReading.Event.Readings[0] = dtos.NewNullReading(TestDeviceProfileName, TestDeviceName, TestDeviceResourceName, common.ValueTypeObject)
 
 	tests := []struct {
 		name        string
@@ -293,7 +293,6 @@ func TestAddEvent_UnmarshalCBOR(t *testing.T) {
 
 func Test_AddEventReqToEventModels(t *testing.T) {
 	valid := eventRequestData()
-	testReadingValue := "45"
 	s := models.SimpleReading{
 		BaseReading: models.BaseReading{
 			Id:           ExampleUUID,
@@ -303,7 +302,7 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 			Origin:       TestOriginTime,
 			ValueType:    common.ValueTypeUint8,
 		},
-		Value: &testReadingValue,
+		Value: "45",
 	}
 	expectedEventModel := models.Event{
 		Id:          ExampleUUID,

--- a/models/reading.go
+++ b/models/reading.go
@@ -24,7 +24,19 @@ type BinaryReading struct {
 
 type SimpleReading struct {
 	BaseReading `json:",inline"`
-	Value       *string
+	Value       string
+}
+
+type NullReading struct {
+	BaseReading `json:",inline"`
+	Value       any
+}
+
+func NewNullReading(b BaseReading) NullReading {
+	return NullReading{
+		BaseReading: b,
+		Value:       nil,
+	}
 }
 
 type ObjectReading struct {
@@ -44,3 +56,4 @@ type Reading interface {
 func (b BinaryReading) GetBaseReading() BaseReading { return b.BaseReading }
 func (s SimpleReading) GetBaseReading() BaseReading { return s.BaseReading }
 func (o ObjectReading) GetBaseReading() BaseReading { return o.BaseReading }
+func (n NullReading) GetBaseReading() BaseReading   { return n.BaseReading }


### PR DESCRIPTION
Using isNull to indicate the reading value should be nul after marshaling.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->