### PR TITLE
feat: Add ActiveYearlyTimeWindow to ScheduleDef

### DIFF
--- a/dtos/schedulejob.go
+++ b/dtos/schedulejob.go
@@ -64,9 +64,20 @@ type ScheduleDef struct {
 	Type           string `json:"type" validate:"oneof='INTERVAL' 'CRON'"`
 	StartTimestamp int64  `json:"startTimestamp,omitempty"`
 	EndTimestamp   int64  `json:"endTimestamp,omitempty"`
+	// ActiveYearlyTimeWindow is an optional recurring within-year active period; nil means no window constraint.
+	ActiveYearlyTimeWindow *ActiveYearlyTimeWindow `json:"activeYearlyTimeWindow,omitempty" validate:"omitempty"`
 
 	IntervalScheduleDef `json:",inline" validate:"-"`
 	CronScheduleDef     `json:",inline" validate:"-"`
+}
+
+// ActiveYearlyTimeWindow is the DTO for a recurring within-year active period. See models.ActiveYearlyTimeWindow
+// for the semantics; Validate enforces the month/day range and calendar-date rules.
+type ActiveYearlyTimeWindow struct {
+	StartMonth int `json:"startMonth" validate:"min=1,max=12"`
+	StartDay   int `json:"startDay" validate:"min=1,max=31"`
+	EndMonth   int `json:"endMonth" validate:"min=1,max=12"`
+	EndDay     int `json:"endDay" validate:"min=1,max=31"`
 }
 
 // Validate satisfies the Validator interface
@@ -93,6 +104,48 @@ func (s *ScheduleDef) Validate() error {
 		if s.EndTimestamp < s.StartTimestamp {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, "endTimestamp must be greater than startTimestamp", nil)
 		}
+	}
+
+	if s.ActiveYearlyTimeWindow != nil {
+		if err = s.ActiveYearlyTimeWindow.Validate(); err != nil {
+			return errors.NewCommonEdgeX(errors.KindContractInvalid, "invalid ScheduleDef.ActiveYearlyTimeWindow.", err)
+		}
+	}
+
+	return nil
+}
+
+// maxDayOfMonth returns the largest valid day for the given month, ignoring the year. February allows 29
+// (leap day) because the window pattern is year-agnostic and may recur in a leap year.
+func maxDayOfMonth(month int) int {
+	switch month {
+	case 1, 3, 5, 7, 8, 10, 12:
+		return 31
+	case 4, 6, 9, 11:
+		return 30
+	case 2:
+		return 29
+	default:
+		return 0
+	}
+}
+
+// Validate satisfies the Validator interface. It enforces the month/day range bounds via struct tags and the
+// calendar-date rule (a (month, day) pair must be a real date; Feb 29 is allowed) here. start == end is a valid
+// single-day window and start > end is a year-crossing window, so neither ordering is rejected.
+func (w *ActiveYearlyTimeWindow) Validate() error {
+	err := common.Validate(w)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "invalid ActiveYearlyTimeWindow.", err)
+	}
+
+	if w.StartDay > maxDayOfMonth(w.StartMonth) {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid,
+			fmt.Sprintf("invalid start date %d/%d: day out of range for month", w.StartMonth, w.StartDay), nil)
+	}
+	if w.EndDay > maxDayOfMonth(w.EndMonth) {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid,
+			fmt.Sprintf("invalid end date %d/%d: day out of range for month", w.EndMonth, w.EndDay), nil)
 	}
 
 	return nil
