### PR TITLE
feat: Add linkedDeviceCount field to DeviceProfileBasicInfo DTO

### DIFF
--- a/dtos/deviceprofile_test.go
+++ b/dtos/deviceprofile_test.go
@@ -1,11 +1,12 @@
 //
-// Copyright (C) 2021-2024 IOTech Ltd
+// Copyright (C) 2021-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package dtos
 
 import (
+	"encoding/json"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -90,6 +91,61 @@ func profileData() DeviceProfile {
 func TestFromDeviceProfileModelToDTO(t *testing.T) {
 	result := FromDeviceProfileModelToDTO(testDeviceProfile)
 	assert.Equal(t, profileData(), result, "FromDeviceProfileModelToDTO did not result in expected device profile DTO.")
+}
+
+func TestDeviceProfileBasicInfo_LinkedDeviceCount_JSON(t *testing.T) {
+	tests := []struct {
+		name              string
+		linkedDeviceCount uint32
+	}{
+		{"non-zero LinkedDeviceCount", 5},
+		{"zero LinkedDeviceCount present without omitempty", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := DeviceProfileBasicInfo{
+				Name:              TestDeviceProfileName,
+				LinkedDeviceCount: tt.linkedDeviceCount,
+			}
+
+			data, err := json.Marshal(info)
+			require.NoError(t, err)
+			assert.Contains(t, string(data), "linkedDeviceCount")
+
+			var result DeviceProfileBasicInfo
+			err = json.Unmarshal(data, &result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.linkedDeviceCount, result.LinkedDeviceCount)
+		})
+	}
+}
+
+func TestDeviceProfileBasicInfo_LinkedDeviceCount_YAML(t *testing.T) {
+	tests := []struct {
+		name              string
+		linkedDeviceCount uint32
+	}{
+		{"non-zero LinkedDeviceCount", 10},
+		{"zero LinkedDeviceCount", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := DeviceProfileBasicInfo{
+				Name:              TestDeviceProfileName,
+				LinkedDeviceCount: tt.linkedDeviceCount,
+			}
+
+			data, err := yaml.Marshal(info)
+			require.NoError(t, err)
+
+			var result DeviceProfileBasicInfo
+			err = yaml.Unmarshal(data, &result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.linkedDeviceCount, result.LinkedDeviceCount)
+		})
+	}
 }
 
 func TestFromDeviceProfileModelToBasicInfoDTO(t *testing.T) {

--- a/dtos/deviceprofilebasicinfo.go
+++ b/dtos/deviceprofilebasicinfo.go
@@ -1,18 +1,19 @@
 //
-// Copyright (C) 2022 IOTech Ltd
+// Copyright (C) 2022-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package dtos
 
 type DeviceProfileBasicInfo struct {
-	DBTimestamp  `json:",inline" yaml:"dbTimestamp,omitempty"`
-	Id           string   `json:"id,omitempty" validate:"omitempty,uuid" yaml:"id,omitempty"`
-	Name         string   `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string"`
-	Manufacturer string   `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
-	Description  string   `json:"description,omitempty" yaml:"description,omitempty"`
-	Model        string   `json:"model,omitempty" yaml:"model,omitempty"`
-	Labels       []string `json:"labels,omitempty" yaml:"labels,flow,omitempty"`
+	DBTimestamp       `json:",inline" yaml:"dbTimestamp,omitempty"`
+	Id                string   `json:"id,omitempty" validate:"omitempty,uuid" yaml:"id,omitempty"`
+	Name              string   `json:"name" yaml:"name" validate:"required,edgex-dto-none-empty-string"`
+	Manufacturer      string   `json:"manufacturer,omitempty" yaml:"manufacturer,omitempty"`
+	Description       string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Model             string   `json:"model,omitempty" yaml:"model,omitempty"`
+	Labels            []string `json:"labels,omitempty" yaml:"labels,flow,omitempty"`
+	LinkedDeviceCount uint32   `json:"linkedDeviceCount" yaml:"linkedDeviceCount"`
 }
 
 type UpdateDeviceProfileBasicInfo struct {


### PR DESCRIPTION
Fixed #1034. Add linkedDeviceCount field to DeviceProfileBasicInfo DTO.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->