### PR TITLE
fix: Initialize Readings as empty slice in NewEvent

### DIFF
--- a/dtos/event.go
+++ b/dtos/event.go
@@ -42,6 +42,7 @@ func NewEvent(profileName, deviceName, sourceName string) Event {
 		ProfileName: profileName,
 		SourceName:  sourceName,
 		Origin:      time.Now().UnixNano(),
+		Readings:    make([]BaseReading, 0),
 		Extensions:  make(map[string]any),
 		Tags:        make(Tags),
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>
