### PR TITLE
fix: Update LinkedDeviceCount data type to int64

### DIFF
--- a/dtos/deviceprofile_test.go
+++ b/dtos/deviceprofile_test.go
@@ -96,7 +96,7 @@ func TestFromDeviceProfileModelToDTO(t *testing.T) {
 func TestDeviceProfileBasicInfo_LinkedDeviceCount_JSON(t *testing.T) {
 	tests := []struct {
 		name              string
-		linkedDeviceCount uint32
+		linkedDeviceCount int64
 	}{
 		{"non-zero LinkedDeviceCount", 5},
 		{"zero LinkedDeviceCount present without omitempty", 0},
@@ -124,7 +124,7 @@ func TestDeviceProfileBasicInfo_LinkedDeviceCount_JSON(t *testing.T) {
 func TestDeviceProfileBasicInfo_LinkedDeviceCount_YAML(t *testing.T) {
 	tests := []struct {
 		name              string
-		linkedDeviceCount uint32
+		linkedDeviceCount int64
 	}{
 		{"non-zero LinkedDeviceCount", 10},
 		{"zero LinkedDeviceCount", 0},

--- a/dtos/deviceprofilebasicinfo.go
+++ b/dtos/deviceprofilebasicinfo.go
@@ -13,7 +13,7 @@ type DeviceProfileBasicInfo struct {
 	Description       string   `json:"description,omitempty" yaml:"description,omitempty"`
 	Model             string   `json:"model,omitempty" yaml:"model,omitempty"`
 	Labels            []string `json:"labels,omitempty" yaml:"labels,flow,omitempty"`
-	LinkedDeviceCount uint32   `json:"linkedDeviceCount" yaml:"linkedDeviceCount"`
+	LinkedDeviceCount int64    `json:"linkedDeviceCount" yaml:"linkedDeviceCount"`
 }
 
 type UpdateDeviceProfileBasicInfo struct {


### PR DESCRIPTION
Relates to #1035. Update LinkedDeviceCount data type to int64 to sync with CountResponse DTO.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->