### PR TITLE
feat: Populate Extensions field during unmarshal for Event and Reading

### DIFF
--- a/clients/http/deviceservicecommand_test.go
+++ b/clients/http/deviceservicecommand_test.go
@@ -42,7 +42,6 @@ var testEventDTO = dtos.Event{
 		"Latitude":  "29.630771",
 		"Longitude": "-95.377603",
 	},
-	Extensions: map[string]any{},
 }
 
 func TestGetCommand(t *testing.T) {

--- a/clients/http/deviceservicecommand_test.go
+++ b/clients/http/deviceservicecommand_test.go
@@ -42,6 +42,7 @@ var testEventDTO = dtos.Event{
 		"Latitude":  "29.630771",
 		"Longitude": "-95.377603",
 	},
+	Extensions: map[string]any{},
 }
 
 func TestGetCommand(t *testing.T) {

--- a/clients/http/deviceservicecommand_test.go
+++ b/clients/http/deviceservicecommand_test.go
@@ -42,6 +42,8 @@ var testEventDTO = dtos.Event{
 		"Latitude":  "29.630771",
 		"Longitude": "-95.377603",
 	},
+	Readings:   make([]dtos.BaseReading, 0),
+	Extensions: make(map[string]any),
 }
 
 func TestGetCommand(t *testing.T) {

--- a/dtos/consts.go
+++ b/dtos/consts.go
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dtos
+
+// JSON field name constants shared by Event and BaseReading unmarshal logic.
+const (
+	// shared keys
+	keyApiVersion  = "apiVersion"
+	keyId          = "id"
+	keyDeviceName  = "deviceName"
+	keyProfileName = "profileName"
+	keyOrigin      = "origin"
+	keyTags        = "tags"
+
+	// Event-only keys
+	keySourceName = "sourceName"
+	keyReadings   = "readings"
+
+	// BaseReading-only keys
+	keyResourceName = "resourceName"
+	keyValueType    = "valueType"
+	keyUnits        = "units"
+	keyBinaryValue  = "binaryValue"
+	keyMediaType    = "mediaType"
+	keyObjectValue  = "objectValue"
+	keyValue        = "value"
+)

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -42,6 +42,8 @@ func NewEvent(profileName, deviceName, sourceName string) Event {
 		ProfileName: profileName,
 		SourceName:  sourceName,
 		Origin:      time.Now().UnixNano(),
+		Extensions:  make(map[string]any),
+		Tags:        make(Tags),
 	}
 }
 
@@ -171,6 +173,8 @@ func (e *Event) UnmarshalCBOR(b []byte) error {
 }
 
 func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error {
+	*e = Event{}
+
 	var (
 		rawMap map[string]any
 		err    error
@@ -231,8 +235,14 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 	// convert json.Number in rawMap to native numeric types before assigning Tags/Extensions
 	convertJSONNumbers(rawMap)
 
-	if tags, ok := popKey(rawMap, keyTags).(map[string]any); ok {
-		e.Tags = tags
+	if rawTags := popKey(rawMap, keyTags); rawTags != nil {
+		if tags, ok := rawTags.(map[string]any); ok {
+			e.Tags = tags
+		} else {
+			return fmt.Errorf("failed to decode tags: expected map[string]any, got %T", rawTags)
+		}
+	} else {
+		e.Tags = make(map[string]any)
 	}
 
 	if len(rawReadings) > 0 {
@@ -246,6 +256,8 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 				return err
 			}
 		}
+	} else {
+		e.Readings = make([]BaseReading, 0)
 	}
 
 	if os.Getenv(common.EnvOptimizeEventPayload) == common.ValueTrue {
@@ -265,6 +277,8 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 	// remaining keys are extensions
 	if len(rawMap) > 0 {
 		e.Extensions = rawMap
+	} else {
+		e.Extensions = make(map[string]any)
 	}
 	return nil
 }

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -40,6 +40,7 @@ func NewEvent(profileName, deviceName, sourceName string) Event {
 		ProfileName: profileName,
 		SourceName:  sourceName,
 		Origin:      time.Now().UnixNano(),
+		Extensions:  make(map[string]any),
 	}
 }
 