@@ -243,18 +296,20 @@ func ToScheduleDefModel(dto ScheduleDef) models.ScheduleDef {
 	case common.DefInterval:
 		model = models.IntervalScheduleDef{
 			BaseScheduleDef: models.BaseScheduleDef{
-				Type:           common.DefInterval,
-				StartTimestamp: dto.StartTimestamp,
-				EndTimestamp:   dto.EndTimestamp,
+				Type:                   common.DefInterval,
+				StartTimestamp:         dto.StartTimestamp,
+				EndTimestamp:           dto.EndTimestamp,
+				ActiveYearlyTimeWindow: toActiveYearlyTimeWindowModel(dto.ActiveYearlyTimeWindow),
 			},
 			Interval: dto.Interval,
 		}
 	case common.DefCron:
 		model = models.CronScheduleDef{
 			BaseScheduleDef: models.BaseScheduleDef{
-				Type:           common.DefCron,
-				StartTimestamp: dto.StartTimestamp,
-				EndTimestamp:   dto.EndTimestamp,
+				Type:                   common.DefCron,
+				StartTimestamp:         dto.StartTimestamp,
+				EndTimestamp:           dto.EndTimestamp,
+				ActiveYearlyTimeWindow: toActiveYearlyTimeWindowModel(dto.ActiveYearlyTimeWindow),
 			},
 			Crontab: dto.Crontab,
 		}
@@ -270,22 +325,48 @@ func FromScheduleDefModelToDTO(model models.ScheduleDef) ScheduleDef {
 	case common.DefInterval:
 		durationModel := model.(models.IntervalScheduleDef)
 		dto = ScheduleDef{
-			Type:                common.DefInterval,
-			StartTimestamp:      durationModel.StartTimestamp,
-			EndTimestamp:        durationModel.EndTimestamp,
-			IntervalScheduleDef: IntervalScheduleDef{Interval: durationModel.Interval},
+			Type:                   common.DefInterval,
+			StartTimestamp:         durationModel.StartTimestamp,
+			EndTimestamp:           durationModel.EndTimestamp,
+			ActiveYearlyTimeWindow: fromActiveYearlyTimeWindowModel(durationModel.ActiveYearlyTimeWindow),
+			IntervalScheduleDef:    IntervalScheduleDef{Interval: durationModel.Interval},
 		}
 	case common.DefCron:
 		cronModel := model.(models.CronScheduleDef)
 		dto = ScheduleDef{
-			Type:            common.DefCron,
-			StartTimestamp:  cronModel.StartTimestamp,
-			EndTimestamp:    cronModel.EndTimestamp,
-			CronScheduleDef: CronScheduleDef{Crontab: cronModel.Crontab},
+			Type:                   common.DefCron,
+			StartTimestamp:         cronModel.StartTimestamp,
+			EndTimestamp:           cronModel.EndTimestamp,
+			ActiveYearlyTimeWindow: fromActiveYearlyTimeWindowModel(cronModel.ActiveYearlyTimeWindow),
+			CronScheduleDef:        CronScheduleDef{Crontab: cronModel.Crontab},
 		}
 	}
 
 	return dto
+}
+
+func toActiveYearlyTimeWindowModel(dto *ActiveYearlyTimeWindow) *models.ActiveYearlyTimeWindow {
+	if dto == nil {
+		return nil
+	}
+	return &models.ActiveYearlyTimeWindow{
+		StartMonth: dto.StartMonth,
+		StartDay:   dto.StartDay,
+		EndMonth:   dto.EndMonth,
+		EndDay:     dto.EndDay,
+	}
+}
+
+func fromActiveYearlyTimeWindowModel(model *models.ActiveYearlyTimeWindow) *ActiveYearlyTimeWindow {
+	if model == nil {
+		return nil
+	}
+	return &ActiveYearlyTimeWindow{
+		StartMonth: model.StartMonth,
+		StartDay:   model.StartDay,
+		EndMonth:   model.EndMonth,
+		EndDay:     model.EndDay,
+	}
 }
 
 func ToScheduleActionModel(dto ScheduleAction) models.ScheduleAction {

--- a/dtos/schedulejob_test.go
+++ b/dtos/schedulejob_test.go
@@ -305,3 +305,85 @@ func TestFromScheduleActionModelToDTO(t *testing.T) {
 	result3 := FromScheduleActionModelToDTO(scheduleActionDeviceControlModel)
 	assert.Equal(t, scheduleActionDeviceControl, result3, "FromScheduleActionModelToDTO did not result in DeviceControl ScheduleAction dto")
 }
+
+func TestActiveYearlyTimeWindow_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		window      ActiveYearlyTimeWindow
+		expectedErr bool
+	}{
+		{"valid same-year window", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 5, EndMonth: 3, EndDay: 12}, false},
+		{"valid year-crossing window", ActiveYearlyTimeWindow{StartMonth: 11, StartDay: 15, EndMonth: 2, EndDay: 10}, false},
+		{"valid same-month year-crossing window", ActiveYearlyTimeWindow{StartMonth: 12, StartDay: 10, EndMonth: 12, EndDay: 1}, false},
+		{"valid single-day window (start == end)", ActiveYearlyTimeWindow{StartMonth: 6, StartDay: 15, EndMonth: 6, EndDay: 15}, false},
+		{"valid Feb 29", ActiveYearlyTimeWindow{StartMonth: 2, StartDay: 29, EndMonth: 3, EndDay: 1}, false},
+		{"valid end of Dec", ActiveYearlyTimeWindow{StartMonth: 12, StartDay: 1, EndMonth: 12, EndDay: 31}, false},
+		{"invalid start month 0", ActiveYearlyTimeWindow{StartMonth: 0, StartDay: 5, EndMonth: 3, EndDay: 12}, true},
+		{"invalid start month 13", ActiveYearlyTimeWindow{StartMonth: 13, StartDay: 5, EndMonth: 3, EndDay: 12}, true},
+		{"invalid end month 0", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 5, EndMonth: 0, EndDay: 12}, true},
+		{"invalid start day 0", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 0, EndMonth: 3, EndDay: 12}, true},
+		{"invalid day 32", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 32, EndMonth: 3, EndDay: 12}, true},
+		{"invalid Feb 30", ActiveYearlyTimeWindow{StartMonth: 2, StartDay: 30, EndMonth: 3, EndDay: 1}, true},
+		{"invalid Feb 31", ActiveYearlyTimeWindow{StartMonth: 2, StartDay: 31, EndMonth: 3, EndDay: 1}, true},
+		{"invalid Apr 31", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 1, EndMonth: 4, EndDay: 31}, true},
+		{"invalid Jun 31", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 1, EndMonth: 6, EndDay: 31}, true},
+		{"invalid Sep 31", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 1, EndMonth: 9, EndDay: 31}, true},
+		{"invalid Nov 31", ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 1, EndMonth: 11, EndDay: 31}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.window.Validate()
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScheduleDef_Validate_ActiveYearlyTimeWindow(t *testing.T) {
+	base := scheduleIntervalDef
+
+	validWindow := base
+	validWindow.ActiveYearlyTimeWindow = &ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 5, EndMonth: 3, EndDay: 12}
+
+	invalidWindow := base
+	invalidWindow.ActiveYearlyTimeWindow = &ActiveYearlyTimeWindow{StartMonth: 2, StartDay: 30, EndMonth: 3, EndDay: 1}
+
+	nilWindow := base
+	nilWindow.ActiveYearlyTimeWindow = nil
+
+	tests := []struct {
+		name        string
+		def         ScheduleDef
+		expectedErr bool
+	}{
+		{"nil window is valid", nilWindow, false},
+		{"valid window", validWindow, false},
+		{"invalid window (Feb 30) rejected", invalidWindow, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.def.Validate()
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScheduleDefModel_ActiveYearlyTimeWindow_RoundTrip(t *testing.T) {
+	dto := scheduleIntervalDef
+	dto.ActiveYearlyTimeWindow = &ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 5, EndMonth: 3, EndDay: 12}
+
+	model := ToScheduleDefModel(dto)
+	base := model.GetBaseScheduleDef()
+	assert.NotNil(t, base.ActiveYearlyTimeWindow)
+	assert.Equal(t, &models.ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 5, EndMonth: 3, EndDay: 12}, base.ActiveYearlyTimeWindow)
+
+	roundTrip := FromScheduleDefModelToDTO(model)
+	assert.Equal(t, dto, roundTrip, "ActiveYearlyTimeWindow did not survive DTO -> model -> DTO round trip")
+}

