### PR TITLE
feat: Make ProfileName and SourceName optional in Event and Reading DTOs

### DIFF
--- a/dtos/discovereddevice.go
+++ b/dtos/discovereddevice.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2023-2024 IOTech Ltd
+// Copyright (C) 2023-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,14 +8,14 @@ package dtos
 import "github.com/edgexfoundry/go-mod-core-contracts/v4/models"
 
 type DiscoveredDevice struct {
-	ProfileName string         `json:"profileName" yaml:"profileName" validate:"len=0|edgex-dto-none-empty-string"`
+	ProfileName string         `json:"profileName,omitempty" yaml:"profileName,omitempty" validate:"omitempty,edgex-dto-none-empty-string"`
 	AdminState  string         `json:"adminState" yaml:"adminState" validate:"oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents  []AutoEvent    `json:"autoEvents,omitempty" yaml:"autoEvents,omitempty" validate:"dive"`
 	Properties  map[string]any `json:"properties" yaml:"properties"`
 }
 
 type UpdateDiscoveredDevice struct {
-	ProfileName *string        `json:"profileName" validate:"omitempty,len=0|edgex-dto-none-empty-string"`
+	ProfileName *string        `json:"profileName,omitempty" validate:"omitempty,len=0|edgex-dto-none-empty-string"`
 	AdminState  *string        `json:"adminState" validate:"omitempty,oneof='LOCKED' 'UNLOCKED'"`
 	AutoEvents  []AutoEvent    `json:"autoEvents" validate:"dive"`
 	Properties  map[string]any `json:"properties"`

--- a/dtos/event.go
+++ b/dtos/event.go
@@ -25,8 +25,8 @@ type Event struct {
 	dtoCommon.Versionable `json:",inline"`
 	Id                    string         `json:"id" validate:"required,uuid"`
 	DeviceName            string         `json:"deviceName" validate:"required,edgex-dto-none-empty-string"`
-	ProfileName           string         `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
-	SourceName            string         `json:"sourceName" validate:"required,edgex-dto-none-empty-string"`
+	ProfileName           string         `json:"profileName,omitempty" validate:"omitempty,edgex-dto-none-empty-string"`
+	SourceName            string         `json:"sourceName,omitempty" validate:"omitempty,edgex-dto-none-empty-string"`
 	Origin                int64          `json:"origin" validate:"required"`
 	Readings              []BaseReading  `json:"readings" validate:"gt=0,dive,required"`
 	Tags                  Tags           `json:"tags,omitempty"`

--- a/dtos/reading.go
+++ b/dtos/reading.go
@@ -28,7 +28,7 @@ type BaseReading struct {
 	Origin         int64          `json:"origin" validate:"required"`
 	DeviceName     string         `json:"deviceName" validate:"required,edgex-dto-none-empty-string"`
 	ResourceName   string         `json:"resourceName" validate:"required,edgex-dto-none-empty-string"`
-	ProfileName    string         `json:"profileName" validate:"required,edgex-dto-none-empty-string"`
+	ProfileName    string         `json:"profileName,omitempty" validate:"omitempty,edgex-dto-none-empty-string"`
 	ValueType      string         `json:"valueType" validate:"required,edgex-dto-value-type"`
 	Units          string         `json:"units,omitempty"`
 	Tags           Tags           `json:"tags,omitempty"`

--- a/dtos/requests/event_test.go
+++ b/dtos/requests/event_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -109,13 +109,13 @@ func TestAddEventRequest_Validate(t *testing.T) {
 		{"invalid AddEventRequest, no Event Id", noEventId, true},
 		{"invalid AddEventRequest, Event Id is not an uuid", invalidEventId, true},
 		{"invalid AddEventRequest, no DeviceName", noDeviceName, true},
-		{"invalid AddEventRequest, no ProfileName", noProfileName, true},
-		{"invalid AddEventRequest, no SourceName", noSourceName, true},
+		{"valid AddEventRequest, no ProfileName", noProfileName, false},
+		{"valid AddEventRequest, no SourceName", noSourceName, false},
 		{"invalid AddEventRequest, no Origin", noOrigin, true},
 		{"invalid AddEventRequest, no Reading", noReading, true},
 		{"invalid AddEventRequest, no Reading DeviceName", invalidReadingNoDevice, true},
 		{"invalid AddEventRequest, no Resource Name", invalidReadingNoResourceName, true},
-		{"invalid AddEventRequest, no Profile Name", invalidReadingNoProfileName, true},
+		{"valid AddEventRequest, no Profile Name", invalidReadingNoProfileName, false},
 		{"invalid AddEventRequest, no Reading Origin", invalidReadingNoOrigin, true},
 		{"invalid AddEventRequest, no Reading ValueType", invalidReadingNoValueType, true},
 		{"invalid AddEventRequest, invalid Reading ValueType", invalidReadingInvalidValueType, true},


### PR DESCRIPTION
fix: #1053 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
core-data accepts an AddEventRequest with empty ProfileName and SourceName fields and successfully stores the event in the database.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->