@@ -161,7 +162,7 @@ func (e Event) marshal(marshal func(any) ([]byte, error)) ([]byte, error) {
 }
 
 func (e *Event) UnmarshalJSON(b []byte) error {
-	return e.unmarshal(b, json.Unmarshal)
+	return e.unmarshal(b, jsonUnmarshalUseNumber)
 }
 
 func (e *Event) UnmarshalCBOR(b []byte) error {
@@ -169,28 +170,50 @@ func (e *Event) UnmarshalCBOR(b []byte) error {
 }
 
 func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error {
-	var aux struct {
-		dtoCommon.Versionable
-		Id          string
-		DeviceName  string
-		ProfileName string
-		SourceName  string
-		Origin      int64
-		Readings    []BaseReading
-		Tags        Tags
-	}
-	if err := unmarshal(data, &aux); err != nil {
+	var rawMap map[string]any
+	if err := unmarshal(data, &rawMap); err != nil {
 		return err
 	}
+	// When cbor.Unmarshal decodes into map[string]any, the top-level keys are strings,
+	// but nested map values (e.g. readings, tags) are decoded as map[any]any because
+	// their target type is any. normalizeMap recursively converts these to map[string]any
+	// so that subsequent type assertions work correctly for both JSON and CBOR paths.
+	normalizeMap(rawMap)
 
-	e.Versionable = aux.Versionable
-	e.Id = aux.Id
-	e.DeviceName = aux.DeviceName
-	e.ProfileName = aux.ProfileName
-	e.SourceName = aux.SourceName
-	e.Origin = aux.Origin
-	e.Readings = aux.Readings
-	e.Tags = aux.Tags
+	e.ApiVersion, _ = popKey(rawMap, keyApiVersion).(string)
+	e.Id, _ = popKey(rawMap, keyId).(string)
+	e.DeviceName, _ = popKey(rawMap, keyDeviceName).(string)
+	e.ProfileName, _ = popKey(rawMap, keyProfileName).(string)
+	e.SourceName, _ = popKey(rawMap, keySourceName).(string)
+
+	switch v := popKey(rawMap, keyOrigin).(type) {
+	case json.Number:
+		e.Origin, _ = v.Int64()
+	case uint64: // CBOR, positive integers decode as uint64
+		e.Origin = int64(v)
+	}
+
+	// Pop readings before convertJSONNumbers so that json.Number values inside each reading
+	// (e.g. origin) are preserved for precise int64 conversion in populateFromMap.
+	rawReadings, _ := popKey(rawMap, keyReadings).([]any)
+
+	// convert json.Number in rawMap to native numeric types before assigning Tags/Extensions
+	convertJSONNumbers(rawMap)
+
+	if tags, ok := popKey(rawMap, keyTags).(map[string]any); ok {
+		e.Tags = tags
+	}
+
+	if len(rawReadings) > 0 {
+		e.Readings = make([]BaseReading, len(rawReadings))
+		for i, raw := range rawReadings {
+			if readingMap, ok := raw.(map[string]any); ok {
+				if err := e.Readings[i].populateFromMap(readingMap); err != nil {
+					return err
+				}
+			}
+		}
+	}
 
 	if os.Getenv(common.EnvOptimizeEventPayload) == common.ValueTrue {
 		// recover the reduced fields
@@ -205,5 +228,8 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 			}
 		}
 	}
+
+	// remaining keys are extensions
+	e.Extensions = rawMap
 	return nil
 }

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -42,7 +42,6 @@ func NewEvent(profileName, deviceName, sourceName string) Event {
 		ProfileName: profileName,
 		SourceName:  sourceName,
 		Origin:      time.Now().UnixNano(),
-		Extensions:  make(map[string]any),
 	}
 }
 
@@ -172,8 +171,11 @@ func (e *Event) UnmarshalCBOR(b []byte) error {
 }
 
 func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error {
-	var rawMap map[string]any
-	if err := unmarshal(data, &rawMap); err != nil {
+	var (
+		rawMap map[string]any
+		err    error
+	)
+	if err = unmarshal(data, &rawMap); err != nil {
 		return err
 	}
 	// When cbor.Unmarshal decodes into map[string]any, the top-level keys are strings,
@@ -182,15 +184,24 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 	// so that subsequent type assertions work correctly for both JSON and CBOR paths.
 	normalizeMap(rawMap)
 
-	e.ApiVersion = popStringValuefromKey(rawMap, keyApiVersion)
-	e.Id = popStringValuefromKey(rawMap, keyId)
-	e.DeviceName = popStringValuefromKey(rawMap, keyDeviceName)
-	e.ProfileName = popStringValuefromKey(rawMap, keyProfileName)
-	e.SourceName = popStringValuefromKey(rawMap, keySourceName)
+	if e.ApiVersion, err = popStringValueFromKey(rawMap, keyApiVersion); err != nil {
+		return err
+	}
+	if e.Id, err = popStringValueFromKey(rawMap, keyId); err != nil {
+		return err
+	}
+	if e.DeviceName, err = popStringValueFromKey(rawMap, keyDeviceName); err != nil {
+		return err
+	}
+	if e.ProfileName, err = popStringValueFromKey(rawMap, keyProfileName); err != nil {
+		return err
+	}
+	if e.SourceName, err = popStringValueFromKey(rawMap, keySourceName); err != nil {
+		return err
+	}
 
 	switch v := popKey(rawMap, keyOrigin).(type) {
 	case json.Number:
-		var err error
 		if e.Origin, err = v.Int64(); err != nil {
 			return fmt.Errorf("failed to decode origin: %w", err)
 		}
@@ -199,6 +210,12 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 			return fmt.Errorf("origin value %d overflows int64", v)
 		}
 		e.Origin = int64(v)
+	case int64: // CBOR, negative integers decode as int64
+		e.Origin = v
+	case nil:
+		// key absent — leave Origin as zero
+	default:
+		return fmt.Errorf("origin must be a numeric type, got %T", v)
 	}
 
 	// Pop readings before convertJSONNumbers so that json.Number values inside each reading
@@ -221,10 +238,12 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 	if len(rawReadings) > 0 {
 		e.Readings = make([]BaseReading, len(rawReadings))
 		for i, raw := range rawReadings {
-			if readingMap, ok := raw.(map[string]any); ok {
-				if err := e.Readings[i].populateFromMap(readingMap); err != nil {
-					return err
-				}
+			readingMap, ok := raw.(map[string]any)
+			if !ok {
+				return fmt.Errorf("failed to decode readings[%d]: expected map[string]any, got %T", i, raw)
+			}
+			if err := e.Readings[i].populateFromMap(readingMap); err != nil {
+				return err
 			}
 		}
 	}
@@ -244,6 +263,8 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 	}
 
 	// remaining keys are extensions
-	e.Extensions = rawMap
+	if len(rawMap) > 0 {
+		e.Extensions = rawMap
+	}
 	return nil
 }

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -8,6 +8,8 @@ package dtos
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -180,22 +182,34 @@ func (e *Event) unmarshal(data []byte, unmarshal func([]byte, any) error) error 
 	// so that subsequent type assertions work correctly for both JSON and CBOR paths.
 	normalizeMap(rawMap)
 
