### PR TITLE
fix: Allow binary reading value to be empty

### DIFF
--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -41,7 +41,7 @@ type SimpleReading struct {
 }
 
 type BinaryReading struct {
-	BinaryValue []byte `json:"binaryValue,omitempty" validate:"omitempty,gt=0"`
+	BinaryValue []byte `json:"binaryValue,omitempty" validate:"omitempty"`
 	MediaType   string `json:"mediaType,omitempty" validate:"required_with=BinaryValue"`
 }
 

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -120,7 +120,7 @@ func TestAddEventRequest_Validate(t *testing.T) {
 		{"invalid AddEventRequest, no Reading ValueType", invalidReadingNoValueType, true},
 		{"invalid AddEventRequest, invalid Reading ValueType", invalidReadingInvalidValueType, true},
 		{"invalid AddEventRequest, no SimpleReading Value", invalidSimpleReadingNoValue, true},
-		{"invalid AddEventRequest, no BinaryReading BinaryValue", invalidBinaryReadingNoValue, true},
+		{"valid AddEventRequest, no BinaryReading BinaryValue", invalidBinaryReadingNoValue, false},
 		{"invalid AddEventRequest, no BinaryReading MediaType", invalidBinaryReadingNoMedia, true},
 		{"valid AddEventRequest, nil Binary value", nilBinaryReadingNoMedia, false},
 		{"valid AddEventRequest, nil Simple value", nilSimpleReading, false},


### PR DESCRIPTION
Since we accept the nil reading value, the binary reading value can be empty

fixes edgex-go#4986

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run make test.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->