### PR TITLE
fix: Generate proper error message for 'unique' validation tag

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -1,7 +1,7 @@
 //go:build !no_dto_validator
 
 //
-// Copyright (C) 2020-2024 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -103,6 +103,13 @@ func getErrorMessage(e validator.FieldError) string {
 		msg = fmt.Sprintf("%s field should be one of %s", fieldName, fieldValue)
 	case "gt":
 		msg = fmt.Sprintf("%s field should greater than %s", fieldName, fieldValue)
+	case "unique":
+		// If the tag contains a field param, it means that the unique tag is used for a slice of struct
+		if fieldValue != "" {
+			msg = fmt.Sprintf("%s field should only contain unique elements with unique '%s' values", fieldName, fieldValue)
+		} else {
+			msg = fmt.Sprintf("%s field should only contain unique elements", fieldName)
+		}
 	case dtoDurationTag:
 		msg = fmt.Sprintf("%s field should follows the ISO 8601 Durations format, e.g.,100ms, 24h, or be greater than or equal to the minimum value %s ", fieldName, fieldValue)
 	case dtoUuidTag:

--- a/common/validator_test.go
+++ b/common/validator_test.go
@@ -1,0 +1,63 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TestItem struct {
+	Name                string
+	UniqueArray         []string   `validate:"unique"`
+	UniqueSliceOfStruct []TestItem `validate:"unique=Name"` // only one field is supported
+}
+
+// The test only covers the validation of the "unique" tag at the time of writing this comment.
+// TODO: Add more tests to cover other validation tags if needed
+
+// TestValidate tests the Validate function
+func TestValidate(t *testing.T) {
+
+	validUniqueArray := TestItem{
+		UniqueArray: []string{"a", "b", "c"},
+	}
+	invalidUniqueArray := TestItem{
+		UniqueArray: []string{"a", "a", "c"},
+	}
+	validUniqueSliceOfSturct := TestItem{
+		UniqueSliceOfStruct: []TestItem{
+			{Name: "a"},
+			{Name: "b"},
+		},
+	}
+	invalidUniqueSliceOfSturct := TestItem{
+		UniqueSliceOfStruct: []TestItem{
+			{Name: "a"},
+			{Name: "a"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		input    any
+		expected bool
+	}{
+		{"valid, unique tag for arrays and slices", validUniqueArray, false},
+		{"invalid, unique tag for arrays and slices", invalidUniqueArray, true},
+		{"valid, unique tag for slices of struct", validUniqueSliceOfSturct, false},
+		{"invalid, unique tag for slices of struct", invalidUniqueSliceOfSturct, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.input)
+			if tt.expected {
+				require.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #966

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```go
type User struct {
	Name  string
	Roles []string `validate:"unique"`
}

type Group struct {
	Users []User `validate:"unique=Name"` // only one field can be specified
}

func main() {
	user := User{
		Name:  "admin",
		Roles: []string{"admin", "admin"},
	}

	err := common.Validate(user)
	// User.Roles field should only contain unique elements

	group := Group{
		Users: []User{
			{
				Name: "user1",
			},
			{
				Name: "user1",
			},
		},
	}

	err = common.Validate(group)
	// Group.Users field should only contain unique elements with unique 'Name' values
}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->