### PR TITLE
feat: Support day unit with edgex-dto-duration validation tag

### DIFF
--- a/common/validator_test.go
+++ b/common/validator_test.go
@@ -168,6 +168,10 @@ func TestParseDurationWithDay(t *testing.T) {
 	expectedDur6, err := time.ParseDuration(durStr6)
 	require.NoError(t, err)
 
+	durStr7 := "2.2d1.1d20m3h1h10m"
+	expectedDur7, err := time.ParseDuration("83.2h30m")
+	require.NoError(t, err)
+
 	tests := []struct {
 		name             string
 		durString        string
@@ -180,6 +184,7 @@ func TestParseDurationWithDay(t *testing.T) {
 		{"valid - duration string with fractional days and hour", durStr4, true, expectedDur4},
 		{"valid - duration string with hour and day at last", durStr5, true, expectedDur5},
 		{"valid - duration string with min in ms and max in h", durStr6, true, expectedDur6},
+		{"valid - duration string with repeated day and other time units", durStr7, true, expectedDur7},
 		{"invalid - duration string with valid day and invalid minute", "1dxxm", false, 0},
 		{"invalid - duration string with invalid day and valid second", "xxd30s", false, 0},
 		{"invalid duration string", "abc", false, 0},


### PR DESCRIPTION
Resolves #1013. Support day unit in edgex-dto-duration validation tag.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->