### PR TITLE
fix: parse float to string with precision to a sufficient level

### DIFF
--- a/dtos/event_test.go
+++ b/dtos/event_test.go
@@ -147,7 +147,7 @@ func TestEvent_AddSimpleReading(t *testing.T) {
 		value        string
 	}{
 		{int32(12345), "myInt32", common.ValueTypeInt32, "12345"},
-		{float32(12345.4567), "myFloat32", common.ValueTypeFloat32, "1.234546e+04"},
+		{float32(12345.4567), "myFloat32", common.ValueTypeFloat32, "1.2345457e+04"},
 		{[]bool{false, true, false}, "myBoolArray", common.ValueTypeBoolArray, "[false, true, false]"},
 	}
 	expectedReadingsCount := len(expectedReadingDetails)

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -203,7 +203,24 @@ func convertFloatValue(valueType string, kind reflect.Kind, value any) (string, 
 		return "", err
 	}
 
-	return fmt.Sprintf("%e", value), nil
+	switch kind {
+	case reflect.Float32:
+		// as above has validated the value type/kind/value, it is safe to cast the value to float32 here
+		float32Val, ok := value.(float32)
+		if !ok {
+			return "", fmt.Errorf("unable to cast value to float32 for %s", valueType)
+		}
+		return strconv.FormatFloat(float64(float32Val), 'e', -1, 32), nil
+	case reflect.Float64:
+		// as above has validated the value type/kind/value, it is safe to cast the value to float64 here
+		float64Val, ok := value.(float64)
+		if !ok {
+			return "", fmt.Errorf("unable to cast value to float64 for %s", valueType)
+		}
+		return strconv.FormatFloat(float64Val, 'e', -1, 64), nil
+	default:
+		return "", fmt.Errorf("invalid kind %s to convert float value to string", kind.String())
+	}
 }
 
 func convertSimpleArrayValue(valueType string, kind reflect.Kind, value any) (string, error) {

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -124,8 +124,8 @@ func TestNewSimpleReading(t *testing.T) {
 		{"Simple int16", common.ValueTypeInt16, int16(-12345), "-12345"},
 		{"Simple int32", common.ValueTypeInt32, int32(-1234567890), "-1234567890"},
 		{"Simple int64", common.ValueTypeInt64, int64(-1234567890987654321), "-1234567890987654321"},
-		{"Simple Float32", common.ValueTypeFloat32, float32(123.456), "1.234560e+02"},
-		{"Simple Float64", common.ValueTypeFloat64, float64(123456789.0987654321), "1.234568e+08"},
+		{"Simple Float32", common.ValueTypeFloat32, float32(123.456), "1.23456e+02"},
+		{"Simple Float64", common.ValueTypeFloat64, float64(123456789.0987654321), "1.2345678909876543e+08"},
 		{"Simple Boolean Array", common.ValueTypeBoolArray, []bool{true, false}, "[true, false]"},
 		{"Simple String Array", common.ValueTypeStringArray, []string{"hello", "world"}, "[hello, world]"},
 		{"Simple Uint8 Array", common.ValueTypeUint8Array, []uint8{123, 21}, "[123, 21]"},
@@ -136,8 +136,8 @@ func TestNewSimpleReading(t *testing.T) {
 		{"Simple Int16 Array", common.ValueTypeInt16Array, []int16{-12345, 12345}, "[-12345, 12345]"},
 		{"Simple Int32 Array", common.ValueTypeInt32Array, []int32{-1234567890, 1234567890}, "[-1234567890, 1234567890]"},
 		{"Simple Int64 Array", common.ValueTypeInt64Array, []int64{-1234567890987654321, 1234567890987654321}, "[-1234567890987654321, 1234567890987654321]"},
-		{"Simple Float32 Array", common.ValueTypeFloat32Array, []float32{123.456, -654.321}, "[1.234560e+02, -6.543210e+02]"},
-		{"Simple Float64 Array", common.ValueTypeFloat64Array, []float64{123456789.0987654321, -987654321.123456789}, "[1.234568e+08, -9.876543e+08]"},
+		{"Simple Float32 Array", common.ValueTypeFloat32Array, []float32{123.456, -654.321}, "[1.23456e+02, -6.54321e+02]"},
+		{"Simple Float64 Array", common.ValueTypeFloat64Array, []float64{123456789.0987654321, -987654321.123456789}, "[1.2345678909876543e+08, -9.876543211234568e+08]"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/go-mod-core-contracts/issues/989

The original implemetation uses `fmt.Sprintf("%e", value)` to convert float to string, which will be truncated and rounded at the 6th decimal point. For a float value that needs more precision (not arbitrary precision), it's better to use `strconv.FormatFloat` with prec -1 to achieve the smallest number of digits necessary such that `ParseFloat` will return f exactly. Moreover, as `fmt.Sprintf` is for more general purpose and `strconv.FormatFloat` is specifically for formatting a float, the `strconv.FormatFloat` has better performance than `fmt.Sprintf`.

The benchmark test shows the `strconv.FormatFloat` takes 955.5 ns/op and `fmt.Sprintf` takes 1961 ns/op.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->