--- a/models/schedulejob.go
+++ b/models/schedulejob.go
@@ -114,6 +114,22 @@ type BaseScheduleDef struct {
 	Type           ScheduleDefType
 	StartTimestamp int64
 	EndTimestamp   int64
+	// ActiveYearlyTimeWindow is an optional recurring within-year active period. When nil, the schedule
+	// has no window constraint and fires on every tick within its lifetime. See ActiveYearlyTimeWindow.
+	ActiveYearlyTimeWindow *ActiveYearlyTimeWindow
+}
+
+// ActiveYearlyTimeWindow describes a recurring month/day range within a year. The rules are:
+//   - The pattern repeats every year; StartTimestamp/EndTimestamp bound the job's overall lifetime independently.
+//   - EndDay is inclusive — the whole end day is active.
+//   - start == end (same month and day) is a valid single-day window.
+//   - start > end is a year-crossing window, e.g. Nov 15 -> Feb 10. Here start and end are compared by
+//     month first, then day, so a same-month range like 12/10 -> 12/1 is also year-crossing.
+type ActiveYearlyTimeWindow struct {
+	StartMonth int
+	StartDay   int
+	EndMonth   int
+	EndDay     int
 }
 
 type IntervalScheduleDef struct {


### PR DESCRIPTION
Add an optional ActiveYearlyTimeWindow field to BaseScheduleDef (model) and ScheduleDef (DTO) so a ScheduleJob can express a recurring within-year active period (e.g. Jan 5 - Mar 12, every year) without being re-created each year. StartTimestamp/EndTimestamp continue to bound the job's overall lifetime independently; the window filters which days within that lifetime actually fire. A nil window means no constraint.

The window is month/day only. EndDay is inclusive, start == end is a valid single-day window, and start > end (compared by month then day) is a year-crossing window. Validate enforces the month/day range via struct tags and rejects impossible calendar dates (e.g. 2/30, 4/31) while allowing Feb 29.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->