### PR TITLE
feat: ScheduleAction add UseRawPayload field for EdgeXMessageBus

### DIFF
--- a/dtos/schedulejob.go
+++ b/dtos/schedulejob.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -184,7 +184,8 @@ func (s *ScheduleAction) Validate() error {
 }
 
 type EdgeXMessageBusAction struct {
-	Topic string `json:"topic,omitempty" validate:"required"`
+	Topic         string `json:"topic,omitempty" validate:"required"`
+	UseRawPayload bool   `json:"useRawPayload,omitempty"`
 }
 
 type RESTAction struct {
@@ -298,7 +299,8 @@ func ToScheduleActionModel(dto ScheduleAction) models.ScheduleAction {
 				ContentType: dto.ContentType,
 				Payload:     dto.Payload,
 			},
-			Topic: dto.Topic,
+			Topic:         dto.Topic,
+			UseRawPayload: dto.UseRawPayload,
 		}
 	case common.ActionREST:
 		model = models.RESTAction{
@@ -337,7 +339,8 @@ func FromScheduleActionModelToDTO(model models.ScheduleAction) ScheduleAction {
 			ContentType: messageBusModel.ContentType,
 			Payload:     messageBusModel.Payload,
 			EdgeXMessageBusAction: EdgeXMessageBusAction{
-				Topic: messageBusModel.Topic,
+				Topic:         messageBusModel.Topic,
+				UseRawPayload: messageBusModel.UseRawPayload,
 			},
 		}
 	case common.ActionREST:

--- a/dtos/schedulejob_test.go
+++ b/dtos/schedulejob_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,7 +29,8 @@ var scheduleActionEdgeXMessageBus = ScheduleAction{
 	ContentType: common.ContentTypeJSON,
 	Payload:     []byte(payload),
 	EdgeXMessageBusAction: EdgeXMessageBusAction{
-		Topic: topic,
+		Topic:         topic,
+		UseRawPayload: true,
 	},
 }
 
@@ -39,7 +40,8 @@ var scheduleActionEdgeXMessageBusModel = models.EdgeXMessageBusAction{
 		ContentType: common.ContentTypeJSON,
 		Payload:     []byte(payload),
 	},
-	Topic: topic,
+	Topic:         topic,
+	UseRawPayload: true,
 }
 
 var scheduleActionRest = ScheduleAction{

--- a/models/schedulejob.go
+++ b/models/schedulejob.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,6 +7,7 @@ package models
 
 import (
 	"encoding/json"
+
 	"github.com/google/uuid"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
@@ -194,7 +195,8 @@ type BaseScheduleAction struct {
 
 type EdgeXMessageBusAction struct {
 	BaseScheduleAction
-	Topic string
+	Topic         string
+	UseRawPayload bool
 }
 
 func (m EdgeXMessageBusAction) GetBaseScheduleAction() BaseScheduleAction {


### PR DESCRIPTION
ScheduleAction add UseRawPayload field for EdgeXMessageBus type to support sending binary data without EdgeX format

Close #1046

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) update open api in edgex-go
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->