### PR TITLE
feat: Support deleting device resource/command tags

### DIFF
--- a/dtos/requests/deviceprofiletags.go
+++ b/dtos/requests/deviceprofiletags.go
@@ -54,7 +54,8 @@ func (dt *DeviceProfileTagsRequest) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// ReplaceDeviceProfileModelTagsWithDTO replace existing DeviceProfile's device resources/commands tags fields with DTO patch
+// ReplaceDeviceProfileModelTagsWithDTO replaces existing DeviceProfile's device resources/commands tags fields with the DTO patch.
+// A tag whose value is null is deleted rather than set (see mergeTags).
 func ReplaceDeviceProfileModelTagsWithDTO(dp *models.DeviceProfile, patch dtos.UpdateDeviceProfileTags) {
 	// Convert UpdateTags list to maps for fast lookup
 	resourceUpdate := convertUpdateTagsToMap(patch.DeviceResources)
@@ -86,11 +87,17 @@ func convertUpdateTagsToMap(list []dtos.UpdateTags) map[string]map[string]any {
 	return tagsMap
 }
 
+// mergeTags merges src into dest, where a nil value deletes the key from dest.
 func mergeTags(dest, src map[string]any) map[string]any {
 	if dest == nil {
 		dest = make(map[string]any)
 	}
 	for key, value := range src {
+		if value == nil {
+			delete(dest, key)
+			continue
+		}
+
 		dv, destOk := dest[key].(map[string]any)
 		sv, srcOk := value.(map[string]any)
 		if destOk && srcOk {

--- a/dtos/requests/deviceprofiletags_test.go
+++ b/dtos/requests/deviceprofiletags_test.go
@@ -144,6 +144,35 @@ func TestReplaceDeviceProfileModelTagsWithDTO(t *testing.T) {
 	assert.Equal(t, expectedDeviceProfileModels, profile, "ReplaceDeviceProfileModelTagsWithDTO did not result in expected DeviceProfile model.")
 }
 
+func TestReplaceDeviceProfileModelTagsWithDTO_DeleteTag(t *testing.T) {
+	const deletedKey = "TestTagsKey"
+	const keptKey = "KeptTagsKey"
+	// the shared fixtures are package-level, so give this profile its own maps to mutate
+	startingTags := func() map[string]any {
+		return map[string]any{deletedKey: "TestTagsValue", keptKey: "KeptTagsValue"}
+	}
+
+	profile := testDeviceProfileModel
+	profile.DeviceResources = []models.DeviceResource{{
+		Name: TestDeviceResourceName,
+		Tags: startingTags(),
+	}}
+	profile.DeviceCommands = []models.DeviceCommand{{
+		Name: TestDeviceCommandName,
+		Tags: startingTags(),
+	}}
+
+	patch := dtos.UpdateDeviceProfileTags{
+		DeviceResources: []dtos.UpdateTags{testUpdateTags(TestDeviceResourceName, map[string]any{deletedKey: nil})},
+		DeviceCommands:  []dtos.UpdateTags{testUpdateTags(TestDeviceCommandName, map[string]any{deletedKey: nil})},
+	}
+	ReplaceDeviceProfileModelTagsWithDTO(&profile, patch)
+
+	expected := map[string]any{keptKey: "KeptTagsValue"}
+	assert.Equal(t, expected, profile.DeviceResources[0].Tags, "device resource tag was not deleted")
+	assert.Equal(t, expected, profile.DeviceCommands[0].Tags, "device command tag was not deleted")
+}
+
 func TestMergeTags(t *testing.T) {
 	testTagsKey := "TestTagsKey"
 	testTagsValue := "TestTagsValue"
@@ -161,6 +190,24 @@ func TestMergeTags(t *testing.T) {
 	nestedSrc := map[string]any{testTagsKey: newTestTags}
 	expectedNestedMergeMap := map[string]any{testTagsKey: expectedMergeMap}
 
+	// the delete cases keep a sibling key so that wiping the whole map is distinguishable from
+	// deleting the requested one
+	deleteDest := map[string]any{testTagsKey: testTagsValue, testNewTagsKey: testNewTagsValue}
+	deleteSrc := map[string]any{testTagsKey: nil}
+	expectedDeleteMap := map[string]any{testNewTagsKey: testNewTagsValue}
+
+	nestedDeleteDest := map[string]any{testTagsKey: map[string]any{testTagsKey: testTagsValue, testNewTagsKey: testNewTagsValue}}
+	nestedDeleteSrc := map[string]any{testTagsKey: map[string]any{testTagsKey: nil}}
+	expectedNestedDeleteMap := map[string]any{testTagsKey: map[string]any{testNewTagsKey: testNewTagsValue}}
+
+	deleteNoExistKeyDest := map[string]any{testTagsKey: testTagsValue}
+	deleteNoExistKeySrc := map[string]any{testNewTagsKey: nil}
+	expectedDeleteNoExistKeyMap := map[string]any{testTagsKey: testTagsValue}
+
+	deleteAndUpdateDest := map[string]any{testTagsKey: testTagsValue}
+	deleteAndUpdateSrc := map[string]any{testTagsKey: nil, testNewTagsKey: testNewTagsValue}
+	expectedDeleteAndUpdateMap := map[string]any{testNewTagsKey: testNewTagsValue}
+
 	tests := []struct {
 		name     string
 		dest     map[string]any
@@ -174,6 +221,11 @@ func TestMergeTags(t *testing.T) {
 		{"merge tags with existing key", existKeyDest, updateTestTags, updateTestTags},
 		{"merge tags with new key", noExistKeyDest, newTestTags, expectedMergeMap},
 		{"merge tags with nested struct", nestedDest, nestedSrc, expectedNestedMergeMap},
+		{"merge tags with nil value deletes the key", deleteDest, deleteSrc, expectedDeleteMap},
+		{"merge tags with nil value deletes the nested key", nestedDeleteDest, nestedDeleteSrc, expectedNestedDeleteMap},
+		{"merge tags with nil value on non-existing key", deleteNoExistKeyDest, deleteNoExistKeySrc, expectedDeleteNoExistKeyMap},
+		{"merge tags with nil value mixed with an update", deleteAndUpdateDest, deleteAndUpdateSrc, expectedDeleteAndUpdateMap},
+		{"merge tags with nil value and nil dest", nil, map[string]any{testTagsKey: nil}, map[string]any{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Delete the tag key in mergeTags when the patched value is null
- Add merge and model-level tests for the null deletion cases

Close #1064 1064

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break) the null value tag will be removed
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->