### PR TITLE
fix: Export ParseDurationWithDay function

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -138,7 +138,7 @@ func getErrorMessage(e validator.FieldError) string {
 func ValidateDuration(fl validator.FieldLevel) bool {
 	durationStr := fl.Field().String()
 
-	valid, duration := parseDurationWithDay(durationStr)
+	valid, duration := ParseDurationWithDay(durationStr)
 	if !valid {
 		return false
 	}
@@ -150,7 +150,7 @@ func ValidateDuration(fl validator.FieldLevel) bool {
 		if len(params) > 0 {
 			// Check if minimum value is defined from the tag param
 			if params[0] != "" {
-				valid, minDuration := parseDurationWithDay(params[0])
+				valid, minDuration := ParseDurationWithDay(params[0])
 				if !valid {
 					return false
 				}
@@ -163,7 +163,7 @@ func ValidateDuration(fl validator.FieldLevel) bool {
 			if len(params) > 1 {
 				// Check if maximum value is defined from the tag param
 				if params[1] != "" {
-					valid, maxDuration := parseDurationWithDay(params[1])
+					valid, maxDuration := ParseDurationWithDay(params[1])
 					if !valid {
 						return false
 					}
@@ -178,9 +178,9 @@ func ValidateDuration(fl validator.FieldLevel) bool {
 	return true
 }
 
-// parseDurationWithDay extends duration string parsing to support the "d" (day) unit.
+// ParseDurationWithDay extends duration string parsing to support the "d" (day) unit.
 // It returns a boolean indicating whether the string is valid, along with the corresponding Duration value.
-func parseDurationWithDay(durationStr string) (bool, time.Duration) {
+func ParseDurationWithDay(durationStr string) (bool, time.Duration) {
 	// Duration string should not be empty
 	if durationStr == "" {
 		return false, time.Duration(0)

--- a/common/validator_test.go
+++ b/common/validator_test.go
@@ -142,7 +142,7 @@ func TestValidateDuration_WithMinMax(t *testing.T) {
 	}
 }
 
-// TestParseDurationWithDay tests the parseDurationWithDay function
+// TestParseDurationWithDay tests the ParseDurationWithDay function
 func TestParseDurationWithDay(t *testing.T) {
 	durStr1 := "10h30m"
 	expectedDur1, err := time.ParseDuration(durStr1)
@@ -193,7 +193,7 @@ func TestParseDurationWithDay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, duration := parseDurationWithDay(tt.durString)
+			result, duration := ParseDurationWithDay(tt.durString)
 			require.Equal(t, tt.expectedResult, result)
 			if tt.expectedResult {
 				require.Equal(t, tt.expectedDuration, duration)


### PR DESCRIPTION
Relates #1013. Export the ParseDurationWithDay function for external use.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->