### PR TITLE
fix: Allow Auto event duration is empty

### DIFF
--- a/dtos/autoevent.go
+++ b/dtos/autoevent.go
@@ -21,7 +21,7 @@ type AutoEvent struct {
 type Retention struct {
 	MaxCap   int64  `json:"maxCap" yaml:"maxCap"`
 	MinCap   int64  `json:"minCap" yaml:"minCap"`
-	Duration string `json:"duration" yaml:"duration" validate:"edgex-dto-duration=0s"`
+	Duration string `json:"duration" yaml:"duration" validate:"omitempty,edgex-dto-duration=0s"`
 }
 
 // ToAutoEventModel transforms the AutoEvent DTO to the AutoEvent model


### PR DESCRIPTION
 Auto event duration should allow empty because the Core Metadata will apply the default value if duration is empty.

Close #987

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Test core metadata API with empty duration like below
```
curl 'http://localhost:59881/api/v3/device' \
--header 'Content-Type: application/json' \
--data '[{
    "device": {
      "name": "testDevice",
      "adminState": "UNLOCKED",
      "operatingState": "UP",
      "location": {},
      "serviceName": "device-virtual",
      "profileName": "Random-Boolean-Device",
      "autoEvents": [
        { "interval": "1s", "onChange": false, "sourceName": "Bool", 
       "retention": {"maxCap": 2000, "minCap": 1000, "duration":""}}
      ],
      "protocols": {
        "other": {}
        }
    },
    "apiVersion":"v3"
  }]
'
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->