### PR TITLE
fix: NewRESTAddress use http as default scheme

### DIFF
--- a/dtos/address.go
+++ b/dtos/address.go
@@ -69,6 +69,9 @@ type RESTAddress struct {
 }
 
 func NewRESTAddress(host string, port int, httpMethod string, scheme string) Address {
+	if scheme == "" {
+		scheme = common.HTTP
+	}
 	return Address{
 		Type:   common.REST,
 		Host:   host,


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/go-mod-core-contracts/issues/990

The PR https://github.com/edgexfoundry/go-mod-core-contracts/pull/986 set the scheme configurable in NewRESTAddress, but didn't consider a default value when scheme is empty string.

This commit will set http as the default value when scheme is an empty string.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->