### PR TITLE
feat: Add onChangeThreshold in Device AutoEvent

### DIFF
--- a/dtos/autoevent.go
+++ b/dtos/autoevent.go
@@ -10,17 +10,19 @@ import (
 )
 
 type AutoEvent struct {
-	Interval   string `json:"interval" yaml:"interval" validate:"required,edgex-dto-duration"`
-	OnChange   bool   `json:"onChange" yaml:"onChange"`
-	SourceName string `json:"sourceName" yaml:"sourceName" validate:"required"`
+	Interval          string  `json:"interval" yaml:"interval" validate:"required,edgex-dto-duration"`
+	OnChange          bool    `json:"onChange" yaml:"onChange"`
+	OnChangeThreshold float64 `json:"onChangeThreshold" yaml:"onChangeThreshold" validate:"gte=0"`
+	SourceName        string  `json:"sourceName" yaml:"sourceName" validate:"required"`
 }
 
 // ToAutoEventModel transforms the AutoEvent DTO to the AutoEvent model
 func ToAutoEventModel(a AutoEvent) models.AutoEvent {
 	return models.AutoEvent{
-		Interval:   a.Interval,
-		OnChange:   a.OnChange,
-		SourceName: a.SourceName,
+		Interval:          a.Interval,
+		OnChange:          a.OnChange,
+		OnChangeThreshold: a.OnChangeThreshold,
+		SourceName:        a.SourceName,
 	}
 }
 
@@ -36,9 +38,10 @@ func ToAutoEventModels(autoEventDTOs []AutoEvent) []models.AutoEvent {
 // FromAutoEventModelToDTO transforms the AutoEvent model to the AutoEvent DTO
 func FromAutoEventModelToDTO(a models.AutoEvent) AutoEvent {
 	return AutoEvent{
-		Interval:   a.Interval,
-		OnChange:   a.OnChange,
-		SourceName: a.SourceName,
+		Interval:          a.Interval,
+		OnChange:          a.OnChange,
+		OnChangeThreshold: a.OnChangeThreshold,
+		SourceName:        a.SourceName,
 	}
 }
 

--- a/dtos/requests/provisionwatcher_test.go
+++ b/dtos/requests/provisionwatcher_test.go
@@ -194,7 +194,7 @@ func TestAddProvisionWatcherReqToProvisionWatcherModels(t *testing.T) {
 				ProfileName: TestDeviceProfileName,
 				AdminState:  models.Locked,
 				AutoEvents: []models.AutoEvent{
-					{SourceName: "TestDevice", Interval: "300ms", OnChange: true},
+					{SourceName: "TestDevice", Interval: "300ms", OnChange: true, OnChangeThreshold: 0.01},
 				},
 			},
 		},

--- a/models/autoevent.go
+++ b/models/autoevent.go
@@ -6,7 +6,8 @@
 package models
 
 type AutoEvent struct {
-	Interval   string
-	OnChange   bool
-	SourceName string
+	Interval          string
+	OnChange          bool
+	OnChangeThreshold float64
+	SourceName        string
 }


### PR DESCRIPTION
The onChange flag in Device AutoEvent can prevent any non changed values sent out. The onChangeThreshold could provide the advanced feature, and the default value is 0, any changed value that exceeds (>) bounds shall be published. For example, Current_value - Current_prev > 0.01 shall be published where "Current_value" is the new value and "Current_prev" is the previously published value.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->