-	e.ApiVersion, _ = popKey(rawMap, keyApiVersion).(string)
-	e.Id, _ = popKey(rawMap, keyId).(string)
-	e.DeviceName, _ = popKey(rawMap, keyDeviceName).(string)
-	e.ProfileName, _ = popKey(rawMap, keyProfileName).(string)
-	e.SourceName, _ = popKey(rawMap, keySourceName).(string)
+	e.ApiVersion = popStringValuefromKey(rawMap, keyApiVersion)
+	e.Id = popStringValuefromKey(rawMap, keyId)
+	e.DeviceName = popStringValuefromKey(rawMap, keyDeviceName)
+	e.ProfileName = popStringValuefromKey(rawMap, keyProfileName)
+	e.SourceName = popStringValuefromKey(rawMap, keySourceName)
 
 	switch v := popKey(rawMap, keyOrigin).(type) {
 	case json.Number:
-		e.Origin, _ = v.Int64()
+		var err error
+		if e.Origin, err = v.Int64(); err != nil {
+			return fmt.Errorf("failed to decode origin: %w", err)
+		}
 	case uint64: // CBOR, positive integers decode as uint64
+		if v > math.MaxInt64 {
+			return fmt.Errorf("origin value %d overflows int64", v)
+		}
 		e.Origin = int64(v)
 	}
 
 	// Pop readings before convertJSONNumbers so that json.Number values inside each reading
 	// (e.g. origin) are preserved for precise int64 conversion in populateFromMap.
-	rawReadings, _ := popKey(rawMap, keyReadings).([]any)
+	var rawReadings []any
+	if v := popKey(rawMap, keyReadings); v != nil {
+		var ok bool
+		if rawReadings, ok = v.([]any); !ok {
+			return fmt.Errorf("failed to decode readings: expected []any, got %T", v)
+		}
+	}
 
 	// convert json.Number in rawMap to native numeric types before assigning Tags/Extensions
 	convertJSONNumbers(rawMap)

--- a/dtos/event_test.go
+++ b/dtos/event_test.go
@@ -321,3 +321,28 @@ func TestEvent_MarshalOptimizedEventPayload(t *testing.T) {
 	testEvent.Readings[0].Id = "" // the id field will be omitted ,and it isn’t used to store in the database
 	assert.Equal(t, testEvent, res)
 }
+
+func TestEvent_UnmarshalExtensions(t *testing.T) {
+	baseJSON := `{"apiVersion":"v3","deviceName":"TestDevice","profileName":"TestDeviceProfileName",` +
+		`"sourceName":"TestSourceName","origin":1594963842,"readings":[], "description":"d"}`
+
+	t.Run("JSON", func(t *testing.T) {
+		var result Event
+		require.NoError(t, json.Unmarshal([]byte(baseJSON), &result))
+
+		assert.Equal(t, "d", result.Extensions["description"])
+	})
+
+	t.Run("CBOR", func(t *testing.T) {
+		var intermediate Event
+		require.NoError(t, json.Unmarshal([]byte(baseJSON), &intermediate))
+
+		data, err := cbor.Marshal(intermediate)
+		require.NoError(t, err)
+
+		var result Event
+		require.NoError(t, cbor.Unmarshal(data, &result))
+
+		assert.Equal(t, "d", result.Extensions["description"])
+	})
+}

