### PR TITLE
fix: Initialize resourcesCache for new DeviceProfileClient

### DIFF
--- a/clients/http/deviceprofile.go
+++ b/clients/http/deviceprofile.go
@@ -48,6 +48,7 @@ func NewDeviceProfileClientWithUrlCallback(baseUrlFunc clients.ClientBaseUrlFunc
 	return &DeviceProfileClient{
 		baseUrlFunc:           baseUrlFunc,
 		authInjector:          authInjector,
+		resourcesCache:        make(map[string]responses.DeviceResourceResponse),
 		enableNameFieldEscape: enableNameFieldEscape,
 	}
 }

--- a/clients/http/deviceprofile_test.go
+++ b/clients/http/deviceprofile_test.go
@@ -24,11 +24,19 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/responses"
 	edgexErrors "github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewDeviceProfileClientWithUrlCallback(t *testing.T) {
+	baseUrlFunc := func() (string, error) {
+		return "", nil
+	}
+	client := NewDeviceProfileClientWithUrlCallback(baseUrlFunc, &emptyAuthenticationInjector{}, true)
+	require.NotNil(t, client)
+	require.NotNil(t, client.(*DeviceProfileClient).resourcesCache)
+}
 
 func TestAddDeviceProfiles(t *testing.T) {
 	requestId := uuid.New().String()


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->
Closes #1000 
<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->