### PR TITLE
feat: Add new MultiReadingsAggregationResponse DTO

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -210,6 +210,7 @@ const (
 	KeyOnly       = "keyOnly"        //query string to specify if the response will only return the keys of the specified query key prefix, without values and metadata
 	Plaintext     = "plaintext"      //query string to specify if the response will return the stored plain text value of the key(s) without any encoding
 	Deregistered  = "deregistered"   //query string to specify if the response will return the registries of deregistered services
+	AggregateFunc = "aggregateFunc"  //query string to specify which SQL aggregate function to apply when calculating the reading value
 )
 
 // Constants related to the default value of query strings in the v3 service APIs
@@ -416,4 +417,13 @@ const (
 const (
 	EntityId = "entityId"
 	Token    = "token"
+)
+
+// Constants related to the supported SQL aggregate functions from reading APIs
+const (
+	MinFunc   = "MIN"
+	MaxFunc   = "MAX"
+	CountFunc = "COUNT"
+	SumFunc   = "SUM"
+	AvgFunc   = "AVG"
 )

--- a/dtos/responses/reading.go
+++ b/dtos/responses/reading.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,6 +22,13 @@ type MultiReadingsResponse struct {
 	Readings                          []dtos.BaseReading `json:"readings"`
 }
 
+// MultiReadingsAggregationResponse defines the Response Content for GET multiple aggregated readings DTO.
+type MultiReadingsAggregationResponse struct {
+	common.BaseResponse `json:",inline"`
+	AggregateFunc       string             `json:"aggregateFunc"`
+	Readings            []dtos.BaseReading `json:"readings"`
+}
+
 func NewReadingResponse(requestId string, message string, statusCode int, reading dtos.BaseReading) ReadingResponse {
 	return ReadingResponse{
 		BaseResponse: common.NewBaseResponse(requestId, message, statusCode),
@@ -33,5 +40,13 @@ func NewMultiReadingsResponse(requestId string, message string, statusCode int, 
 	return MultiReadingsResponse{
 		BaseWithTotalCountResponse: common.NewBaseWithTotalCountResponse(requestId, message, statusCode, totalCount),
 		Readings:                   readings,
+	}
+}
+
+func NewMultiReadingsAggregationResponse(requestId string, message string, statusCode int, aggregateFunc string, readings []dtos.BaseReading) MultiReadingsAggregationResponse {
+	return MultiReadingsAggregationResponse{
+		BaseResponse:  common.NewBaseResponse(requestId, message, statusCode),
+		AggregateFunc: aggregateFunc,
+		Readings:      readings,
 	}
 }

--- a/dtos/responses/reading_test.go
+++ b/dtos/responses/reading_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 )
 
@@ -42,4 +43,22 @@ func TestNewMultiReadingsResponse(t *testing.T) {
 	assert.Equal(t, expectedMessage, actual.Message)
 	assert.Equal(t, expectedReadings, actual.Readings)
 	assert.Equal(t, expectedTotalCount, actual.TotalCount)
+}
+
+func TestNewMultiReadingsAggregationResponse(t *testing.T) {
+	expectedRequestId := "123456"
+	expectedStatusCode := 200
+	expectedMessage := "unit test message"
+	expectedReadings := []dtos.BaseReading{
+		{Id: "7a1707f0-166f-4c4b-bc9d-1d54c74e0137"},
+		{Id: "11111111-2222-3333-4444-555555555555"},
+	}
+	expectedAggFunc := common.AvgFunc
+	actual := NewMultiReadingsAggregationResponse(expectedRequestId, expectedMessage, expectedStatusCode, expectedAggFunc, expectedReadings)
+
+	assert.Equal(t, expectedRequestId, actual.RequestId)
+	assert.Equal(t, expectedStatusCode, actual.StatusCode)
+	assert.Equal(t, expectedMessage, actual.Message)
+	assert.Equal(t, expectedReadings, actual.Readings)
+	assert.Equal(t, expectedAggFunc, actual.AggregateFunc)
 }


### PR DESCRIPTION
Relates to edgexfoundry/edgex-go#5242. Add new MultiReadingsAggregationResponse DTO and agg func related constants.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->