--- a/dtos/extensions.go
+++ b/dtos/extensions.go
@@ -5,6 +5,11 @@
 
 package dtos
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 // mergeExtensions merges the extensions map into the already-marshaled data bytes at top level.
 // The extensions keys will overwrite existing keys if there is a conflict.
 func mergeExtensions(data []byte, extensions map[string]any, unmarshalFn func([]byte, any) error,
@@ -17,4 +22,70 @@ func mergeExtensions(data []byte, extensions map[string]any, unmarshalFn func([]
 		m[k] = v
 	}
 	return marshalFn(m)
+}
+
+// jsonUnmarshalUseNumber unmarshals JSON with UseNumber enabled to preserve numeric precision.
+func jsonUnmarshalUseNumber(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
+
+// convertJSONNumbers recursively converts json.Number values in a map/slice to float64,
+// matching the behavior of standard json.Unmarshal when decoding numbers into any-typed targets.
+// This is called after origin is extracted (which uses json.Number.Int64() directly to preserve
+// int64 precision), so the remaining numeric values in the map can safely use float64.
+func convertJSONNumbers(v any) any {
+	switch val := v.(type) {
+	case json.Number:
+		if f, err := val.Float64(); err == nil {
+			return f
+		}
+		return val.String()
+	case map[string]any:
+		for k, v := range val {
+			val[k] = convertJSONNumbers(v)
+		}
+		return val
+	case []any:
+		for i, v := range val {
+			val[i] = convertJSONNumbers(v)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+// normalizeMap recursively converts map[interface{}]interface{} (produced by CBOR decoding into any)
+// to map[string]any for consistency with JSON-decoded maps. No-op for JSON-decoded data.
+func normalizeMap(v any) any {
+	switch val := v.(type) {
+	case map[any]any:
+		result := make(map[string]any, len(val))
+		for k, v := range val {
+			ks, _ := k.(string)
+			result[ks] = normalizeMap(v)
+		}
+		return result
+	case map[string]any:
+		for k, v := range val {
+			val[k] = normalizeMap(v)
+		}
+		return val
+	case []any:
+		for i, v := range val {
+			val[i] = normalizeMap(v)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+// popKey removes the key from the map and returns the value.
+func popKey(m map[string]any, key string) any {
+	v := m[key]
+	delete(m, key)
+	return v
 }

--- a/dtos/extensions.go
+++ b/dtos/extensions.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strconv"
+	"io"
 )
 
 // mergeExtensions merges the extensions map into the already-marshaled data bytes at top level.
@@ -30,7 +30,17 @@ func mergeExtensions(data []byte, extensions map[string]any, unmarshalFn func([]
 func jsonUnmarshalUseNumber(data []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
-	return dec.Decode(v)
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	// Ensure no trailing non-whitespace content remains
+	if err := dec.Decode(new(struct{})); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("invalid JSON: extra data after first value")
+		}
+		return err
+	}
+	return nil
 }
 
 // convertJSONNumbers recursively converts json.Number values in a map/slice to float64,
@@ -66,7 +76,10 @@ func normalizeMap(v any) any {
 	case map[any]any:
 		result := make(map[string]any, len(val))
 		for k, v := range val {
-			ks, _ := k.(string)
+			ks, ok := k.(string)
+			if !ok {
+				ks = fmt.Sprint(k)
+			}
 			result[ks] = normalizeMap(v)
 		}
 		return result
@@ -92,17 +105,16 @@ func popKey(m map[string]any, key string) any {
 	return v
 }
 
-func popStringValuefromKey(m map[string]any, key string) string {
-	switch v := popKey(m, key).(type) {
+// popStringValueFromKey removes the key from the map and returns its value as a string.
+// Returns an error if the key is present but not a string type.
+func popStringValueFromKey(m map[string]any, key string) (string, error) {
+	v := popKey(m, key)
+	switch val := v.(type) {
 	case string:
-		return v
-	case int:
-		return strconv.Itoa(v)
-	case bool:
-		return strconv.FormatBool(v)
+		return val, nil
 	case nil:
-		return ""
+		return "", nil
 	default:
-		return fmt.Sprintf("%v", v)
+		return "", fmt.Errorf("field %q must be a string, got %T", key, v)
 	}
 }

--- a/dtos/extensions.go
+++ b/dtos/extensions.go
@@ -8,6 +8,8 @@ package dtos
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"strconv"
 )
 
 // mergeExtensions merges the extensions map into the already-marshaled data bytes at top level.
@@ -57,7 +59,7 @@ func convertJSONNumbers(v any) any {
 	}
 }
 
-// normalizeMap recursively converts map[interface{}]interface{} (produced by CBOR decoding into any)
+// normalizeMap recursively converts map[any]any (produced by CBOR decoding into any)
 // to map[string]any for consistency with JSON-decoded maps. No-op for JSON-decoded data.
 func normalizeMap(v any) any {
 	switch val := v.(type) {
@@ -88,4 +90,19 @@ func popKey(m map[string]any, key string) any {
 	v := m[key]
 	delete(m, key)
 	return v
+}
+
+func popStringValuefromKey(m map[string]any, key string) string {
+	switch v := popKey(m, key).(type) {
+	case string:
+		return v
+	case int:
+		return strconv.Itoa(v)
+	case bool:
+		return strconv.FormatBool(v)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }

--- a/dtos/extensions_test.go
+++ b/dtos/extensions_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPopKey(t *testing.T) {
+	m := map[string]any{"a": "1", "b": "2", "c": "3"}
+
+	v := popKey(m, "b")
+	assert.Equal(t, "2", v)
+	assert.Equal(t, map[string]any{"a": "1", "c": "3"}, m)
+
+	v = popKey(m, "nonexistent")
+	assert.Nil(t, v)
+	assert.Equal(t, map[string]any{"a": "1", "c": "3"}, m)
+}
+
 func TestMergeExtensions(t *testing.T) {
 	base := map[string]any{"deviceName": "sensor-1", "value": "42"}
 

--- a/dtos/extensions_test.go
+++ b/dtos/extensions_test.go
@@ -75,3 +75,57 @@ func TestMergeExtensions(t *testing.T) {
 		})
 	}
 }
+
+func TestJsonUnmarshalUseNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		checkNum bool // verify json.Number preservation
+	}{
+		{
+			name:  "valid object",
+			input: `{"a":1}`,
+		},
+		{
+			name:     "preserves number as json.Number",
+			input:    `{"number":123}`,
+			checkNum: true,
+		},
+		{
+			name:    "trailing garbage after value",
+			input:   `{"a":1}garbage`,
+			wantErr: true,
+		},
+		{
+			name:    "concatenated JSON objects",
+			input:   `{"a":1}{"b":2}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{bad}`,
+			wantErr: true,
+		},
+		{
+			name:  "trailing whitespace is allowed",
+			input: `{"a":1}   `,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v map[string]any
+			err := jsonUnmarshalUseNumber([]byte(tt.input), &v)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.checkNum {
+				_, ok := v["number"].(json.Number)
+				assert.True(t, ok, "expected json.Number, got %T", v["n"])
+			}
+		})
+	}
+}

--- a/dtos/extensions_test.go
+++ b/dtos/extensions_test.go
@@ -124,7 +124,7 @@ func TestJsonUnmarshalUseNumber(t *testing.T) {
 			require.NoError(t, err)
 			if tt.checkNum {
 				_, ok := v["number"].(json.Number)
-				assert.True(t, ok, "expected json.Number, got %T", v["n"])
+				assert.True(t, ok, "expected json.Number, got %T", v["number"])
 			}
 		})
 	}

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -74,6 +74,8 @@ func newBaseReading(profileName string, deviceName string, resourceName string, 
 		ResourceName: resourceName,
 		ProfileName:  profileName,
 		ValueType:    valueType,
+		Extensions:   make(map[string]any),
+		Tags:         make(Tags),
 	}
 }
 
@@ -708,6 +710,8 @@ func (b *BaseReading) Unmarshal(data []byte, unmarshal func([]byte, any) error) 
 }
 
 func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
+	*b = BaseReading{}
+
 	var err error
 	if b.Id, err = popStringValueFromKey(rawMap, keyId); err != nil {
 		return err
@@ -743,7 +747,7 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 	case nil:
 		// key absent — leave Origin as zero
 	default:
-		return fmt.Errorf("failed to decode origin: unsupported type %T\"", v)
+		return fmt.Errorf("failed to decode origin: unsupported type %T", v)
 	}
 
 	// convert json.Number in rawMap to native numeric types before assigning Tags/Extensions
@@ -755,10 +759,8 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 		} else {
 			return fmt.Errorf("failed to decode tags: expected map[string]any, got %T", rawTags)
 		}
-	}
-
-	if tags, ok := popKey(rawMap, keyTags).(map[string]any); ok {
-		b.Tags = tags
+	} else {
+		b.Tags = make(map[string]any)
 	}
 
 	// BinaryReading: JSON gives base64 string, CBOR gives []byte
@@ -808,6 +810,8 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 	// remaining keys are extensions
 	if len(rawMap) > 0 {
 		b.Extensions = rawMap
+	} else {
+		b.Extensions = make(map[string]any)
 	}
 	return nil
 }

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -74,7 +74,6 @@ func newBaseReading(profileName string, deviceName string, resourceName string, 
 		ResourceName: resourceName,
 		ProfileName:  profileName,
 		ValueType:    valueType,
-		Extensions:   make(map[string]any),
 	}
 }
 
@@ -709,16 +708,28 @@ func (b *BaseReading) Unmarshal(data []byte, unmarshal func([]byte, any) error) 
 }
 
 func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
-	b.Id = popStringValuefromKey(rawMap, keyId)
-	b.DeviceName = popStringValuefromKey(rawMap, keyDeviceName)
-	b.ResourceName = popStringValuefromKey(rawMap, keyResourceName)
-	b.ProfileName = popStringValuefromKey(rawMap, keyProfileName)
-	b.ValueType = popStringValuefromKey(rawMap, keyValueType)
-	b.Units = popStringValuefromKey(rawMap, keyUnits)
+	var err error
+	if b.Id, err = popStringValueFromKey(rawMap, keyId); err != nil {
+		return err
+	}
+	if b.DeviceName, err = popStringValueFromKey(rawMap, keyDeviceName); err != nil {
+		return err
+	}
+	if b.ResourceName, err = popStringValueFromKey(rawMap, keyResourceName); err != nil {
+		return err
+	}
+	if b.ProfileName, err = popStringValueFromKey(rawMap, keyProfileName); err != nil {
+		return err
+	}
+	if b.ValueType, err = popStringValueFromKey(rawMap, keyValueType); err != nil {
+		return err
+	}
+	if b.Units, err = popStringValueFromKey(rawMap, keyUnits); err != nil {
+		return err
+	}
 
 	switch v := popKey(rawMap, keyOrigin).(type) {
 	case json.Number:
-		var err error
 		if b.Origin, err = v.Int64(); err != nil {
 			return fmt.Errorf("failed to decode origin: %w", err)
 		}
@@ -727,10 +738,24 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 			return fmt.Errorf("origin value %d overflows int64", v)
 		}
 		b.Origin = int64(v)
+	case int64: // CBOR, negative integers decode as int64
+		b.Origin = v
+	case nil:
+		// key absent — leave Origin as zero
+	default:
+		return fmt.Errorf("failed to decode origin: unsupported type %T\"", v)
 	}
 
 	// convert json.Number in rawMap to native numeric types before assigning Tags/Extensions
 	convertJSONNumbers(rawMap)
+
+	if rawTags := popKey(rawMap, keyTags); rawTags != nil {
+		if tags, ok := rawTags.(map[string]any); ok {
+			b.Tags = tags
+		} else {
+			return fmt.Errorf("failed to decode tags: expected map[string]any, got %T", rawTags)
+		}
+	}
 
 	if tags, ok := popKey(rawMap, keyTags).(map[string]any); ok {
 		b.Tags = tags
@@ -739,11 +764,17 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 	// BinaryReading: JSON gives base64 string, CBOR gives []byte
 	switch v := popKey(rawMap, keyBinaryValue).(type) {
 	case string:
-		b.BinaryValue, _ = base64.StdEncoding.DecodeString(v)
+		decoded, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			return fmt.Errorf("failed to decode binaryValue: %w", err)
+		}
+		b.BinaryValue = decoded
 	case []byte:
 		b.BinaryValue = v
 	}
-	b.MediaType = popStringValuefromKey(rawMap, keyMediaType)
+	if b.MediaType, err = popStringValueFromKey(rawMap, keyMediaType); err != nil {
+		return err
+	}
 
 	// ObjectReading
 	objectValue := popKey(rawMap, keyObjectValue)
@@ -775,6 +806,8 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 	}
 
 	// remaining keys are extensions
-	b.Extensions = rawMap
+	if len(rawMap) > 0 {
+		b.Extensions = rawMap
+	}
 	return nil
 }

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -785,7 +785,7 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 	// Value -> SimpleReading / NumericReading
 	value := popKey(rawMap, keyValue)
 	if value != nil {
-		b.SimpleReading = SimpleReading{Value: fmt.Sprintf("%s", value)}
+		b.SimpleReading = SimpleReading{Value: fmt.Sprintf("%v", value)}
 	}
 	// if the value is not string, let the NumericReading contain the equivalent value
 	if _, ok := value.(string); !ok {

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -6,6 +6,7 @@
 package dtos
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -72,6 +73,7 @@ func newBaseReading(profileName string, deviceName string, resourceName string, 
 		ResourceName: resourceName,
 		ProfileName:  profileName,
 		ValueType:    valueType,
+		Extensions:   make(map[string]any),
 	}
 }
 
@@ -685,7 +687,7 @@ func (b BaseReading) marshal(marshal func(any) ([]byte, error)) ([]byte, error) 
 }
 
 func (b *BaseReading) UnmarshalJSON(data []byte) error {
-	return b.Unmarshal(data, json.Unmarshal)
+	return b.Unmarshal(data, jsonUnmarshalUseNumber)
 }
 
 func (b *BaseReading) UnmarshalCBOR(data []byte) error {
@@ -693,56 +695,79 @@ func (b *BaseReading) UnmarshalCBOR(data []byte) error {
 }
 
 func (b *BaseReading) Unmarshal(data []byte, unmarshal func([]byte, any) error) error {
-	var aux struct {
-		Id           string
-		Origin       int64
-		DeviceName   string
-		ResourceName string
-		ProfileName  string
-		ValueType    string
-		Units        string
-		Tags         Tags
-		Value        any
-		BinaryReading
-		ObjectReading
-	}
-	if err := unmarshal(data, &aux); err != nil {
+	var rawMap map[string]any
+	if err := unmarshal(data, &rawMap); err != nil {
 		return err
 	}
+	// When cbor.Unmarshal decodes into map[string]any, the top-level keys are strings,
+	// but nested map values (e.g. tags, objectValue) are decoded as map[any]any because
+	// their target type is any. normalizeMap recursively converts these to map[string]any
+	// so that subsequent type assertions work correctly for both JSON and CBOR paths.
+	normalizeMap(rawMap)
+	return b.populateFromMap(rawMap)
+}
 
-	b.Id = aux.Id
-	b.Origin = aux.Origin
-	b.DeviceName = aux.DeviceName
-	b.ResourceName = aux.ResourceName
-	b.ProfileName = aux.ProfileName
-	b.ValueType = aux.ValueType
-	b.Units = aux.Units
-	b.Tags = aux.Tags
-	b.BinaryReading = aux.BinaryReading
-	if aux.Value != nil {
-		b.SimpleReading = SimpleReading{Value: fmt.Sprintf("%s", aux.Value)}
+func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
+	b.Id, _ = popKey(rawMap, keyId).(string)
+	b.DeviceName, _ = popKey(rawMap, keyDeviceName).(string)
+	b.ResourceName, _ = popKey(rawMap, keyResourceName).(string)
+	b.ProfileName, _ = popKey(rawMap, keyProfileName).(string)
+	b.ValueType, _ = popKey(rawMap, keyValueType).(string)
+	b.Units, _ = popKey(rawMap, keyUnits).(string)
+
+	switch v := popKey(rawMap, keyOrigin).(type) {
+	case json.Number:
+		b.Origin, _ = v.Int64()
+	case uint64: // CBOR, positive integers decode as uint64
+		b.Origin = int64(v)
 	}
 
+	// convert json.Number in rawMap to native numeric types before assigning Tags/Extensions
+	convertJSONNumbers(rawMap)
+
+	if tags, ok := popKey(rawMap, keyTags).(map[string]any); ok {
+		b.Tags = tags
+	}
+
+	// BinaryReading: JSON gives base64 string, CBOR gives []byte
+	switch v := popKey(rawMap, keyBinaryValue).(type) {
+	case string:
+		b.BinaryValue, _ = base64.StdEncoding.DecodeString(v)
+	case []byte:
+		b.BinaryValue = v
+	}
+	b.MediaType, _ = popKey(rawMap, keyMediaType).(string)
+
+	// ObjectReading
+	objectValue := popKey(rawMap, keyObjectValue)
+	b.ObjectValue = objectValue
+
+	// Value -> SimpleReading / NumericReading
+	value := popKey(rawMap, keyValue)
+	if value != nil {
+		b.SimpleReading = SimpleReading{Value: fmt.Sprintf("%s", value)}
+	}
 	// if the value is not string, let the NumericReading contain the equivalent value
-	if _, ok := aux.Value.(string); !ok {
-		b.NumericReading = NumericReading{NumericValue: aux.Value}
+	if _, ok := value.(string); !ok {
+		b.NumericReading = NumericReading{NumericValue: value}
 	}
 
-	b.ObjectReading = aux.ObjectReading
-
-	switch aux.ValueType {
+	switch b.ValueType {
 	case common.ValueTypeObject, common.ValueTypeObjectArray:
-		if aux.ObjectValue == nil {
+		if objectValue == nil {
 			b.isNull = true
 		}
 	case common.ValueTypeBinary:
-		if aux.BinaryValue == nil {
+		if b.BinaryValue == nil {
 			b.isNull = true
 		}
 	default:
-		if aux.Value == nil {
+		if value == nil {
 			b.isNull = true
 		}
 	}
+
+	// remaining keys are extensions
+	b.Extensions = rawMap
 	return nil
 }

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -708,17 +709,23 @@ func (b *BaseReading) Unmarshal(data []byte, unmarshal func([]byte, any) error) 
 }
 
 func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
-	b.Id, _ = popKey(rawMap, keyId).(string)
-	b.DeviceName, _ = popKey(rawMap, keyDeviceName).(string)
-	b.ResourceName, _ = popKey(rawMap, keyResourceName).(string)
-	b.ProfileName, _ = popKey(rawMap, keyProfileName).(string)
-	b.ValueType, _ = popKey(rawMap, keyValueType).(string)
-	b.Units, _ = popKey(rawMap, keyUnits).(string)
+	b.Id = popStringValuefromKey(rawMap, keyId)
+	b.DeviceName = popStringValuefromKey(rawMap, keyDeviceName)
+	b.ResourceName = popStringValuefromKey(rawMap, keyResourceName)
+	b.ProfileName = popStringValuefromKey(rawMap, keyProfileName)
+	b.ValueType = popStringValuefromKey(rawMap, keyValueType)
+	b.Units = popStringValuefromKey(rawMap, keyUnits)
 
 	switch v := popKey(rawMap, keyOrigin).(type) {
 	case json.Number:
-		b.Origin, _ = v.Int64()
+		var err error
+		if b.Origin, err = v.Int64(); err != nil {
+			return fmt.Errorf("failed to decode origin: %w", err)
+		}
 	case uint64: // CBOR, positive integers decode as uint64
+		if v > math.MaxInt64 {
+			return fmt.Errorf("origin value %d overflows int64", v)
+		}
 		b.Origin = int64(v)
 	}
 
@@ -736,7 +743,7 @@ func (b *BaseReading) populateFromMap(rawMap map[string]any) error {
 	case []byte:
 		b.BinaryValue = v
 	}
-	b.MediaType, _ = popKey(rawMap, keyMediaType).(string)
+	b.MediaType = popStringValuefromKey(rawMap, keyMediaType)
 
 	// ObjectReading
 	objectValue := popKey(rawMap, keyObjectValue)

--- a/dtos/reading_test.go
+++ b/dtos/reading_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
@@ -811,4 +812,30 @@ func TestMarshalNumericReading(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("%v", tt.value), fmt.Sprintf("%v", res.NumericValue))
 		})
 	}
+}
+
+func TestBaseReading_UnmarshalExtensions(t *testing.T) {
+	baseJSON := `{"deviceName":"TestDevice","profileName":"TestDeviceProfileName",` +
+		`"resourceName":"TestDeviceResource","valueType":"String","value":"val",` +
+		`"origin":1594963842,"description":"d"}`
+
+	t.Run("JSON", func(t *testing.T) {
+		var result BaseReading
+		require.NoError(t, json.Unmarshal([]byte(baseJSON), &result))
+
+		assert.Equal(t, "d", result.Extensions["description"])
+	})
+
+	t.Run("CBOR", func(t *testing.T) {
+		var intermediate BaseReading
+		require.NoError(t, json.Unmarshal([]byte(baseJSON), &intermediate))
+
+		data, err := cbor.Marshal(intermediate)
+		require.NoError(t, err)
+
+		var result BaseReading
+		require.NoError(t, cbor.Unmarshal(data, &result))
+
+		assert.Equal(t, "d", result.Extensions["description"])
+	})
 }

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -301,6 +301,7 @@ func Test_AddEventReqToEventModels(t *testing.T) {
 			ProfileName:  TestDeviceProfileName,
 			Origin:       TestOriginTime,
 			ValueType:    common.ValueTypeUint8,
+			Tags:         make(map[string]any),
 		},
 		Value: "45",
 	}


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Test the core-data POST event API and verify that the Event payload published to the message bus includes the custom fields.
For example:
```
curl -X 'POST' \
  'http://localhost:59880/api/v3/event/device-virtual/Random-Boolean-Device/Random-Boolean-Device/Bool' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "apiVersion": "v3",
  "event": {
    "apiVersion": "v3",
    "deviceName": "Random-Boolean-Device",
    "profileName": "Random-Boolean-Device",
    "sourceName": "Bool",
    "id": "563513b3-f020-46fa-ae44-0fdd1d129185",
    "origin": 1692721935934211800,
    "event-extension1": "ext1",
    "event-extension2": "ext2",
    "tags": {
      "Gateway": "HoustonStore-000123",
      "Latitude": {
        "degrees": 25,
        "minute": 1,
        "second": 26.6268000000062
      },
      "Longitude": {
        "degree": 121,
        "minute": 31,
        "second": 19.600799999980154
      }
    },
    "readings": [
      {
        "deviceName": "Random-Boolean-Device",
        "resourceName": "Bool",
        "profileName": "Random-Boolean-Device",
        "origin": 1692721935934211800,
        "valueType": "Bool",
        "value": "false",
        "reading-extension1": "ext1",
        "reading-extension2": "ext2"
      }
    ]
  }
}'
```
```
edgex/events/core/device%2Dvirtual/Random%2DBoolean%2DDevice/Random%2DBoolean%2DDevice/Bool {
    "apiVersion": "v3",
    "receivedTopic": "",
    "correlationID": "8ccd114e-3bdf-4549-bd08-302cc2ce99b1",
    "requestID": "",
    "errorCode": 0,
    "payload": {
        "apiVersion": "v3",
        "requestId": "",
        "event": {
            "apiVersion": "v3",
            "deviceName": "Random-Boolean-Device",
            "event-extension1": "ext1",
            "event-extension2": "ext2",
            "id": "563513b3-f020-46fa-ae44-0fdd1d129185",
            "origin": 1692721935934211800,
            "profileName": "Random-Boolean-Device",
            "readings": [
                {
                    "deviceName": "Random-Boolean-Device",
                    "origin": 1692721935934211800,
                    "profileName": "Random-Boolean-Device",
                    "reading-extension1": "ext1",
                    "reading-extension2": "ext2",
                    "resourceName": "Bool",
                    "value": "false",
                    "valueType": "Bool"
                }
            ],
            "sourceName": "Bool",
            "tags": {
                "Gateway": "HoustonStore-000123",
                "Latitude": {
                    "degrees": 25,
                    "minute": 1,
                    "second": 26.6268000000062
                },
                "Longitude": {
                    "degree": 121,
                    "minute": 31,
                    "second": 19.600799999980154
                }
            }
        }
    },
    "contentType": "application/json"
}
```
